### PR TITLE
tools: Add a new ocpn-install tool.

### DIFF
--- a/tools/ocpn-install.sh
+++ b/tools/ocpn-install.sh
@@ -116,10 +116,13 @@ case $filename in
         tar -cf - -C OpenCPN.app Contents \
             | tar -vC "$basedir" -xf - 2>&1 \
             | sed -e "s|^|$basedir/|" -e 's|/x ||'  > $manifest
-        sed -i '/exists/d' $manifest
         ;;
 esac
-echo "Files installed, manifest: $manifest"
+
+for f in $(cat $manifest); do
+    if [ -f "$f" ]; then count=$((count + 1)); fi
+done
+echo "$count files installed, manifest: $manifest"
 
 readonly version=$(echo $tarball | sed -e 's/[^-]*-\([^_]*\)_.*/\1/')
 echo "Rewriting version info using $version"

--- a/tools/ocpn-install.sh
+++ b/tools/ocpn-install.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+#
+#  Test tool which installs ań opencpn tarball directly,  without the
+#  upload/download cycle. The installation is intended to be identical
+#  with the plugin installer.
+#
+#  Dependencies:
+#     bash and sed -- both of which available in linux and macos.
+#     For windows, available in the git package.
+#
+#  Usage: 
+#     ocpn-install.sh <tarball>
+#
+
+function abspath() {
+    # Make path absolute
+    # $1:      existing path, possibly relative
+    # return:  absolute path
+    if [ -d "$1" ]; then
+        (cd "$1"; pwd)
+    elif [ -f "$1" ]; then
+        if [[ $1 = /* ]]; then
+            echo "$1"
+        elif [[ $1 == */* ]]; then
+            echo "$(cd "${1%/*}"; pwd)/${1##*/}"
+        else
+            echo "$(pwd)/$1"
+        fi
+    else 
+        echo "Cannot open: \"$1\" for read" >&2
+        exit 1
+    fi 
+}
+
+
+
+if [ $# -ne 1 ]; then
+    echo "Usage: local-install.sh <tarball>" >&2
+    exit 2
+fi
+if [ ! -f "$1" ]; then
+    echo "Cannot find tarball file \"$1\""
+    exit 1;
+fi
+
+readonly here=$(abspath $(dirname $0))
+readonly tarball=$(abspath $1)
+readonly filename=$(basename $tarball)
+readonly plugin_piname=${filename%%-*}
+readonly plugin_name=${plugin_piname%%_pi}
+readonly tmpdir=$(mktemp -d)
+
+echo "Unpacking tarball $tarball"
+cd $tmpdir
+tar --strip-components=1 -xf $tarball
+
+case $filename in 
+    *msvc*.tar.gz)
+        basedir=$HOME/AppData/Local/opencpn
+        installdir="/c/ProgramData/opencpn/plugins/install_data"
+        ;;
+    *flatpak*.tar.gz)
+        basedir=$HOME/.var/app/org.opencpn.OpenCPN
+        installdir="$HOME/.opencpn/plugins/install_data"
+        ;;
+    *ubuntu*.tar.gz | *debian*.tar.gz)
+        basedir=$HOME/.local
+        installdir="$HOME/.opencpn/plugins/install_data"
+        ;;
+    *darwin*.tar.gz)
+        basedir=$HOME/Library/Application\ Support/OpenCPN/
+        installdir="$HOME/Library/Preferences/plugins/"
+        installdir="$installdir/${plugin_piname}/install_data"
+esac
+test -d $installdir || mkdir -p $installdir
+
+manifest="$installdir/$plugin_name.files"
+version_file="$installdir/$plugin_name.version"
+
+if [ -f "$manifest" ]; then
+    echo "Cleaning up old files in $basedir"
+    rm -f $(cat $manifest) 2>/dev/null
+    rm $manifest
+fi
+
+case $filename in 
+    *msvc*.tar.gz | *mingw*.tar.gz)
+        echo "Installing windows plugin into $basedir/{plugins,share}"
+        tar -cf - plugins \
+            | tar -vC $basedir -xf - \
+            | sed -e "s|^|$basedir/|"  -e "s|/c/|C:/|" > $manifest
+        tar -cf - share \
+            | tar -vC $basedir -xf - \
+            | sed -e "s|^|$basedir/|"  -e "s|/c/|C:/|" >> $manifest
+        ;;
+
+    *flatpak*.tar.gz)
+        echo "Installing flatpak plugin into $basedir"
+        tar -cf - bin lib \
+            | tar -vC $basedir -xf - \
+            | sed -e "s|^|$basedir/|"   > $manifest
+        tar -cf - -C share locale opencpn \
+            | tar -vC $basedir/data -xf - \
+            | sed -e "s|^|$basedir/|"   >> $manifest
+        ;;
+
+    *ubuntu*.tar.gz | *debian*.tar.gz)
+        echo "Installing linux plugin into $basedir"
+        tar -cf - bin lib share \
+            | tar -vC $basedir -xf - \
+            | sed "s|^|$basedir/|" >$manifest
+        ;;
+
+    *darwin*.tar.gz)
+        echo "Installing macos plugin into \"$basedir\""
+        tar -cf - -C OpenCPN.app Contents \
+            | tar -vC "$basedir" -xf - 2>&1 \
+            | sed -e "s|^|$basedir/|" -e 's|/x ||'  > $manifest
+        sed -i '/exists/d' $manifest
+        ;;
+esac
+echo "Files installed, manifest: $manifest"
+
+readonly version=$(echo $tarball | sed -e 's/[^-]*-\([^_]*\)_.*/\1/')
+echo "Rewriting version info using $version"
+echo $version > $version_file
+
+cd $here
+rm -rf $tmpdir

