### PR TITLE
Python 3.8.0 fix, documentation update, fix broken windows files

### DIFF
--- a/DEVELOPER-INFO.md
+++ b/DEVELOPER-INFO.md
@@ -56,14 +56,14 @@ The procedure is then done on the command line using the *ocpn-metadata*
 tool. This works in two steps. The first is to create a private set of
 xml source files, something like:
 
-    $ ocpn-metadata copy
+    $  python ocpn-metadata copy
     New xml sources copied to /home/al/.opencpn/plugins-metadata 
 
 Now is the time to patch or add new xml files in
 */home/al/.opencpn/plugins-metadata*. When done, generate the new 
 ocpn-plugins.xml using:
 
-    $ ocpn-metadata generate
+    $  python ocpn-metadata generate
     Generated new ocpn-plugins.xml at /home/al/.opencpn/ocpn-plugins.xml
 
 The generated file is by default placed in a location overriding the
@@ -142,5 +142,16 @@ System-wide metadata: */app/share/opencpn/ocpn-plugins.xml*
 
 User metadata (overrides system if existing): *~/.opencpn/ocpn-plugins.xml*
 
-Tarball layout: identical to linux with a manifest.json in the top directory
-added.
+Tarball layout: 
+
+   - .so dynamic libraries goes into *top-dir/lib/opencpn*
+
+   - Optional helper binaries goes into *top-dir/bin* 
+
+   - Plugin data files: *top-dir/share/opencpn/plugins/<name>*
+     where <name> is as in the plugin metadata.
+
+   - metadata.json is at top level.
+
+
+

--- a/DEVELOPER-INFO.md
+++ b/DEVELOPER-INFO.md
@@ -1,56 +1,46 @@
-OpenCPN plugins project README
-===============================
+OpenCPN plugins project developer info
+======================================
 
 This project is currently in an utterly experimental state. It is
 aimed to be an important groundwork for the proposed plugin installer [1].
 
 The project exports the fundamental pieces required to install a plugin using
-the new installer: The plugin catalogue `ocpn-plugins.xml` and the plugin
+the new installer: The plugin catalog `ocpn-plugins.xml` and the plugin
 icons in the `icons/` directory.
 
 `ocpn-plugin.xml` is basically built by merging the files in the `metadata/`
 using the tool ocpn-metadata. Each file in  the metadata directory represents
-a plugin build for a given platform. The shorthand command is *make* on linux
-and macos, *make\_catalogue.bat* on windows
+a plugin build for a given platform. The shorthand command is *make*.
 
 The subdirectores metadata and icons provides support for plugins
 which can be downloaded and installed by the new plugin UI. Note
 that the previous way to install using installation packages is
 still supported.
 
-Plugins which could be downloaded and installed needs to have:
-
-  - A downloadable installation tarball available at an URI.
-  - Plugin metadata merged into the common file ocpn-plugins.xml.
-  - An optional icon available in the plugins/icons directory.
-
-
-Tarball
--------
-
-The installable plugin tarball is basically the result of *make install*
-packed into a tar archive. Directory layout is platform-dependent,
-see below.
-
+See the wiki at https://github.com/leamas/opencpn/wiki for more
+info on the installer
 
 ocpn-plugins.xml
 ----------------
-The file ocpn-plugins.xml represents the plugin catalogue available for
+
+The file ocpn-plugins.xml represents the plugin catalog available for
 users to install. This file is created by merging a set of separate
-xml files. The catalogue could be re-generated from sources.
+xml files. The catalog could be re-generated from sources.
 
 Creating a new xml file should be straight-forward using existing
 examples. Patching existing xml files is of course also possible.
 BEWARE: The name is as returned by the `common_name` function,
 typically without the *_pi* suffix.
 
-The process to regenerate the catalogue starts on Windows by adding the
-OpenCPN install directory to %PATH%, like:
+The process to regenerate the catalog starts on Windows by installing 
+chocolatey as describe on https://chocolatey.org
 
-   C:> set PATH=%PATH%;C:\Program Files (x86)\OpenCPN
+Then install the dependencies:
 
