### PR TITLE
vfkaps-2.1.1.7

### DIFF
--- a/metadata/vfkaps_pi-2.1.1.7-darwin-x86_64-10.13.6-macos.xml
+++ b/metadata/vfkaps_pi-2.1.1.7-darwin-x86_64-10.13.6-macos.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
-<name> VFkaps </name>
-<version> 2.1.1.6 </version>
-<release> 6 </release>
+<name> vfkaps </name>
+<version> 2.1.1.7 </version>
+<release> 7 </release>
 <summary> Produce KAP charts from downloaded satellite images </summary>
 
 <api-version> 1.16 </api-version>
@@ -14,11 +14,11 @@
 Download and install KAP charts from VentureFarther.com
 </description>
 
-<target>ubuntu-x86_64</target>
-<target-version>16.04</target-version>
+<target>darwin</target>
+<target-version>10.13.6</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/vfkaps-prod/raw/names/vfkaps_pi-2.1.1.6-ubuntu-x86_64-16.04-xenial-tarball/versions/v2.1.1.6/vfkaps_pi-2.1.1.6-ubuntu-x86_64-16.04-xenial.tar.gz
+https://dl.cloudsmith.io/public/opencpn/vfkaps-prod/raw/names/vfkaps_pi-2.1.1.7-darwin-x86_64-10.13.6-macos-tarball/versions/V2.1.1.7/vfkaps_pi-2.1.1.7-darwin-x86_64-10.13.6-macos.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:charts:vfkaps </info-url>
 </plugin>

--- a/metadata/vfkaps_pi-2.1.1.7-debian-x86_64-10-buster.xml
+++ b/metadata/vfkaps_pi-2.1.1.7-debian-x86_64-10-buster.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
-<name> VFkaps </name>
-<version> 2.1.1.6 </version>
-<release> 6 </release>
+<name> vfkaps </name>
+<version> 2.1.1.7 </version>
+<release> 7 </release>
 <summary> Produce KAP charts from downloaded satellite images </summary>
 
 <api-version> 1.16 </api-version>
@@ -14,11 +14,11 @@
 Download and install KAP charts from VentureFarther.com
 </description>
 
-<target>msvc</target>
-<target-version>10.0.14393</target-version>
+<target>debian-x86_64</target>
+<target-version>10</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/vfkaps-prod/raw/names/vfkaps_pi-2.1.1.6-msvc-x86_64-10.0.14393-MSVC-tarball/versions/v2.1.1.6/vfkaps_pi-2.1.1.6-msvc-x86_64-10.0.14393-MSVC.tar.gz
+https://dl.cloudsmith.io/public/opencpn/vfkaps-prod/raw/names/vfkaps_pi-2.1.1.7-debian-x86_64-10-buster-tarball/versions/V2.1.1.7/vfkaps_pi-2.1.1.7-debian-x86_64-10-buster.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:charts:vfkaps </info-url>
 </plugin>

--- a/metadata/vfkaps_pi-2.1.1.7-flatpak-x86_64-18.08-flatpak.xml
+++ b/metadata/vfkaps_pi-2.1.1.7-flatpak-x86_64-18.08-flatpak.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
-<name> VFkaps </name>
-<version> 2.1.1.6 </version>
-<release> 6 </release>
+<name> vfkaps </name>
+<version> 2.1.1.7 </version>
+<release> 7 </release>
 <summary> Produce KAP charts from downloaded satellite images </summary>
 
 <api-version> 1.16 </api-version>
@@ -14,11 +14,11 @@
 Download and install KAP charts from VentureFarther.com
 </description>
 
