### PR TITLE
dashboardtactics 1.6.6.0 + fe2 v1.0.132

### DIFF
--- a/metadata/dashboardtactics_pi-1.6.6.0-darwin-x86_64-10.13.6-macos.xml
+++ b/metadata/dashboardtactics_pi-1.6.6.0-darwin-x86_64-10.13.6-macos.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> DashboardTactics </name>
-<version> 1.6.3.0 </version>
+<version> 1.6.6.0 </version>
 <release> 0 </release>
 <summary> Dashboard and Tactics </summary>
 
 <api-version> 1.16 </api-version>
 <open-source> yes </open-source>
-<author> TBD </author>
+<author> Rick Gleason </author>
 <source> https://github.com/rgleason/dashboard_tactics_pi </source>
 
 <description>
 Dashboard PlugIn with Tactics for OpenCPN Provides navigation instruments enhanced with performance functions and alternative input/output functions.
 </description>
 
-<target>raspbian-armhf</target>
-<target-version>9.4</target-version>
-<target-arch>armhf</target-arch>
+<target>darwin</target>
+<target-version>10.13.6</target-version>
+<target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboardtactics_pi-1.6.3.0-raspbian-armhf-9.4-stretch-armhf-tarball/versions/v1.6.3.0/dashboardtactics_pi-1.6.3.0-raspbian-armhf-9.4-stretch-armhf.tar.gz
+https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboardtactics_pi-1.6.6.0-darwin-x86_64-10.13.6-macos-tarball/versions/v1.6.6.0/dashboardtactics_pi-1.6.6.0-darwin-x86_64-10.13.6-macos.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/dashboardtactics.html </info-url>
 </plugin>

--- a/metadata/dashboardtactics_pi-1.6.6.0-debian-x86_64-10-buster.xml
+++ b/metadata/dashboardtactics_pi-1.6.6.0-debian-x86_64-10-buster.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> DashboardTactics </name>
-<version> 1.6.3.0 </version>
+<version> 1.6.6.0 </version>
 <release> 0 </release>
 <summary> Dashboard and Tactics </summary>
 
 <api-version> 1.16 </api-version>
 <open-source> yes </open-source>
-<author> TBD </author>
+<author> Rick Gleason </author>
 <source> https://github.com/rgleason/dashboard_tactics_pi </source>
 
 <description>
 Dashboard PlugIn with Tactics for OpenCPN Provides navigation instruments enhanced with performance functions and alternative input/output functions.
 </description>
 
-<target>darwin</target>
-<target-version>10.13.6</target-version>
+<target>debian-x86_64</target>
+<target-version>10</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboardtactics_pi-1.6.3.0-darwin-x86_64-10.13.6-macos-tarball/versions/v1.6.3.0/dashboardtactics_pi-1.6.3.0-darwin-x86_64-10.13.6-macos.tar.gz
+https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboardtactics_pi-1.6.6.0-debian-x86_64-10-buster-tarball/versions/v1.6.6.0/dashboardtactics_pi-1.6.6.0-debian-x86_64-10-buster.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/dashboardtactics.html </info-url>
 </plugin>

--- a/metadata/dashboardtactics_pi-1.6.6.0-flatpak-x86_64-18.08-flatpak.xml
+++ b/metadata/dashboardtactics_pi-1.6.6.0-flatpak-x86_64-18.08-flatpak.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> DashboardTactics </name>
-<version> 1.6.3.0 </version>
+<version> 1.6.6.0 </version>
 <release> 0 </release>
 <summary> Dashboard and Tactics </summary>
 
 <api-version> 1.16 </api-version>
 <open-source> yes </open-source>
-<author> TBD </author>
+<author> Rick Gleason </author>
 <source> https://github.com/rgleason/dashboard_tactics_pi </source>
 
 <description>
 Dashboard PlugIn with Tactics for OpenCPN Provides navigation instruments enhanced with performance functions and alternative input/output functions.
 </description>
 
