### PR TITLE
Xsd update -- constrain values and handle plugin metadata (#112, #115)

### DIFF
--- a/ocpn-plugin.xsd
+++ b/ocpn-plugin.xsd
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+<xs:element name="plugin">
+  <xs:complexType>
+    <xs:sequence>
+      <xs:element name="name" type="xs:token"/>
+      <xs:element name="version" type="xs:token"/>
+      <xs:element name="release" type="xs:token"/>
+      <xs:element ref="summary"/>
+      <xs:element name="api-version" type="xs:token"/>
+      <xs:element name="open-source" type="xs:token"/>
+      <xs:element name="author" type="xs:token"/>
+      <xs:element name="source" type="xs:token"/>
+      <xs:element name="info-url" type="xs:token" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="description" type="xs:string"/>
+      <xs:element ref="target"/>
+      <xs:element name="target-version" type="xs:token"/>
+      <xs:element ref="target-arch"/>
+      <xs:element name="tarball-url" type="xs:token"/>
+      <!-- Tarball sha256 checksum , not implemented. -->
+      <xs:element name="tarball-checksum" type="xs:token"
+                  minOccurs="0" maxOccurs="1"/>
+      <xs:element name="info-url" type="xs:token" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="version" type="xs:string" use="required"/> 
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="summary">
+  <xs:simpleType>
+    <xs:restriction base="xs:token">
+      <xs:maxLength value="72"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:element>
+
+
+<xs:element name="target-arch">
+  <xs:simpleType>
+    <xs:restriction base = "xs:string">
+      <xs:enumeration value = "i386"/>
+      <xs:enumeration value = "x86_64"/>
+      <xs:enumeration value = "armhf"/>
+      <xs:enumeration value = "arm64"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:element> 
+
+<xs:element name="target">
+  <xs:simpleType>
+    <xs:restriction base = "xs:string">
+      <xs:enumeration value = "darwin"/>
+      <xs:enumeration value = "debian-armhf"/>
+      <xs:enumeration value = "debian-x86_64"/>
+      <xs:enumeration value = "flatpak"/>
+      <xs:enumeration value = "flatpak-x86_64"/>
+      <xs:enumeration value = "mingw"/>
+      <xs:enumeration value = "msvc"/>
+      <xs:enumeration value = "raspbian-armhf"/>
+      <xs:enumeration value = "ubuntu-arm64"/>
+      <xs:enumeration value = "ubuntu-gtk3-arm64"/>
+      <xs:enumeration value = "ubuntu-gtk3-x86_64"/>
+      <xs:enumeration value = "ubuntu-x86_64"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:element> 
+
+
+</xs:schema>

--- a/ocpn-plugins.xsd
+++ b/ocpn-plugins.xsd
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
+<xs:include schemaLocation="ocpn-plugin.xsd"/>
+
 <xs:element name="plugins">
   <xs:complexType>
     <xs:sequence>
@@ -10,71 +12,5 @@
    </xs:sequence>
   </xs:complexType>
 </xs:element>
-
-<xs:element name="plugin">
-  <xs:complexType>
-    <xs:sequence>
-      <xs:element name="name" type="xs:token"/>
-      <xs:element name="version" type="xs:token"/>
-      <xs:element name="release" type="xs:token"/>
-      <xs:element ref="summary"/>
-      <xs:element name="api-version" type="xs:token"/>
-      <xs:element name="open-source" type="xs:token"/>
-      <xs:element name="author" type="xs:token"/>
-      <xs:element name="source" type="xs:token"/>
-      <xs:element name="info-url" type="xs:token" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="description" type="xs:string"/>
-      <xs:element ref="target"/>
-      <xs:element name="target-version" type="xs:token"/>
-      <xs:element ref="target-arch"/>
-      <xs:element name="tarball-url" type="xs:token"/>
-      <!-- Tarball sha256 checksum , not implemented. -->
-      <xs:element name="tarball-checksum" type="xs:token"
-                  minOccurs="0" maxOccurs="1"/>
-      <xs:element name="info-url" type="xs:token" minOccurs="0" maxOccurs="1"/>
-    </xs:sequence>
-    <xs:attribute name="version" type="xs:string" use="required"/> 
-  </xs:complexType>
-</xs:element>
-
-<xs:element name="summary">
-  <xs:simpleType>
-    <xs:restriction base="xs:token">
-      <xs:maxLength value="72"/>
-    </xs:restriction>
-  </xs:simpleType>
-</xs:element>
-
-
-<xs:element name="target-arch">
-  <xs:simpleType>
-    <xs:restriction base = "xs:string">
-      <xs:enumeration value = "i386"/>
-      <xs:enumeration value = "x86_64"/>
-      <xs:enumeration value = "armhf"/>
-      <xs:enumeration value = "arm64"/>
-    </xs:restriction>
-  </xs:simpleType>
-</xs:element> 
-
-<xs:element name="target">
-  <xs:simpleType>
-    <xs:restriction base = "xs:string">
-      <xs:enumeration value = "darwin"/>
-      <xs:enumeration value = "debian-armhf"/>
-      <xs:enumeration value = "debian-x86_64"/>
-      <xs:enumeration value = "flatpak"/>
-      <xs:enumeration value = "flatpak-x86_64"/>
-      <xs:enumeration value = "mingw"/>
-      <xs:enumeration value = "msvc"/>
-      <xs:enumeration value = "raspbian-armhf"/>
-      <xs:enumeration value = "ubuntu-arm64"/>
-      <xs:enumeration value = "ubuntu-gtk3-arm64"/>
-      <xs:enumeration value = "ubuntu-gtk3-x86_64"/>
-      <xs:enumeration value = "ubuntu-x86_64"/>
-    </xs:restriction>
-  </xs:simpleType>
-</xs:element> 
-
 
 </xs:schema>

--- a/ocpn-plugins.xsd
+++ b/ocpn-plugins.xsd
@@ -24,7 +24,7 @@
       <xs:element name="source" type="xs:token"/>
       <xs:element name="info-url" type="xs:token" minOccurs="0" maxOccurs="1"/>
       <xs:element name="description" type="xs:string"/>
-      <xs:element name="target" type="xs:token"/>
+      <xs:element ref="target"/>
       <xs:element name="target-version" type="xs:token"/>
       <xs:element ref="target-arch"/>
       <xs:element name="tarball-url" type="xs:token"/>
@@ -56,5 +56,25 @@
     </xs:restriction>
   </xs:simpleType>
 </xs:element> 
+
+<xs:element name="target">
+  <xs:simpleType>
+    <xs:restriction base = "xs:string">
+      <xs:enumeration value = "darwin"/>
+      <xs:enumeration value = "debian-armhf"/>
+      <xs:enumeration value = "debian-x86_64"/>
+      <xs:enumeration value = "flatpak"/>
+      <xs:enumeration value = "flatpak-x86_64"/>
+      <xs:enumeration value = "mingw"/>
+      <xs:enumeration value = "msvc"/>
+      <xs:enumeration value = "raspbian-armhf"/>
+      <xs:enumeration value = "ubuntu-arm64"/>
+      <xs:enumeration value = "ubuntu-gtk3-arm64"/>
+      <xs:enumeration value = "ubuntu-gtk3-x86_64"/>
+      <xs:enumeration value = "ubuntu-x86_64"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:element> 
+
 
 </xs:schema>

--- a/ocpn-plugins.xsd
+++ b/ocpn-plugins.xsd
@@ -26,7 +26,7 @@
       <xs:element name="description" type="xs:string"/>
       <xs:element name="target" type="xs:token"/>
       <xs:element name="target-version" type="xs:token"/>
-      <xs:element name="target-arch" type="xs:token"/>
+      <xs:element ref="target-arch"/>
       <xs:element name="tarball-url" type="xs:token"/>
       <!-- Tarball sha256 checksum , not implemented. -->
       <xs:element name="tarball-checksum" type="xs:token"
@@ -44,5 +44,17 @@
     </xs:restriction>
   </xs:simpleType>
 </xs:element>
+
+
+<xs:element name="target-arch">
+  <xs:simpleType>
+    <xs:restriction base = "xs:string">
+      <xs:enumeration value = "i386"/>
+      <xs:enumeration value = "x86_64"/>
+      <xs:enumeration value = "armhf"/>
+      <xs:enumeration value = "arm64"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:element> 
 
 </xs:schema>


### PR DESCRIPTION
Fixes for #112 (constrain target and target-arch  values) and #115 (support validation of single XML metadata file).

These patches contains lists of allowed values for target and target-arch. These need to be reviewed, I don't have the complete picture.

The PR supports validating a single  plugin metadata file using something like 

     xmllint  --schema ocpn-plugin.xsd  --noout \
        metadata/windvane_pi-1.0.13.0_ubuntu-amd64_20.04-focal.xml

Running `make validate`on current ocpn-plugins.xml  using this PR gives about 120 errors; log is attached. Possibly, some of these errors should be fixed by modifying the xsd, but the bulk is certainly errors in the xml file.


[validate.log](https://github.com/OpenCPN/plugins/files/4748613/validate.log)