-Windows and MacOS users also needs to ensure that python >= 3.4 is
-installed and available as the command `python`.
+   choco install python make git
+
+MacOS users needs to ensure that python >= 3.4 is installed and available
+as the command `python`.
  
 The procedure is then done on the command line using the *ocpn-metadata*
 tool. This works in two steps. The first is to create a private set of
@@ -67,91 +57,8 @@ ocpn-plugins.xml using:
     Generated new ocpn-plugins.xml at /home/al/.opencpn/ocpn-plugins.xml
 
 The generated file is by default placed in a location overriding the
-distributed one (see Platform Notes below). ocpn-metadata has command line
+distributed one (see [wiki]). ocpn-metadata has command line
 options to tweak the locations used, see `ocpn-metadata --help`
 
-Icons
------
 
-The plugin downloader supports png and svg icons.The basename of
-the icon should be the same as the name in the xml metadata.
-
-Icons are rescaled when displayed. For this reason svg icons are
-preferred. Png icons should be reasonable large e. g. 64 x 64.
-
-
-Platform notes - linux.
------------------------
-
-System-wide metadata: Typically  */usr/share/opencpn/ocpn-plugins.xml*,
-possibly  distribution-dependent.
-
-User metadata (overrides system if existing): *~/.opencpn/ocpn-plugins.xml*
-
-Tarball layout (top directory could have any name):
-
-   - .so dynamic libraries goes into *top-dir/usr/lib/opencpn* or
-     *top_dir/usr/local/lib/opencpn*.
-
-   - Optional helper binaries goes into *top-dir/usr/bin* or
-     *top-dir/usr/local/bin*.
-
-   - Plugin data files: *top-dir/usr/share/opencpn/plugins/<name>*
-     where <name> is as in the plugin metadata.
-
-
-Platform notes - Windows
-------------------------
-
-System-wide metadata: *C:\Program Files (x86)\OpenCPN\ocpn-plugins.xml*
-
-User metadata (overrides system if existing):
-    *:C:\ProgramData\opencpn\ocpn-plugins.xml*
-
-Tarball layout (top directory could have any name):
-
-   - .dll dynamic libraries and .exe binaries goes to
-     *top-dir/plugins/\*.exe*
-   - plugin data files goes to *top-dir/plugins/plugin-name*
-
-
-Platform notes - MacOS
-----------------------
-
-System-wide metadata:
-    *~/Desktop/OpenCPN.app/Contents/SharedSupport/ocpn-plugins.xml*
-
-User metadata (overrides system if existing):
-    *~/Library/Preferences/opencpn/ocpn-plugins.xml*
-
-Tarball layout (top directory could have any name):
-
-  - dylib dynamic libraries and binaries:
-    *top-dir/OpenCPN.app/Contents/PlugIns/*
-
-  - Data files:
-    *top-dir/OpenCPN.app/Contents/SharedSupport/plugins/plugin-name*
-
-NOTE: A deprecated prefix *topdir/tmp/bin* is still supported.
-
-
-Platform notes - Flatpak
-------------------------
-
-System-wide metadata: */app/share/opencpn/ocpn-plugins.xml*
-
-User metadata (overrides system if existing): *~/.opencpn/ocpn-plugins.xml*
-
-Tarball layout: 
-
-   - .so dynamic libraries goes into *top-dir/lib/opencpn*
-
-   - Optional helper binaries goes into *top-dir/bin* 
-
-   - Plugin data files: *top-dir/share/opencpn/plugins/<name>*
-     where <name> is as in the plugin metadata.
-
-   - metadata.json is at top level.
-
-
-
+[wiki] wiki :https://github.com/leamas/opencpn/wiki

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@
 #
 #  Needs python >= 3.4 available as the command python. Should
 #  otherwise work on all platforms but only tested on Linux.
+#
+#  The validate target requires xmllint found in packages like
+#  xsltproc or libxslt
 
 
 all: ocpn-plugins.xml
