### PR TITLE
Validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,8 @@ Notes on the XML files, tarball layout and platform issues: DEVELOPER-INFO.md.
 Here is also mer elaborated instructions to create ocpn-plugins.xml if the
 fast track fails.
 
+The pre-commit file is a git hook which validates ocpn-plugins.xml when
+committed. See more info in this file.
+
 
 [1] https://github.com/OpenCPN/OpenCPN/pull/1457

--- a/ocpn-plugins.xml
+++ b/ocpn-plugins.xml
@@ -3,6 +3,9 @@
   <version>0.0.1</version>
   <date>2019-12-29 16:16</date>
   <plugin version="1">
+    <meta-url>http://kalle.org</meta-url>
+  </plugin>
+  <plugin version="1">
     <name> oesenc </name>
     <version> 3.3.0 </version>
     <release> 3 </release>

--- a/ocpn-plugins.xsd
+++ b/ocpn-plugins.xsd
@@ -17,15 +17,13 @@
       <xs:sequence>
         <xs:element name="meta-url" type="xs:token" maxOccurs="unbounded"/>
       </xs:sequence>
-      <xs:sequence>
-        <xs:group ref="plugin-elements"/>
-      </xs:sequence>
+      <xs:group ref="metadata"/>
     </xs:choice>
     <xs:attribute name="version" type="xs:string" use="required"/>
   </xs:complexType>
 </xs:element>
 
-<xs:group name="plugin-elements">
+<xs:group name="metadata">
   <xs:sequence>
     <xs:element name="name" type="xs:token"/>
     <xs:element name="version" type="xs:token"/>

--- a/ocpn-plugins.xsd
+++ b/ocpn-plugins.xsd
@@ -13,37 +13,48 @@
 
 <xs:element name="plugin">
   <xs:complexType>
-    <xs:sequence>
-      <xs:element name="name" type="xs:token"/>
-      <xs:element name="version" type="xs:token"/>
-      <xs:element name="release" type="xs:token"/>
-      <xs:element name="summary">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:maxLength value="72"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:element>
-      <xs:element name="api-version" type="xs:token"/>
-      <xs:element name="open-source" type="xs:token"/>
-      <xs:element name="author" type="xs:token"/>
-      <xs:element name="source" type="xs:token"/>
-      <xs:element name="info-url" type="xs:token" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="description" type="xs:string"/>
-      <xs:element name="target" type="xs:token"/>
-      <xs:element name="target-version" type="xs:token"/>
-      <xs:element name="tarball-url" type="xs:token"/>
-      <!-- Tarball sha256 checksum , not implemented. -->
-      <xs:element name="tarball-checksum" type="xs:token"
-                  minOccurs="0" maxOccurs="1"/>
-      <!-- Path to downloadable ṕlugin icon, not implemented. -->
-      <xs:element name="icon-url" type="xs:token" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="info-url" type="xs:token" minOccurs="0" maxOccurs="1"/>
-    </xs:sequence>
-    <xs:attribute name="version" type="xs:string" use="required"/> 
+    <xs:choice>
+      <xs:sequence>
+        <xs:element name="meta-url" type="xs:token" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:sequence>
+        <xs:group ref="plugin-elements"/>
+      </xs:sequence>
+    </xs:choice>
+    <xs:attribute name="version" type="xs:string" use="required"/>
   </xs:complexType>
 </xs:element>
- 
+
+<xs:group name="plugin-elements">
+  <xs:sequence>
+    <xs:element name="name" type="xs:token"/>
+    <xs:element name="version" type="xs:token"/>
+    <xs:element name="release" type="xs:token"/>
+    <xs:element ref="summary"/>
+    <xs:element name="api-version" type="xs:token"/>
+    <xs:element name="open-source" type="xs:token"/>
+    <xs:element name="author" type="xs:token"/>
+    <xs:element name="source" type="xs:token"/>
+    <xs:element name="info-url" type="xs:token" minOccurs="0" maxOccurs="1"/>
+    <xs:element name="description" type="xs:string"/>
+    <xs:element name="target" type="xs:token"/>
+    <xs:element name="target-version" type="xs:token"/>
+    <xs:element name="tarball-url" type="xs:token"/>
+    <!-- Tarball sha256 checksum , not implemented. -->
+    <xs:element name="tarball-checksum" type="xs:token"
+                minOccurs="0" maxOccurs="1"/>
+    <!-- Path to downloadable ṕlugin icon, not implemented. -->
+    <xs:element name="icon-url" type="xs:token" minOccurs="0" maxOccurs="1"/>
+    <xs:element name="info-url" type="xs:token" minOccurs="0" maxOccurs="1"/>
+  </xs:sequence>
+</xs:group>
+
+<xs:element name="summary">
+  <xs:simpleType>
+    <xs:restriction base="xs:token">
+      <xs:maxLength value="72"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:element>
 
 </xs:schema>
-

--- a/pre-commit
+++ b/pre-commit
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Pre-commit hook: validate ocpn-plugins.xml and check whitespace errors
+#   - Requires xmlllint available on $PATH.
+#   - Copy to .git/hooks to activate.
+#   - Use --no-verify to override.
+
+function files_to_update()
+{
+    git diff --cached --name-status | grep -v ^D | awk '$1 $2 { print $2}'
+}
+
+topdir=$( git rev-parse --show-toplevel )
+
+XML_SOURCES=( $( files_to_update | grep -E '\.xml$'))
+
+if [ -n "$XML_SOURCES" ]; then
+  xmllint --schema $topdir/ocpn-plugins.xsd  $XML_SOURCES --noout || exit 1
+fi
+
+# If there are whitespace errors, print the offending file names and fail.
+exec git diff-index --check --cached HEAD --


### PR DESCRIPTION
  - Update xsd file with new meta-url plugin
  - Add a git pre-commit hook. 

Using these tools it should not be possible to commit a ocpn-plugins.xml which does not validate, unless deliberately overriding the check. 

See more in pre-commit.