-<target>mingw</target>
-<target-version>10</target-version>
+<target>flatpak-x86_64</target>
+<target-version>18.08</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/vfkaps-prod/raw/names/vfkaps_pi-2.1.1.6-mingw-x86_64-10-mingw-tarball/versions/v2.1.1.6/vfkaps_pi-2.1.1.6-mingw-x86_64-10-mingw.tar.gz
+https://dl.cloudsmith.io/public/opencpn/vfkaps-prod/raw/names/vfkaps_pi-2.1.1.7-flatpak-x86_64-18.08-flatpak-tarball/versions/V2.1.1.7/vfkaps_pi-2.1.1.7-x86_64_flatpak-18.08.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:charts:vfkaps </info-url>
 </plugin>

--- a/metadata/vfkaps_pi-2.1.1.7-mingw-x86_64-10-mingw.xml
+++ b/metadata/vfkaps_pi-2.1.1.7-mingw-x86_64-10-mingw.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
-<name> VFkaps </name>
-<version> 2.1.1.6 </version>
-<release> 6 </release>
+<name> vfkaps </name>
+<version> 2.1.1.7 </version>
+<release> 7 </release>
 <summary> Produce KAP charts from downloaded satellite images </summary>
 
 <api-version> 1.16 </api-version>
@@ -14,11 +14,11 @@
 Download and install KAP charts from VentureFarther.com
 </description>
 
-<target>debian-x86_64</target>
+<target>mingw</target>
 <target-version>10</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/vfkaps-prod/raw/names/vfkaps_pi-2.1.1.6-debian-x86_64-10-buster-tarball/versions/v2.1.1.6/vfkaps_pi-2.1.1.6-debian-x86_64-10-buster.tar.gz
+https://dl.cloudsmith.io/public/opencpn/vfkaps-prod/raw/names/vfkaps_pi-2.1.1.7-mingw-x86_64-10-mingw-tarball/versions/V2.1.1.7/vfkaps_pi-2.1.1.7-mingw-x86_64-10-mingw.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:charts:vfkaps </info-url>
 </plugin>

--- a/metadata/vfkaps_pi-2.1.1.7-msvc-x86_64-10.0.14393-MSVC.xml
+++ b/metadata/vfkaps_pi-2.1.1.7-msvc-x86_64-10.0.14393-MSVC.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
-<name> VFkaps </name>
-<version> 2.1.1.6 </version>
-<release> 6 </release>
+<name> vfkaps </name>
+<version> 2.1.1.7 </version>
+<release> 7 </release>
 <summary> Produce KAP charts from downloaded satellite images </summary>
 
 <api-version> 1.16 </api-version>
@@ -14,11 +14,11 @@
 Download and install KAP charts from VentureFarther.com
 </description>
 
-<target>ubuntu-x86_64</target>
-<target-version>14.04</target-version>
+<target>msvc</target>
+<target-version>10.0.14393</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/vfkaps-prod/raw/names/vfkaps_pi-2.1.1.6-ubuntu-x86_64-14.04-trusty-tarball/versions/v2.1.1.6/vfkaps_pi-2.1.1.6-ubuntu-x86_64-14.04-trusty.tar.gz
+https://dl.cloudsmith.io/public/opencpn/vfkaps-prod/raw/names/vfkaps_pi-2.1.1.7-msvc-x86_64-10.0.14393-MSVC-tarball/versions/V2.1.1.7/vfkaps_pi-2.1.1.7-msvc-x86_64-10.0.14393-MSVC.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:charts:vfkaps </info-url>
 </plugin>

--- a/metadata/vfkaps_pi-2.1.1.7-raspbian-armhf-10-buster-armhf.xml
+++ b/metadata/vfkaps_pi-2.1.1.7-raspbian-armhf-10-buster-armhf.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
-<name> VFkaps </name>
-<version> 2.1.1.6 </version>
-<release> 6 </release>
+<name> vfkaps </name>
+<version> 2.1.1.7 </version>
+<release> 7 </release>
 <summary> Produce KAP charts from downloaded satellite images </summary>
 
 <api-version> 1.16 </api-version>
@@ -14,11 +14,11 @@
 Download and install KAP charts from VentureFarther.com
 </description>
 