--- a/tools/ocpn-uninstall.sh
+++ b/tools/ocpn-uninstall.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+#
+#  Test tool which uninstalls a plugin from the command line.
+#
+#  Dependencies:
+#     bash  -- available in linux and macos.
+#     For windows, available in the git package.
+#
+#  Usage: See usage()
+#
+
+function usage() {
+     cat << EOF
+
+Usage: ocpn-uninstall.sh <plugin> <platform | manifest>
+
+Parameters:
+    plugin:    Name of plugin, typically with a _pi suffix.
+    platform:  windows, linux, darwin or flatpak.
+    manifest:  Path to installation manifest, as printed at installation
+
+Example:
+    ./ocpn-uninstall.sh oesenc_pi windows
+EOF
+}
+
+
+if [ $# -ne 2 ]; then
+    usage >&2;
+    exit 2
+fi
+platform=$2
+plugin=$1
+
+if [ -f "$platform" ]; then
+    manifest=$platform
+else
+    case $platform in
+        windows)
+            installdir="/c/ProgramData/opencpn/plugins/install_data"
+            ;;
+        flatpak)
+            installdir="$HOME/.opencpn/plugins/install_data"
+            ;;
+        linux)
+            installdir="$HOME/.opencpn/plugins/install_data"
+            ;;
+        darwin | macos)
+            installdir="$HOME/Library/Preferences/plugins/"
+            installdir="$installdir/${plugin}/install_data"
+            ;;
+        *)
+            echo  "Unknown platform: $platform" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+    manifest="$installdir/${plugin%%_pi}.files"
+fi
+
+if [ ! -f "$manifest" ]; then
+    echo -e "Cannot locate manifest file: $manifest\nGiving up."  >&2
+    exit 2;
+fi
+
+count=0
+for f in $(cat $manifest); do
+    test -f "$f" || continue
+    rm -f "$f"
+    count=$((count + 1))
+done
+
+echo "Removed $count files + manifest"
+rm -f $manifest


### PR DESCRIPTION
Add tool which can install a local tarball in the same way as the
installer. Typically a developer test tool -- a generated
tarball can be tested without the upload/download cycle.

Closes: OpenCPN/OpenCPN#1600

EDIT: fix bug reference