### PR TITLE
Race Start Display

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This will create ocpn-plugins.xml in current directory. You might want to add
 Fast track: Checking URL's used in ocpn-plugins.xml
 ------------------------------------------------
 
-    > python tools/ocpn-metadata-urls [path]  path assumed is to ocpn-plugins.xml
+    > python tools/check-metadata-urls [path]  path assumed is to ocpn-plugins.xml
 	
 
 Fast track: Batch Files to use the above commands

--- a/metadata/race_start_display_pi-1.1.0.0-darwin-x86_64-10.13.6-macos.xml
+++ b/metadata/race_start_display_pi-1.1.0.0-darwin-x86_64-10.13.6-macos.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Race Start Display </name>
+<version> 1.1.0.0 </version>
+<release> 0 </release>
+<summary> Race Start Display, A simple tool for yacht racing </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/RacingPlugin </source>
+
+<description>
+Race Start Display, A simple tool for yacht racing, Displays countdown timer, distance and time to start line
+</description>
+
+<target>darwin</target>
+<target-version>10.13.6</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/racingplugin-prod/raw/names/race_start_display_pi-1.1.0.0-darwin-x86_64-10.13.6-macos-tarball/versions/v1.1/race_start_display_pi-1.1.0.0-darwin-x86_64-10.13.6-macos.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:twocan_pi </info-url>
+</plugin>

--- a/metadata/race_start_display_pi-1.1.0.0-debian-x86_64-10-buster.xml
+++ b/metadata/race_start_display_pi-1.1.0.0-debian-x86_64-10-buster.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Race Start Display </name>
+<version> 1.1.0.0 </version>
+<release> 0 </release>
+<summary> Race Start Display, A simple tool for yacht racing </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/RacingPlugin </source>
+
+<description>
+Race Start Display, A simple tool for yacht racing, Displays countdown timer, distance and time to start line
+</description>
+
+<target>debian-x86_64</target>
+<target-version>10</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/racingplugin-prod/raw/names/race_start_display_pi-1.1.0.0-debian-x86_64-10-buster-tarball/versions/v1.1/race_start_display_pi-1.1.0.0-debian-x86_64-10-buster.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:twocan_pi </info-url>
+</plugin>

--- a/metadata/race_start_display_pi-1.1.0.0-flatpak-x86_64-18.08-flatpak.xml
+++ b/metadata/race_start_display_pi-1.1.0.0-flatpak-x86_64-18.08-flatpak.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Race Start Display </name>
+<version> 1.1.0.0 </version>
+<release> 0 </release>
+<summary> Race Start Display, A simple tool for yacht racing </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/RacingPlugin </source>
+
+<description>
+Race Start Display, A simple tool for yacht racing, Displays countdown timer, distance and time to start line
+</description>
+
+<target>flatpak-x86_64</target>
+<target-version>18.08</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/racingplugin-prod/raw/names/race_start_display_pi-1.1.0.0-flatpak-x86_64-18.08-flatpak-tarball/versions/v1.1/race_start_display_pi-1.1.0.0-x86_64_flatpak-18.08.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:twocan_pi </info-url>
+</plugin>

--- a/metadata/race_start_display_pi-1.1.0.0-mingw-x86_64-10-mingw.xml
+++ b/metadata/race_start_display_pi-1.1.0.0-mingw-x86_64-10-mingw.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Race Start Display </name>
+<version> 1.1.0.0 </version>
+<release> 0 </release>
+<summary> Race Start Display, A simple tool for yacht racing </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/RacingPlugin </source>
+
+<description>
+Race Start Display, A simple tool for yacht racing, Displays countdown timer, distance and time to start line
+</description>
+
+<target>mingw</target>
+<target-version>10</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/racingplugin-prod/raw/names/race_start_display_pi-1.1.0.0-mingw-x86_64-10-mingw-tarball/versions/v1.1/race_start_display_pi-1.1.0.0-mingw-x86_64-10-mingw.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:twocan_pi </info-url>
+</plugin>