-<target>raspbian-armhf</target>
-<target-version>10</target-version>
-<target-arch>armhf</target-arch>
+<target>flatpak-x86_64</target>
+<target-version>18.08</target-version>
+<target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboardtactics_pi-1.6.3.0-raspbian-armhf-10-buster-armhf-tarball/versions/v1.6.3.0/dashboardtactics_pi-1.6.3.0-raspbian-armhf-10-buster-armhf.tar.gz
+https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboardtactics_pi-1.6.6.0-flatpak-x86_64-18.08-flatpak-tarball/versions/v1.6.6.0/dashboardtactics_pi-1.6.6.0-x86_64_flatpak-18.08.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/dashboardtactics.html </info-url>
 </plugin>

--- a/metadata/dashboardtactics_pi-1.6.6.0-msvc-x86_64-10.0.14393-MSVC.xml
+++ b/metadata/dashboardtactics_pi-1.6.6.0-msvc-x86_64-10.0.14393-MSVC.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> DashboardTactics </name>
-<version> 1.6.3.0 </version>
+<version> 1.6.6.0 </version>
 <release> 0 </release>
 <summary> Dashboard and Tactics </summary>
 
 <api-version> 1.16 </api-version>
 <open-source> yes </open-source>
-<author> TBD </author>
+<author> Rick Gleason </author>
 <source> https://github.com/rgleason/dashboard_tactics_pi </source>
 
 <description>
 Dashboard PlugIn with Tactics for OpenCPN Provides navigation instruments enhanced with performance functions and alternative input/output functions.
 </description>
 
-<target>ubuntu-gtk3-x86_64</target>
-<target-version>18.04</target-version>
+<target>msvc</target>
+<target-version>10.0.14393</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboardtactics_pi-1.6.3.0-ubuntu-x86_64-18.04-bionic-gtk3-tarball/versions/v1.6.3.0/dashboardtactics_pi-1.6.3.0-ubuntu-x86_64-18.04-bionic-gtk3.tar.gz
+https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboardtactics_pi-1.6.6.0-msvc-x86_64-10.0.14393-MSVC-tarball/versions/v1.6.6.0/dashboardtactics_pi-1.6.6.0-msvc-x86_64-10.0.14393-MSVC.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/dashboardtactics.html </info-url>
 </plugin>

--- a/metadata/dashboardtactics_pi-1.6.6.0-raspbian-armhf-10-buster-armhf.xml
+++ b/metadata/dashboardtactics_pi-1.6.6.0-raspbian-armhf-10-buster-armhf.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> DashboardTactics </name>
-<version> 1.6.3.0 </version>
+<version> 1.6.6.0 </version>
 <release> 0 </release>
 <summary> Dashboard and Tactics </summary>
 
 <api-version> 1.16 </api-version>
 <open-source> yes </open-source>
-<author> TBD </author>
+<author> Rick Gleason </author>
 <source> https://github.com/rgleason/dashboard_tactics_pi </source>
 
 <description>
 Dashboard PlugIn with Tactics for OpenCPN Provides navigation instruments enhanced with performance functions and alternative input/output functions.
 </description>
 
-<target>msvc</target>
-<target-version>10.0.14393</target-version>
-<target-arch>x86_64</target-arch>
+<target>raspbian-armhf</target>
+<target-version>10</target-version>
+<target-arch>armhf</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboardtactics_pi-1.6.3.0-msvc-x86_64-10.0.14393-MSVC-tarball/versions/v1.6.3.0/dashboardtactics_pi-1.6.3.0-msvc-x86_64-10.0.14393-MSVC.tar.gz
+https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboardtactics_pi-1.6.6.0-raspbian-armhf-10-buster-armhf-tarball/versions/v1.6.6.0/dashboardtactics_pi-1.6.6.0-raspbian-armhf-10-buster-armhf.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/dashboardtactics.html </info-url>
 </plugin>