-<target>ubuntu-arm64</target>
-<target-version>18.04</target-version>
-<target-arch>arm64</target-arch>
+<target>raspbian-armhf</target>
+<target-version>10</target-version>
+<target-arch>armhf</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/vfkaps-prod/raw/names/vfkaps_pi-2.1.1.6-ubuntu-arm64-18.04-bionic-armh64-tarball/versions/v2.1.1.6/vfkaps_pi-2.1.1.6-ubuntu-arm64-18.04-bionic-armh64.tar.gz
+https://dl.cloudsmith.io/public/opencpn/vfkaps-prod/raw/names/vfkaps_pi-2.1.1.7-raspbian-armhf-10-buster-armhf-tarball/versions/V2.1.1.7/vfkaps_pi-2.1.1.7-raspbian-armhf-10-buster-armhf.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:charts:vfkaps </info-url>
 </plugin>

--- a/metadata/vfkaps_pi-2.1.1.7-raspbian-armhf-9.4-stretch-armhf.xml
+++ b/metadata/vfkaps_pi-2.1.1.7-raspbian-armhf-9.4-stretch-armhf.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
-<name> VFkaps </name>
-<version> 2.1.1.6 </version>
-<release> 6 </release>
+<name> vfkaps </name>
+<version> 2.1.1.7 </version>
+<release> 7 </release>
 <summary> Produce KAP charts from downloaded satellite images </summary>
 
 <api-version> 1.16 </api-version>
@@ -14,11 +14,11 @@
 Download and install KAP charts from VentureFarther.com
 </description>
 
-<target>flatpak-x86_64</target>
-<target-version>18.08</target-version>
-<target-arch>x86_64</target-arch>
+<target>raspbian-armhf</target>
+<target-version>9.4</target-version>
+<target-arch>armhf</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/vfkaps-prod/raw/names/vfkaps_pi-2.1.1.6-flatpak-x86_64-18.08-flatpak-tarball/versions/v2.1.1.6/vfkaps_pi-2.1.1.6-x86_64_flatpak-18.08.tar.gz
+https://dl.cloudsmith.io/public/opencpn/vfkaps-prod/raw/names/vfkaps_pi-2.1.1.7-raspbian-armhf-9.4-stretch-armhf-tarball/versions/V2.1.1.7/vfkaps_pi-2.1.1.7-raspbian-armhf-9.4-stretch-armhf.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:charts:vfkaps </info-url>
 </plugin>

--- a/metadata/vfkaps_pi-2.1.1.7-ubuntu-arm64-18.04-bionic-armh64.xml
+++ b/metadata/vfkaps_pi-2.1.1.7-ubuntu-arm64-18.04-bionic-armh64.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
-<name> VFkaps </name>
-<version> 2.1.1.6 </version>
-<release> 6 </release>
+<name> vfkaps </name>
+<version> 2.1.1.7 </version>
+<release> 7 </release>
 <summary> Produce KAP charts from downloaded satellite images </summary>
 
 <api-version> 1.16 </api-version>
@@ -14,11 +14,11 @@
 Download and install KAP charts from VentureFarther.com
 </description>
 
-<target>ubuntu-gtk3-x86_64</target>
+<target>ubuntu-arm64</target>
 <target-version>18.04</target-version>
-<target-arch>x86_64</target-arch>
+<target-arch>arm64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/vfkaps-prod/raw/names/vfkaps_pi-2.1.1.6-ubuntu-x86_64-18.04-bionic-gtk3-tarball/versions/v2.1.1.6/vfkaps_pi-2.1.1.6-ubuntu-x86_64-18.04-bionic-gtk3.tar.gz
+https://dl.cloudsmith.io/public/opencpn/vfkaps-prod/raw/names/vfkaps_pi-2.1.1.7-ubuntu-arm64-18.04-bionic-armh64-tarball/versions/V2.1.1.7/vfkaps_pi-2.1.1.7-ubuntu-arm64-18.04-bionic-armh64.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:charts:vfkaps </info-url>
 </plugin>

