### PR TITLE
Add testplugin to beta stream

### DIFF
--- a/metadata/testplugin-plugin-darwin-10.13.6.xml
+++ b/metadata/testplugin-plugin-darwin-10.13.6.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<opencpn-plugin version="1">
+  <name> testplugin </name>
+  <version> 1.0.43 </version>
+  <release> 0 </release>
+  <summary> Plugin to test examples of the ODAPI and JSON interface for ODRAW 1234# </summary>
+
+  <api-version> 1.16 </api-version>
+  <open-source> yes </open-source>
+  <author> Jon Gough </author>
+  <source> https://github.com/jongough/testplugin_pi </source>
+
+  <description>
+    testplugin Plugin is used to test out the ODraw API and demonstrate how to use it successfully from another plugin
+  </description>
+
+  <target>darwin</target>
+  <target-version>10.13.6</target-version>
+  <tarball-url>
+    https://dl.cloudsmith.io/public/jon-gough/testplugin_pi-beta/raw/names/testplugin-darwin-10.13.6-tarball/versions/1.0.43.0+452.0f48625/testplugin_pi-1.0.43.0-ov50-1.16_darwin-10.13.6.tar.gz
+  </tarball-url>
+  <info-url> https://opencpn.org/OpenCPN/plugins/ocpn_draw.html </info-url>
+</opencpn-plugin>

--- a/metadata/testplugin-plugin-debian-10.xml
+++ b/metadata/testplugin-plugin-debian-10.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<opencpn-plugin version="1">
+  <name> testplugin </name>
+  <version> 1.0.43 </version>
+  <release> 0 </release>
+  <summary> Plugin to test examples of the ODAPI and JSON interface for ODRAW 1234# </summary>
+
+  <api-version> 1.16 </api-version>
+  <open-source> yes </open-source>
+  <author> Jon Gough </author>
+  <source> https://github.com/jongough/testplugin_pi </source>
+
+  <description>
+    testplugin Plugin is used to test out the ODraw API and demonstrate how to use it successfully from another plugin
+  </description>
+
+  <target>debian</target>
+  <target-version>10</target-version>
+  <tarball-url>
+    https://dl.cloudsmith.io/public/jon-gough/testplugin_pi-beta/raw/names/testplugin-debian-10-tarball/versions/1.0.43.0+458.0f48625/opencpn-plugin-testplugin-1.0.43.0-ov50-1.16_debian-10.tar.gz
+  </tarball-url>
+  <info-url> https://opencpn.org/OpenCPN/plugins/ocpn_draw.html </info-url>
+</opencpn-plugin>

--- a/metadata/testplugin-plugin-fedora-29.xml
+++ b/metadata/testplugin-plugin-fedora-29.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<opencpn-plugin version="1">
+  <name> testplugin </name>
+  <version> 1.0.43 </version>
+  <release> 0 </release>
+  <summary> Plugin to test examples of the ODAPI and JSON interface for ODRAW 1234# </summary>
+
+  <api-version> 1.16 </api-version>
+  <open-source> yes </open-source>
+  <author> Jon Gough </author>
+  <source> https://github.com/jongough/testplugin_pi </source>
+
+  <description>
+    testplugin Plugin is used to test out the ODraw API and demonstrate how to use it successfully from another plugin
+  </description>
+
+  <target>fedora</target>
+  <target-version>29</target-version>
+  <tarball-url>
+    https://dl.cloudsmith.io/public/jon-gough/testplugin_pi-beta/raw/names/testplugin-fedora-29-tarball/versions/1.0.43.0+455.0f48625/opencpn-plugin-testplugin-1.0.43.0-ov50-1.16_fedora-29.tar.gz
+  </tarball-url>
+  <info-url> https://opencpn.org/OpenCPN/plugins/ocpn_draw.html </info-url>
+</opencpn-plugin>

--- a/metadata/testplugin-plugin-flatpak-18.08.xml
+++ b/metadata/testplugin-plugin-flatpak-18.08.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<opencpn-plugin version="1">
+  <name> testplugin </name>
+  <version> 1.0.43 </version>
+  <release> 0 </release>
+  <summary> Plugin to test examples of the ODAPI and JSON interface for ODRAW 1234# </summary>
+
+  <api-version> 1.16 </api-version>
+  <open-source> yes </open-source>
+  <author> Jon Gough </author>
+  <source> https://github.com/jongough/testplugin_pi </source>
+
+  <description>
+    testplugin Plugin is used to test out the ODraw API and demonstrate how to use it successfully from another plugin
+  </description>
+
+  <target>flatpak</target>
+  <target-version>18.08</target-version>
+  <tarball-url>
+    https://dl.cloudsmith.io/public/jon-gough/testplugin_pi-beta/raw/names/testplugin-flatpak-18.08-tarball/versions/1.0.43.0+457.0f48625/testplugin_pi-1.0.43.0-ov50-1.16_flatpak-18.08.tar.gz
+  </tarball-url>
+  <info-url> https://opencpn.org/OpenCPN/plugins/ocpn_draw.html </info-url>
+</opencpn-plugin>