--- a/metadata/dashboardtactics_pi-1.6.6.0-raspbian-armhf-9.4-stretch-armhf.xml
+++ b/metadata/dashboardtactics_pi-1.6.6.0-raspbian-armhf-9.4-stretch-armhf.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> DashboardTactics </name>
-<version> 1.6.3.0 </version>
+<version> 1.6.6.0 </version>
 <release> 0 </release>
 <summary> Dashboard and Tactics </summary>
 
 <api-version> 1.16 </api-version>
 <open-source> yes </open-source>
-<author> TBD </author>
+<author> Rick Gleason </author>
 <source> https://github.com/rgleason/dashboard_tactics_pi </source>
 
 <description>
 Dashboard PlugIn with Tactics for OpenCPN Provides navigation instruments enhanced with performance functions and alternative input/output functions.
 </description>
 
-<target>ubuntu-x86_64</target>
-<target-version>16.04</target-version>
-<target-arch>x86_64</target-arch>
+<target>raspbian-armhf</target>
+<target-version>9.4</target-version>
+<target-arch>armhf</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboardtactics_pi-1.6.3.0-ubuntu-x86_64-16.04-xenial-tarball/versions/v1.6.3.0/dashboardtactics_pi-1.6.3.0-ubuntu-x86_64-16.04-xenial.tar.gz
+https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboardtactics_pi-1.6.6.0-raspbian-armhf-9.4-stretch-armhf-tarball/versions/v1.6.6.0/dashboardtactics_pi-1.6.6.0-raspbian-armhf-9.4-stretch-armhf.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/dashboardtactics.html </info-url>
 </plugin>

--- a/metadata/dashboardtactics_pi-1.6.6.0-ubuntu-x86_64-16.04-xenial.xml
+++ b/metadata/dashboardtactics_pi-1.6.6.0-ubuntu-x86_64-16.04-xenial.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> DashboardTactics </name>
-<version> 1.6.3.0 </version>
+<version> 1.6.6.0 </version>
 <release> 0 </release>
 <summary> Dashboard and Tactics </summary>
 
 <api-version> 1.16 </api-version>
 <open-source> yes </open-source>
-<author> TBD </author>
+<author> Rick Gleason </author>
 <source> https://github.com/rgleason/dashboard_tactics_pi </source>
 
 <description>
 Dashboard PlugIn with Tactics for OpenCPN Provides navigation instruments enhanced with performance functions and alternative input/output functions.
 </description>
 
-<target>ubuntu-gtk3-x86_64</target>
-<target-version>20.04</target-version>
+<target>ubuntu-x86_64</target>
+<target-version>16.04</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboardtactics_pi-1.6.3.0-ubuntu-x86_64-20.04-focal-gtk3-tarball/versions/v1.6.3.0/dashboardtactics_pi-1.6.3.0-ubuntu-x86_64-20.04-focal-gtk3.tar.gz
+https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboardtactics_pi-1.6.6.0-ubuntu-x86_64-16.04-xenial-tarball/versions/v1.6.6.0/dashboardtactics_pi-1.6.6.0-ubuntu-x86_64-16.04-xenial.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/dashboardtactics.html </info-url>
 </plugin>

--- a/metadata/dashboardtactics_pi-1.6.6.0-ubuntu-x86_64-18.04-bionic-gtk3.xml
+++ b/metadata/dashboardtactics_pi-1.6.6.0-ubuntu-x86_64-18.04-bionic-gtk3.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> DashboardTactics </name>
-<version> 1.6.3.0 </version>
+<version> 1.6.6.0 </version>
 <release> 0 </release>
 <summary> Dashboard and Tactics </summary>
 
 <api-version> 1.16 </api-version>
 <open-source> yes </open-source>
-<author> TBD </author>
+<author> Rick Gleason </author>
 <source> https://github.com/rgleason/dashboard_tactics_pi </source>
 
 <description>
 Dashboard PlugIn with Tactics for OpenCPN Provides navigation instruments enhanced with performance functions and alternative input/output functions.
 </description>
 
