### PR TITLE
ocpn-metadata: Decrease noise on nomal usage, enhanced parser error info.

### DIFF
--- a/tools/ocpn-metadata
+++ b/tools/ocpn-metadata
@@ -12,6 +12,7 @@ import xml.dom.minidom as minidom
 
 from sys import platform
 from pathlib import Path
+from xml.etree.ElementTree import ParseError
 
 
 def get_paths():
@@ -92,7 +93,13 @@ def generate(args):
     for path in Path(args.userdir).glob("*.xml"):
         if args.verbose:
             print(f'Processing:  {path}')
-        subtree = ET.parse(str(path))
+        try:
+            subtree = ET.parse(str(path))
+        except ParseError as e:
+            print("Error parsing %s at line %d" %
+                          (path.as_posix(), e.position[0]),
+                  file=sys.stderr)
+            sys.exit(2)
         subtree.getroot().tag = 'plugin'
         tree.append(subtree.getroot())
     dom = minidom.parseString(ET.tostring(tree))

--- a/tools/ocpn-metadata
+++ b/tools/ocpn-metadata
@@ -79,20 +79,20 @@ def get_args(paths):
     return args
 
 
-def generate(sourcedir, destfile, version):
+def generate(args):
     """Generate a new ocpn-plugins.xml."""
     tree = ET.Element('plugins')
     version_elem = ET.SubElement(tree, "version")
-    version_elem.text = version
+    version_elem.text = args.version
     date_elem = ET.SubElement(tree, "date")
     date_elem.text = datetime.datetime.now().strftime('%Y-%m-%d %H:%M')
-    for path in Path(sourcedir).glob("*.xml"):
+    for path in Path(args.userdir).glob("*.xml"):
         print(f'Processing:  {path}')
         subtree = ET.parse(str(path))
         subtree.getroot().tag = 'plugin'
         tree.append(subtree.getroot())
     dom = minidom.parseString(ET.tostring(tree))
-    with open(destfile, "w") as f:
+    with open(args.destfile, "w") as f:
         for line in dom.toprettyxml(indent="  ").split("\n"):
             line = line.rstrip()
             if line:
@@ -130,7 +130,7 @@ def main():
             print("The file %s is in the way" % args.destfile)
             print("Please remove or use --force")
             sys.exit(1)
-        generate(args.userdir, args.destfile, args.version)
+        generate(args)
         print("Generated new ocpn-plugins.xml at " + args.destfile)
 
 

--- a/tools/ocpn-metadata
+++ b/tools/ocpn-metadata
@@ -75,6 +75,9 @@ def get_args(paths):
     generate_parser.add_argument(
             '--force', action="store_true",
             help='Overwrite possibly existing ocpn-plugins.xml.')
+    generate_parser.add_argument(
+            '--verbose', action="store_true",
+            help='Add verbose output')
     args = parser.parse_args()
     return args
 
@@ -87,7 +90,8 @@ def generate(args):
     date_elem = ET.SubElement(tree, "date")
     date_elem.text = datetime.datetime.now().strftime('%Y-%m-%d %H:%M')
     for path in Path(args.userdir).glob("*.xml"):
-        print(f'Processing:  {path}')
+        if args.verbose:
+            print(f'Processing:  {path}')
         subtree = ET.parse(str(path))
         subtree.getroot().tag = 'plugin'
         tree.append(subtree.getroot())


### PR DESCRIPTION
After 5d5c5f4 the output from ocpn-metadata is way to noisy for regular usage already now, and after adding some more plugins it will generate several pages of  what's basically debug info also on normal use.

Add a --verbose option, and conditionalize the output on this option.

Also, add some info when a ParseError is generated due to for example not well-formed xml input.

Closes: #59