--- a/metadata/vfkaps_pi-2.1.1.7-ubuntu-x86_64-14.04-trusty.xml
+++ b/metadata/vfkaps_pi-2.1.1.7-ubuntu-x86_64-14.04-trusty.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
-<name> VFkaps </name>
-<version> 2.1.1.6 </version>
-<release> 6 </release>
+<name> vfkaps </name>
+<version> 2.1.1.7 </version>
+<release> 7 </release>
 <summary> Produce KAP charts from downloaded satellite images </summary>
 
 <api-version> 1.16 </api-version>
@@ -14,11 +14,11 @@
 Download and install KAP charts from VentureFarther.com
 </description>
 
-<target>raspbian-armhf</target>
-<target-version>9.4</target-version>
-<target-arch>armhf</target-arch>
+<target>ubuntu-x86_64</target>
+<target-version>14.04</target-version>
+<target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/vfkaps-prod/raw/names/vfkaps_pi-2.1.1.6-raspbian-armhf-9.4-stretch-armhf-tarball/versions/v2.1.1.6/vfkaps_pi-2.1.1.6-raspbian-armhf-9.4-stretch-armhf.tar.gz
+https://dl.cloudsmith.io/public/opencpn/vfkaps-prod/raw/names/vfkaps_pi-2.1.1.7-ubuntu-x86_64-14.04-trusty-tarball/versions/V2.1.1.7/vfkaps_pi-2.1.1.7-ubuntu-x86_64-14.04-trusty.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:charts:vfkaps </info-url>
 </plugin>

--- a/metadata/vfkaps_pi-2.1.1.7-ubuntu-x86_64-16.04-xenial.xml
+++ b/metadata/vfkaps_pi-2.1.1.7-ubuntu-x86_64-16.04-xenial.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
-<name> VFkaps </name>
-<version> 2.1.1.6 </version>
-<release> 6 </release>
+<name> vfkaps </name>
+<version> 2.1.1.7 </version>
+<release> 7 </release>
 <summary> Produce KAP charts from downloaded satellite images </summary>
 
 <api-version> 1.16 </api-version>
@@ -14,11 +14,11 @@
 Download and install KAP charts from VentureFarther.com
 </description>
 
-<target>raspbian-armhf</target>
-<target-version>10</target-version>
-<target-arch>armhf</target-arch>
+<target>ubuntu-x86_64</target>
+<target-version>16.04</target-version>
+<target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/vfkaps-prod/raw/names/vfkaps_pi-2.1.1.6-raspbian-armhf-10-buster-armhf-tarball/versions/v2.1.1.6/vfkaps_pi-2.1.1.6-raspbian-armhf-10-buster-armhf.tar.gz
+https://dl.cloudsmith.io/public/opencpn/vfkaps-prod/raw/names/vfkaps_pi-2.1.1.7-ubuntu-x86_64-16.04-xenial-tarball/versions/V2.1.1.7/vfkaps_pi-2.1.1.7-ubuntu-x86_64-16.04-xenial.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:charts:vfkaps </info-url>
 </plugin>

--- a/metadata/vfkaps_pi-2.1.1.7-ubuntu-x86_64-18.04-bionic-gtk3.xml
+++ b/metadata/vfkaps_pi-2.1.1.7-ubuntu-x86_64-18.04-bionic-gtk3.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
-<name> VFkaps </name>
-<version> 2.1.1.6 </version>
-<release> 6 </release>
+<name> vfkaps </name>
+<version> 2.1.1.7 </version>
+<release> 7 </release>
 <summary> Produce KAP charts from downloaded satellite images </summary>
 
 <api-version> 1.16 </api-version>
@@ -15,10 +15,10 @@ Download and install KAP charts from VentureFarther.com
 </description>
 
 <target>ubuntu-gtk3-x86_64</target>