--- a/metadata/testplugin-plugin-mingw-10.xml
+++ b/metadata/testplugin-plugin-mingw-10.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<opencpn-plugin version="1">
+  <name> testplugin </name>
+  <version> 1.0.43 </version>
+  <release> 0 </release>
+  <summary> Plugin to test examples of the ODAPI and JSON interface for ODRAW 1234# </summary>
+
+  <api-version> 1.16 </api-version>
+  <open-source> yes </open-source>
+  <author> Jon Gough </author>
+  <source> https://github.com/jongough/testplugin_pi </source>
+
+  <description>
+    testplugin Plugin is used to test out the ODraw API and demonstrate how to use it successfully from another plugin
+  </description>
+
+  <target>mingw</target>
+  <target-version>10</target-version>
+  <tarball-url>
+    https://dl.cloudsmith.io/public/jon-gough/testplugin_pi-beta/raw/names/testplugin-mingw-10-tarball/versions/1.0.43.0+454.0f48625/testplugin_pi-1.0.43.0-ov50-1.16_mingw-10.tar.gz
+  </tarball-url>
+  <info-url> https://opencpn.org/OpenCPN/plugins/ocpn_draw.html </info-url>
+</opencpn-plugin>

--- a/metadata/testplugin-plugin-msvc-10.0.14393.xml
+++ b/metadata/testplugin-plugin-msvc-10.0.14393.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<opencpn-plugin version="1">
+<name> testplugin </name>
+<version> 1.0.43 </version>
+<release> 0 </release>
+<summary> Plugin to test examples of the ODAPI and JSON interface for ODRAW 1234# </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> Jon Gough </author>
+<source> https://github.com/jongough/testplugin_pi </source>
+
+<description>
+testplugin Plugin is used to test out the ODraw API and demonstrate how to use it successfully from another plugin
+</description>
+
+<target>msvc</target>
+<target-version>10.0.14393</target-version>
+<tarball-url>
+https://dl.cloudsmith.io/public/jon-gough/testplugin_pi-beta/raw/names/testplugin-msvc-10.0.14393-tarball/versions/1.0.43.+321.0f48625/testplugin_pi-1.0.43.0-ov50-1.16_msvc-10.0.14393.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/ocpn_draw.html </info-url>
+</opencpn-plugin>

--- a/metadata/testplugin-plugin-ubuntu-16.04.xml
+++ b/metadata/testplugin-plugin-ubuntu-16.04.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<opencpn-plugin version="1">
+  <name> testplugin </name>
+  <version> 1.0.43 </version>
+  <release> 0 </release>
+  <summary> Plugin to test examples of the ODAPI and JSON interface for ODRAW 1234# </summary>
+
+  <api-version> 1.16 </api-version>
+  <open-source> yes </open-source>
+  <author> Jon Gough </author>
+  <source> https://github.com/jongough/testplugin_pi </source>
+
+  <description>
+    testplugin Plugin is used to test out the ODraw API and demonstrate how to use it successfully from another plugin
+  </description>
+
+  <target>ubuntu</target>
+  <target-version>16.04</target-version>
+  <tarball-url>
+    https://dl.cloudsmith.io/public/jon-gough/testplugin_pi-beta/raw/names/testplugin-ubuntu-16.04-tarball/versions/1.0.43.0+456.0f48625/opencpn-plugin-testplugin-1.0.43.0-ov50-1.16_ubuntu-16.04.tar.gz
+  </tarball-url>
+  <info-url> https://opencpn.org/OpenCPN/plugins/ocpn_draw.html </info-url>
+</opencpn-plugin>

--- a/metadata/testplugin-plugin-ubuntu-18.04.xml
+++ b/metadata/testplugin-plugin-ubuntu-18.04.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<opencpn-plugin version="1">
+  <name> testplugin </name>
+  <version> 1.0.43 </version>
+  <release> 0 </release>
+  <summary> Plugin to test examples of the ODAPI and JSON interface for ODRAW 1234# </summary>
+
+  <api-version> 1.16 </api-version>
+  <open-source> yes </open-source>
+  <author> Jon Gough </author>
+  <source> https://github.com/jongough/testplugin_pi </source>
+
+  <description>
+    testplugin Plugin is used to test out the ODraw API and demonstrate how to use it successfully from another plugin
+  </description>
+
+  <target>ubuntu</target>
+  <target-version>18.04</target-version>
+  <tarball-url>
+    https://dl.cloudsmith.io/public/jon-gough/testplugin_pi-beta/raw/names/testplugin-ubuntu-18.04-tarball/versions/1.0.43.0+453.0f48625/opencpn-plugin-testplugin-1.0.43.0-ov50-1.16_ubuntu-18.04.tar.gz
+  </tarball-url>
+  <info-url> https://opencpn.org/OpenCPN/plugins/ocpn_draw.html </info-url>
+</opencpn-plugin>


### PR DESCRIPTION
Add 8 versions of testplugin_pi build. Still missing Raspberry PI builds but others are there.
This is the plugin being used to help build the 'generic' build cmake files for building any plugin for the new process.