--- a/metadata/race_start_display_pi-1.1.0.0-msvc-x86_64-10.0.14393-MSVC.xml
+++ b/metadata/race_start_display_pi-1.1.0.0-msvc-x86_64-10.0.14393-MSVC.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Race Start Display </name>
+<version> 1.1.0.0 </version>
+<release> 0 </release>
+<summary> Race Start Display, A simple tool for yacht racing </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/RacingPlugin </source>
+
+<description>
+Race Start Display, A simple tool for yacht racing, Displays countdown timer, distance and time to start line
+</description>
+
+<target>msvc</target>
+<target-version>10.0.14393</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/racingplugin-prod/raw/names/race_start_display_pi-1.1.0.0-msvc-x86_64-10.0.14393-MSVC-tarball/versions/v1.1/race_start_display_pi-1.1.0.0-msvc-x86_64-10.0.14393-MSVC.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:twocan_pi </info-url>
+</plugin>

--- a/metadata/race_start_display_pi-1.1.0.0-raspbian-armhf-10-buster-armhf.xml
+++ b/metadata/race_start_display_pi-1.1.0.0-raspbian-armhf-10-buster-armhf.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Race Start Display </name>
+<version> 1.1.0.0 </version>
+<release> 0 </release>
+<summary> Race Start Display, A simple tool for yacht racing </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/RacingPlugin </source>
+
+<description>
+Race Start Display, A simple tool for yacht racing, Displays countdown timer, distance and time to start line
+</description>
+
+<target>raspbian-armhf</target>
+<target-version>10</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/racingplugin-prod/raw/names/race_start_display_pi-1.1.0.0-raspbian-armhf-10-buster-armhf-tarball/versions/v1.1/race_start_display_pi-1.1.0.0-raspbian-armhf-10-buster-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:twocan_pi </info-url>
+</plugin>

--- a/metadata/race_start_display_pi-1.1.0.0-raspbian-armhf-9.4-stretch-armhf.xml
+++ b/metadata/race_start_display_pi-1.1.0.0-raspbian-armhf-9.4-stretch-armhf.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Race Start Display </name>
+<version> 1.1.0.0 </version>
+<release> 0 </release>
+<summary> Race Start Display, A simple tool for yacht racing </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/RacingPlugin </source>
+
+<description>
+Race Start Display, A simple tool for yacht racing, Displays countdown timer, distance and time to start line
+</description>
+
+<target>raspbian-armhf</target>
+<target-version>9.4</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/racingplugin-prod/raw/names/race_start_display_pi-1.1.0.0-raspbian-armhf-9.4-stretch-armhf-tarball/versions/v1.1/race_start_display_pi-1.1.0.0-raspbian-armhf-9.4-stretch-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:twocan_pi </info-url>
+</plugin>

--- a/metadata/race_start_display_pi-1.1.0.0-ubuntu-arm64-18.04-bionic-armh64.xml
+++ b/metadata/race_start_display_pi-1.1.0.0-ubuntu-arm64-18.04-bionic-armh64.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Race Start Display </name>
+<version> 1.1.0.0 </version>
+<release> 0 </release>
+<summary> Race Start Display, A simple tool for yacht racing </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/RacingPlugin </source>
+
+<description>
+Race Start Display, A simple tool for yacht racing, Displays countdown timer, distance and time to start line
+</description>
+
+<target>ubuntu-arm64</target>
+<target-version>18.04</target-version>
+<target-arch>arm64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/racingplugin-prod/raw/names/race_start_display_pi-1.1.0.0-ubuntu-arm64-18.04-bionic-armh64-tarball/versions/v1.1/race_start_display_pi-1.1.0.0-ubuntu-arm64-18.04-bionic-armh64.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:twocan_pi </info-url>
+</plugin>

--- a/metadata/race_start_display_pi-1.1.0.0-ubuntu-x86_64-14.04-trusty.xml
+++ b/metadata/race_start_display_pi-1.1.0.0-ubuntu-x86_64-14.04-trusty.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Race Start Display </name>
+<version> 1.1.0.0 </version>
+<release> 0 </release>
+<summary> Race Start Display, A simple tool for yacht racing </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/RacingPlugin </source>
+
+<description>
+Race Start Display, A simple tool for yacht racing, Displays countdown timer, distance and time to start line
+</description>
+
+<target>ubuntu-x86_64</target>
+<target-version>14.04</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/racingplugin-prod/raw/names/race_start_display_pi-1.1.0.0-ubuntu-x86_64-14.04-trusty-tarball/versions/v1.1/race_start_display_pi-1.1.0.0-ubuntu-x86_64-14.04-trusty.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:twocan_pi </info-url>
+</plugin>