-<target>flatpak-x86_64</target>
-<target-version>18.08</target-version>
+<target>ubuntu-gtk3-x86_64</target>
+<target-version>18.04</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboardtactics_pi-1.6.3.0-flatpak-x86_64-18.08-flatpak-tarball/versions/v1.6.3.0/dashboardtactics_pi-1.6.3.0-x86_64_flatpak-18.08.tar.gz
+https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboardtactics_pi-1.6.6.0-ubuntu-x86_64-18.04-bionic-gtk3-tarball/versions/v1.6.6.0/dashboardtactics_pi-1.6.6.0-ubuntu-x86_64-18.04-bionic-gtk3.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/dashboardtactics.html </info-url>
 </plugin>

--- a/metadata/dashboardtactics_pi-1.6.6.0-ubuntu-x86_64-18.04-bionic.xml
+++ b/metadata/dashboardtactics_pi-1.6.6.0-ubuntu-x86_64-18.04-bionic.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> DashboardTactics </name>
-<version> 1.6.3.0 </version>
+<version> 1.6.6.0 </version>
 <release> 0 </release>
 <summary> Dashboard and Tactics </summary>
 
 <api-version> 1.16 </api-version>
 <open-source> yes </open-source>
-<author> TBD </author>
+<author> Rick Gleason </author>
 <source> https://github.com/rgleason/dashboard_tactics_pi </source>
 
 <description>
 Dashboard PlugIn with Tactics for OpenCPN Provides navigation instruments enhanced with performance functions and alternative input/output functions.
 </description>
 
-<target>debian-x86_64</target>
-<target-version>10</target-version>
+<target>ubuntu-x86_64</target>
+<target-version>18.04</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboardtactics_pi-1.6.3.0-debian-x86_64-10-buster-tarball/versions/v1.6.3.0/dashboardtactics_pi-1.6.3.0-debian-x86_64-10-buster.tar.gz
+https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboardtactics_pi-1.6.6.0-ubuntu-x86_64-18.04-bionic-tarball/versions/v1.6.6.0/dashboardtactics_pi-1.6.6.0-ubuntu-x86_64-18.04-bionic.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/dashboardtactics.html </info-url>
 </plugin>

--- a/metadata/dashboardtactics_pi-1.6.6.0-ubuntu-x86_64-20.04-focal-gtk3.xml
+++ b/metadata/dashboardtactics_pi-1.6.6.0-ubuntu-x86_64-20.04-focal-gtk3.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> DashboardTactics </name>
-<version> 1.6.3.0 </version>
+<version> 1.6.6.0 </version>
 <release> 0 </release>
 <summary> Dashboard and Tactics </summary>
 
 <api-version> 1.16 </api-version>
 <open-source> yes </open-source>
-<author> TBD </author>
+<author> Rick Gleason </author>
 <source> https://github.com/rgleason/dashboard_tactics_pi </source>
 
 <description>
 Dashboard PlugIn with Tactics for OpenCPN Provides navigation instruments enhanced with performance functions and alternative input/output functions.
 </description>
 
-<target>ubuntu-x86_64</target>
-<target-version>18.04</target-version>
+<target>ubuntu-gtk3-x86_64</target>
+<target-version>20.04</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboardtactics_pi-1.6.3.0-ubuntu-x86_64-18.04-bionic-tarball/versions/v1.6.3.0/dashboardtactics_pi-1.6.3.0-ubuntu-x86_64-18.04-bionic.tar.gz
+https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboardtactics_pi-1.6.6.0-ubuntu-x86_64-20.04-focal-gtk3-tarball/versions/v1.6.6.0/dashboardtactics_pi-1.6.6.0-ubuntu-x86_64-20.04-focal-gtk3.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/dashboardtactics.html </info-url>
 </plugin>


### PR DESCRIPTION
Missing Mingw and Trusty because they use earlier version of wxWidgets and are making errors.
If someone can give the the wx include to fix this I will rebuild and push those builds up too.