### PR TITLE
Common name

### DIFF
--- a/tools/ocpn-install.sh
+++ b/tools/ocpn-install.sh
@@ -9,17 +9,25 @@
 #     For windows, available in the git package.
 #
 #  Usage: 
-#     ocpn-install.sh <tarball>  <metadata>
-#
-#  Parameters
-#     tarball: tar.gz plugin archive aimed to be installed by installer.
-#     metadata: xml file with metadata, used to build catalog.
-#
-#  See:
-#     https://github.com/leamas/opencpn/wiki/Tarballs
-#     https://github.com/leamas/opencpn/wiki/Catalog
+#     See usage()
 #
 
+
+function usage() {
+cat << EOF
+Usage:
+   ocpn-install.sh <tarball>  <metadata>
+
+Parameters
+   tarball: tar.gz plugin archive aimed to be installed by installer.
+   metadata: xml file with metadata, used to build catalog.
+
+See:
+   https://github.com/leamas/opencpn/wiki/Tarballs
+   https://github.com/leamas/opencpn/wiki/Catalog
+
+EOF
+}
 
 function abspath() {
     # Make path absolute
@@ -57,8 +65,12 @@ EOF
 
 
 if [ $# -ne 2 ]; then
-    echo "Usage: local-install.sh <tarball> <metadata>" >&2
+    usage;
     exit 2
+fi
+if [ "$1" == '-h' -o "$1" 0 '--help' ]; then
+    usage;
+    exit 0
 fi
 if [ ! -f "$1" ]; then
     echo "Cannot find tarball file \"$1\""

--- a/tools/ocpn-install.sh
+++ b/tools/ocpn-install.sh
@@ -135,6 +135,8 @@ case $filename in
         ;;
 
     *ubuntu*.tar.gz | *debian*.tar.gz | *raspbian*.tar.gz)
+        if [ -d usr ]; then cd usr; fi
+        if [ -d local ]; then cd local; fi
         echo "Installing linux plugin into $basedir"
         tar -cf - bin lib share \
             | tar -vC $basedir -xf - \

--- a/tools/ocpn-install.sh
+++ b/tools/ocpn-install.sh
@@ -63,7 +63,7 @@ case $filename in
         basedir=$HOME/.var/app/org.opencpn.OpenCPN
         installdir="$HOME/.opencpn/plugins/install_data"
         ;;
-    *ubuntu*.tar.gz | *debian*.tar.gz)
+    *ubuntu*.tar.gz | *debian*.tar.gz | *raspbian*.tar.gz)
         basedir=$HOME/.local
         installdir="$HOME/.opencpn/plugins/install_data"
         ;;
@@ -104,7 +104,7 @@ case $filename in
             | sed -e "s|^|$basedir/|"   >> $manifest
         ;;
 
-    *ubuntu*.tar.gz | *debian*.tar.gz)
+    *ubuntu*.tar.gz | *debian*.tar.gz | *raspbian*.tar.gz)
         echo "Installing linux plugin into $basedir"
         tar -cf - bin lib share \
             | tar -vC $basedir -xf - \

--- a/tools/ocpn-uninstall.sh
+++ b/tools/ocpn-uninstall.sh
@@ -15,12 +15,13 @@ function usage() {
 Usage: ocpn-uninstall.sh <plugin> <platform | manifest>
 
 Parameters:
-    plugin:    Name of plugin, typically with a _pi suffix.
+    plugin:    Common name of plugin as of GetCommonName(), typically
+               without a _pi suffix.
     platform:  windows, linux, darwin or flatpak.
-    manifest:  Path to installation manifest, as printed at installation
+    manifest:  Path to installation manifest, as printed at installation.
 
 Example:
-    ./ocpn-uninstall.sh oesenc_pi windows
+    ./ocpn-uninstall.sh oeSENC windows
 EOF
 }
 


### PR DESCRIPTION
Trying to handle #60 and also some other interesting features of the oernc plugin:
  - Parse the plugin name (common name) from the xml metadata instead of parsing tarball name (#60).
  - Accept tarballs with a /usr or /usr/local prefix.
  - Accept plugin (common) names  containing spaces.  This makes it work for now, but creates manifest and version files with spaces in filename. 
  - Add raspbian to the list of supported target os'es. 
  - While on it, enhance the runtime usage info in scripts.

Closes: #60