--- a/metadata/race_start_display_pi-1.1.0.0-ubuntu-x86_64-16.04-xenial.xml
+++ b/metadata/race_start_display_pi-1.1.0.0-ubuntu-x86_64-16.04-xenial.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Race Start Display </name>
+<version> 1.1.0.0 </version>
+<release> 0 </release>
+<summary> Race Start Display, A simple tool for yacht racing </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/RacingPlugin </source>
+
+<description>
+Race Start Display, A simple tool for yacht racing, Displays countdown timer, distance and time to start line
+</description>
+
+<target>ubuntu-x86_64</target>
+<target-version>16.04</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/racingplugin-prod/raw/names/race_start_display_pi-1.1.0.0-ubuntu-x86_64-16.04-xenial-tarball/versions/v1.1/race_start_display_pi-1.1.0.0-ubuntu-x86_64-16.04-xenial.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:twocan_pi </info-url>
+</plugin>

--- a/metadata/race_start_display_pi-1.1.0.0-ubuntu-x86_64-18.04-bionic-gtk3.xml
+++ b/metadata/race_start_display_pi-1.1.0.0-ubuntu-x86_64-18.04-bionic-gtk3.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Race Start Display </name>
+<version> 1.1.0.0 </version>
+<release> 0 </release>
+<summary> Race Start Display, A simple tool for yacht racing </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/RacingPlugin </source>
+
+<description>
+Race Start Display, A simple tool for yacht racing, Displays countdown timer, distance and time to start line
+</description>
+
+<target>ubuntu-gtk3-x86_64</target>
+<target-version>18.04</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/racingplugin-prod/raw/names/race_start_display_pi-1.1.0.0-ubuntu-x86_64-18.04-bionic-gtk3-tarball/versions/v1.1/race_start_display_pi-1.1.0.0-ubuntu-x86_64-18.04-bionic-gtk3.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:twocan_pi </info-url>
+</plugin>

--- a/metadata/race_start_display_pi-1.1.0.0-ubuntu-x86_64-18.04-bionic.xml
+++ b/metadata/race_start_display_pi-1.1.0.0-ubuntu-x86_64-18.04-bionic.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Race Start Display </name>
+<version> 1.1.0.0 </version>
+<release> 0 </release>
+<summary> Race Start Display, A simple tool for yacht racing </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/RacingPlugin </source>
+
+<description>
+Race Start Display, A simple tool for yacht racing, Displays countdown timer, distance and time to start line
+</description>
+
+<target>ubuntu-x86_64</target>
+<target-version>18.04</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/racingplugin-prod/raw/names/race_start_display_pi-1.1.0.0-ubuntu-x86_64-18.04-bionic-tarball/versions/v1.1/race_start_display_pi-1.1.0.0-ubuntu-x86_64-18.04-bionic.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:twocan_pi </info-url>
+</plugin>

--- a/metadata/race_start_display_pi-1.1.0.0-ubuntu-x86_64-20.04-focal-gtk3.xml
+++ b/metadata/race_start_display_pi-1.1.0.0-ubuntu-x86_64-20.04-focal-gtk3.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Race Start Display </name>
+<version> 1.1.0.0 </version>
+<release> 0 </release>
+<summary> Race Start Display, A simple tool for yacht racing </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/RacingPlugin </source>
+
+<description>
+Race Start Display, A simple tool for yacht racing, Displays countdown timer, distance and time to start line
+</description>
+
+<target>ubuntu-gtk3-x86_64</target>
+<target-version>20.04</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/racingplugin-prod/raw/names/race_start_display_pi-1.1.0.0-ubuntu-x86_64-20.04-focal-gtk3-tarball/versions/v1.1/race_start_display_pi-1.1.0.0-ubuntu-x86_64-20.04-focal-gtk3.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:twocan_pi </info-url>
+</plugin>


### PR DESCRIPTION
Race Start Display plugin ported to new Plugin Manager model. Builds successfully compiled by Continuous Integration systems (CircleCI, Travis &  Appveyor) and resulting metadata, packages and tarballs uploaded to Cloudsmith. Metadata files successfully checked with xmllint, validate_xml.sh and check-metadata-urls scripts.