@@ -16,3 +19,6 @@ ocpn-plugins.xml: metadata/*.xml Makefile
 
 clean:
 	rm -f ocpn-plugins.xml
+
+validate: ocpn-plugins.xml Makefile
+	xmllint  --schema ocpn-plugins.xsd  ocpn-plugins.xml --noout

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,12 @@
 
 all: ocpn-plugins.xml
 
-VERSION  = 0.0.1
+VERSION  ?= 0.0.1
 
 
 ocpn-plugins.xml: metadata/*.xml Makefile
-	tools/ocpn-metadata generate --force --destfile $@ \
+	python tools/ocpn-metadata generate --force --destfile $@ \
 	    --userdir metadata --version $(VERSION)
 
 clean:
-	rm ocpn-plugins.xml
+	rm -f ocpn-plugins.xml

--- a/README.md
+++ b/README.md
@@ -12,25 +12,34 @@ Dependencies
 ------------
 
   - python >= 3.4
+  - GNU make (optional)
 
 
 Fast track: creating a modified ocpn-plugins.xml
 ------------------------------------------------
 
-To create a  modified ocpn-plugins.xml drop new or modified xml files in the
-metadata directory. Then do
+Windows users need to fix the deps. First install chocolatey as described
+at https: //chocolatey.org. Then install the deps:
 
+    > choco install python
+    > choco install make
+    > choco install git
 
-     python tools/ocpn-metadata generate --userdir metadata --destfile ocpn-plugins.xml
+Drop new or modified xml files in the metadata/ directory. Then do
+
+    > python tools/ocpn-metadata generate --userdir metadata --destfile ocpn-plugins.xml
 
 This will create ocpn-plugins.xml in current directory. As an alternative, use
 
-
-     python tools/ocpn-metadata generate --userdir metadata
+    > python tools/ocpn-metadata generate --userdir metadata
 
 which installs the xml file in the user data directory where it will override 
 whatever file opencpn was installed with. You might want to add
 ```--version``` to mark the generated file with a new version.
+
+A third option is to just use `make` which creates a ocpn-plugins.xml in 
+current directory.
+
 
 Developer info
 --------------

--- a/make_catalogue.bat
+++ b/make_catalogue.bat
@@ -1,6 +1,0 @@
-#
-# Windows batch file, creates ocpn-plugins.xml
-#
-# Needs python >= 3.4 available as the command 'python'.
-
-tools/ocpn-metadata generate --force --destfile ocpn-plugins.xml --userdir metadata

--- a/metadata/squiddio-plugin-1.0.18.2-ubuntu-16.04.xml
+++ b/metadata/squiddio-plugin-1.0.18.2-ubuntu-16.04.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<opencpn-plugin version="1">
+  <name> squiddio </name>
+  <version> 1.0.18 </version>
+  <release> 2 </release>
+  <summary> Repository of sailing destination waypoints </summary>
+
+  <api-version>  </api-version>
+  <open-source> no </open-source>
+  <author>  </author>
+  <source> https://github.com/opencpn-radar-pi/radar_pi </source>
+
+  <description>
+Squiddio Plugin makes its global user-sourced and user-maintained
+repository of sailing destinations (marinas, anchorages, yacht clubs,
+docks, fuel stations etc.) available as waypoints in OpenCPN. OpenCPN
+Android comes with sQuiddio built in.
+  </description>
+
+  <target>ubuntu</target>
+  <target-version>16.04</target-version>
+  <tarball-url> https://dl.cloudsmith.io/public/alec-leamas/opencpn-plugins-stable/raw/names/squiddio_pi/versions/1.0.18.2/opencpn-plugin-squiddio-1.0.18.2_ubuntu-16.04.tar.gz </tarball-url>
+  <info-url> https://opencpn.org/OpenCPN/plugins/sQuiddio.html </info-url>
+</opencpn-plugin>

--- a/ocpn-plugins.xml
+++ b/ocpn-plugins.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <plugins>
-  <version>0.0.0</version>
-  <date>2019-11-18 20:10</date>
+  <version>0.0.1</version>
+  <date>2019-12-29 16:16</date>
   <plugin version="1">
     <name> oesenc </name>
     <version> 3.3.0 </version>
@@ -64,6 +64,26 @@ certificates in place.
     <target>msvc</target>
     <target-version>10.0.14393</target-version>
     <tarball-url> https://dl.cloudsmith.io/public/alec-leamas/opencpn-plugins-stable/raw/names/bsb4-msvc-10.0.14393-tarball/versions/v1.5.0.3/bsb4_pi-1.5.0.3_msvc-10.0.14393.tar.gz </tarball-url>
+  </plugin>
+  <plugin version="1">
+    <name> squiddio </name>
+    <version> 1.0.18 </version>
+    <release> 2 </release>
+    <summary> Repository of sailing destination waypoints </summary>
+    <api-version>  </api-version>
+    <open-source> no </open-source>
+    <author>  </author>
+    <source> https://github.com/opencpn-radar-pi/radar_pi </source>
+    <description>
+Squiddio Plugin makes its global user-sourced and user-maintained
+repository of sailing destinations (marinas, anchorages, yacht clubs,
+docks, fuel stations etc.) available as waypoints in OpenCPN. OpenCPN
+Android comes with sQuiddio built in.
+  </description>
+    <target>ubuntu</target>
+    <target-version>16.04</target-version>
+    <tarball-url> https://dl.cloudsmith.io/public/alec-leamas/opencpn-plugins-stable/raw/names/squiddio_pi/versions/1.0.18.2/opencpn-plugin-squiddio-1.0.18.2_ubuntu-16.04.tar.gz </tarball-url>
+    <info-url> https://opencpn.org/OpenCPN/plugins/sQuiddio.html </info-url>
   </plugin>
   <plugin version="1">
     <name> radar </name>

--- a/ocpn-plugins.xsd
+++ b/ocpn-plugins.xsd
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+<xs:element name="plugins">
+  <xs:complexType>
+    <xs:sequence>
+      <xs:element name="version" type="xs:string"/>
+      <xs:element name="date" type="xs:string"/>
+      <xs:element ref="plugin" maxOccurs="unbounded"/>
+   </xs:sequence>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="plugin">
+  <xs:complexType>
+    <xs:sequence>
+      <xs:element name="name" type="xs:token"/>
+      <xs:element name="version" type="xs:token"/>
+      <xs:element name="release" type="xs:token"/>
+      <xs:element name="summary">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:maxLength value="72"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="api-version" type="xs:token"/>
+      <xs:element name="open-source" type="xs:token"/>
+      <xs:element name="author" type="xs:token"/>
+      <xs:element name="source" type="xs:token"/>
+      <xs:element name="info-url" type="xs:token" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="description" type="xs:string"/>
+      <xs:element name="target" type="xs:token"/>
+      <xs:element name="target-version" type="xs:token"/>
+      <xs:element name="tarball-url" type="xs:token"/>
+      <!-- Tarball sha256 checksum , not implemented. -->
+      <xs:element name="tarball-checksum" type="xs:token"
+                  minOccurs="0" maxOccurs="1"/>
+      <!-- Path to downloadable ṕlugin icon, not implemented. -->
+      <xs:element name="icon-url" type="xs:token" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="info-url" type="xs:token" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="version" type="xs:string" use="required"/> 
+  </xs:complexType>
+</xs:element>
+ 
+
+</xs:schema>
+

--- a/tools/ocpn-metadata
+++ b/tools/ocpn-metadata
@@ -87,7 +87,7 @@ def generate(sourcedir, destfile, version):
     date_elem = ET.SubElement(tree, "date")
     date_elem.text = datetime.datetime.now().strftime('%Y-%m-%d %H:%M')
     for path in Path(sourcedir).glob("*.xml"):
-        subtree = ET.parse(path)
+        subtree = ET.parse(str(path))
         subtree.getroot().tag = 'plugin'
         tree.append(subtree.getroot())
     dom = minidom.parseString(ET.tostring(tree))

--- a/tools/ocpn-metadata.bat
+++ b/tools/ocpn-metadata.bat
@@ -1,1 +1,0 @@
-python "\Program Files (x86)\OpenCPN\ocpn-metadata" %*


### PR DESCRIPTION
As heading says:

  - python 3.8.0 introduces a filepath object which leads to a crash in ocpn-metadata
  - Windows: remove bat files, use standard tools (notably make) instaed.
  - Docs refresh: simplified windows usage, remove duplicates from wiki