### PR TITLE
ocpn-plugins.xsd: Fix typo making "make validate" fail.

### DIFF
--- a/ocpn-plugins.xsd
+++ b/ocpn-plugins.xsd
@@ -17,7 +17,7 @@
       <xs:element name="name" type="xs:token"/>
       <xs:element name="version" type="xs:token"/>
       <xs:element name="release" type="xs:token"/>
-      <xs:element ref="summary">
+      <xs:element ref="summary"/>
       <xs:element name="api-version" type="xs:token"/>
       <xs:element name="open-source" type="xs:token"/>
       <xs:element name="author" type="xs:token"/>


### PR DESCRIPTION
Fix a typo in 5285f93 which makes the xsd file useless due to syntax errors (sorry!).