-<target-version>20.04</target-version>
+<target-version>18.04</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/vfkaps-prod/raw/names/vfkaps_pi-2.1.1.6-ubuntu-x86_64-20.04-focal-gtk3-tarball/versions/v2.1.1.6/vfkaps_pi-2.1.1.6-ubuntu-x86_64-20.04-focal-gtk3.tar.gz
+https://dl.cloudsmith.io/public/opencpn/vfkaps-prod/raw/names/vfkaps_pi-2.1.1.7-ubuntu-x86_64-18.04-bionic-gtk3-tarball/versions/V2.1.1.7/vfkaps_pi-2.1.1.7-ubuntu-x86_64-18.04-bionic-gtk3.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:charts:vfkaps </info-url>
 </plugin>

--- a/metadata/vfkaps_pi-2.1.1.7-ubuntu-x86_64-18.04-bionic.xml
+++ b/metadata/vfkaps_pi-2.1.1.7-ubuntu-x86_64-18.04-bionic.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
-<name> VFkaps </name>
-<version> 2.1.1.6 </version>
-<release> 6 </release>
+<name> vfkaps </name>
+<version> 2.1.1.7 </version>
+<release> 7 </release>
 <summary> Produce KAP charts from downloaded satellite images </summary>
 
 <api-version> 1.16 </api-version>
@@ -14,11 +14,11 @@
 Download and install KAP charts from VentureFarther.com
 </description>
 
-<target>darwin</target>
-<target-version>10.13.6</target-version>
+<target>ubuntu-x86_64</target>
+<target-version>18.04</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/vfkaps-prod/raw/names/vfkaps_pi-2.1.1.6-darwin-x86_64-10.13.6-macos-tarball/versions/v2.1.1.6/vfkaps_pi-2.1.1.6-darwin-x86_64-10.13.6-macos.tar.gz
+https://dl.cloudsmith.io/public/opencpn/vfkaps-prod/raw/names/vfkaps_pi-2.1.1.7-ubuntu-x86_64-18.04-bionic-tarball/versions/V2.1.1.7/vfkaps_pi-2.1.1.7-ubuntu-x86_64-18.04-bionic.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:charts:vfkaps </info-url>
 </plugin>

--- a/metadata/vfkaps_pi-2.1.1.7-ubuntu-x86_64-20.04-focal-gtk3.xml
+++ b/metadata/vfkaps_pi-2.1.1.7-ubuntu-x86_64-20.04-focal-gtk3.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
-<name> VFkaps </name>
-<version> 2.1.1.6 </version>
-<release> 6 </release>
+<name> vfkaps </name>
+<version> 2.1.1.7 </version>
+<release> 7 </release>
 <summary> Produce KAP charts from downloaded satellite images </summary>
 
 <api-version> 1.16 </api-version>
@@ -14,11 +14,11 @@
 Download and install KAP charts from VentureFarther.com
 </description>
 
-<target>ubuntu-x86_64</target>
-<target-version>18.04</target-version>
+<target>ubuntu-gtk3-x86_64</target>
+<target-version>20.04</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/vfkaps-prod/raw/names/vfkaps_pi-2.1.1.6-ubuntu-x86_64-18.04-bionic-tarball/versions/v2.1.1.6/vfkaps_pi-2.1.1.6-ubuntu-x86_64-18.04-bionic.tar.gz
+https://dl.cloudsmith.io/public/opencpn/vfkaps-prod/raw/names/vfkaps_pi-2.1.1.7-ubuntu-x86_64-20.04-focal-gtk3-tarball/versions/V2.1.1.7/vfkaps_pi-2.1.1.7-ubuntu-x86_64-20.04-focal-gtk3.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:charts:vfkaps </info-url>
 </plugin>


### PR DESCRIPTION
Updated vfkaps_pi. Upper/lower case was causing issues with the managed plugin installing over a previously installed version. The case in the managed plugins list did not match the name of the installed plugin in the installed list (I think!).

Thanks again Dave.