### PR TITLE
Fixes for checking single metadata files, docs (OpenCPN#2031)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,6 @@ clean:
 
 validate: ocpn-plugins.xml Makefile
 	xmllint  --schema ocpn-plugins.xsd  ocpn-plugins.xml --noout
+
+check-urls: ocpn-plugins.xml Makefile
+	python tools/check-metadata-urls ocpn-plugins.xml

--- a/README.md
+++ b/README.md
@@ -1,22 +1,43 @@
 OpenCPN plugins project README
 ===============================
 
-This project is currently in a experimental state. It is an important
-groundwork for the new plugin installer.
+This project is the underpinnings for the new plugin installer. It exports
+the fundamental piece required to install plugins using the installer:
+the plugin catalog `ocpn-plugins.xml`
 
-The project exports the fundamental piece required to install plugins using
-the new installer: the plugin catalog `ocpn-plugins.xml`
+Doing so, the project also defines the formal interface for plugin
+developers who wants their plugins to be included in the catalog.
 
-Dependencies
-------------
+The project also provides some tools and workflows to create and verify
+a new version of the catalog. These are by no means mandatory, but seems
+to be useful for many plugin developers.
 
-  - python >= 3.6    (for print f)
+Formal interface
+----------------
+
+New plugins (really new or updates) are accepted into the catalog after
+issuing a pull request (PR) against this project, a PR which updates
+files in the metadata directory.
+
+The PR could be accepted into one of three branches:
+
+  - master, used by regular users.
+  - beta, for reasonably stable test plugins.
+  - alpha, for experimental plugins.
+
+
+Tools and workflows
+-------------------
+
+### Dependencies
+
+  - python >= 3.6
   - GNU make (optional)
   - tar
-  - xmllint, sometimes found in the libxml, libxml2  or xsltproc package
+  - xmllint, sometimes found in the libxml, libxml2 or xsltproc package
 
 On Windows, first install chocolatey as described on https://chocolatey.org.
-Then install the dependencies python,  make,  git  and xsltproc using
+Then install the dependencies python, make, git and xsltproc using
 `choco install git` etc.
 
 On macos, packages are available in homebrew. Linux distros normally have these
@@ -24,58 +45,67 @@ available by default.
 
 ocpn-metadata, the most important tool, only depends on python.
 
+### Git pre-commit hook
 
-Fast track: creating a modified ocpn-plugins.xml
-------------------------------------------------
-
-Drop new or modified xml files in the metadata/ directory. Then do
-
-    > python tools/ocpn-metadata generate --userdir metadata \
-          --destfile ocpn-plugins.xml
-
-This will create ocpn-plugins.xml in current directory. You might want to add
-```--version``` to mark the generated file with a new version.
+After having dependencies installed users are strongly recommended to
+install the `pre-commit` file into `.git/hooks`. This will run a test
+on all files committed. If the test produces false negatives the
+`--no-verify` option can be used to commit even if the hook cannot complete
+successfully. Running the tests locally avoids broken committs from the very
+beginning, avoiding all sorts of troubles.
 
 
-Fast track: Checking URL's used in ocpn-plugins.xml
-------------------------------------------------
+### Windows tools
 
-    > python tools/check-metadata-urls [path]  path assumed is to ocpn-plugins.xml
-	
-
-Fast track: Batch Files to use the above commands
-------------------------------------------------
+Windows users have two support scripts which checks the urls:
 
     > check.bat   - to be run from the "plugins" directory
 
     > runcheck.bat   - to be run from the "tools" directory
 
 
-Download cloudsmith files
--------------------------
+### Checking all XML files for validity against XSD
 
-Having generated the installation files they are stored in a cloudsmith repository. These need
-to be download and made into a pull request for the plugins repository. This can be done using
-the 'download_xml_bash.sh' script. This script will run on Linux and Windows using the 'git_bash'
-command.
+Check that all files about to be pushed to upstream repository (main
+repository) will pass validation checks
+
+	$ ./validate_xml.sh plugin_name plugin_version
+
+i.e.
+        ./validate_xml.sh testplugin_pi 1.0.120.0
+
+This will show all good xml files and identify any that do not meet the
+XSD. If in doubt make sure you have the latest version of the plugins master,
+Alpha, Beta or Experimental branch that you are working with. Occasionally
+there are changes to the XSD. The same script will be run when you generate
+a Pull request and if the Pull fails this test it will not be merged.
+
+
+### The frontend2 workflow
+
+Many plugins currently uses the frontend2 workflow. It is based on plugins
+uploading metadata for each build to cloudsmith repositories. The workflow
+downloads these plugins and creates a git pull request based on the update.
+
+The basic tool is the 'download_xml_bash.sh' script. This script will run
+on Linux and also on Windows using the 'git bash' environment.
 	
-	> ./download_xml_bash.sh cloudsmith_repository plugin_version cloudsmith_user cloudsmith_level
-	i.e. 
-		./download_xml_bash.sh testplugin_pi 1.0.114.0 jon-gough prod
-		./download_xml_bash.sh weather-routing 1.13.8.0 opencpn prod
+	> ./download_xml_bash.sh cloudsmith_repository \
+                plugin_version cloudsmith_user cloudsmith_level
+e. g.,
 
-These files can then be added to the push request in git. 
+	./download_xml_bash.sh testplugin_pi 1.0.114.0 jon-gough prod
+	./download_xml_bash.sh weather-routing 1.13.8.0 opencpn prod
 
-With the new process do NOT generate the ocpn-plugins.xml file as this will be done for you
-automatically when your push is merged into the mainline.
+These files can then be added to the push request in git.
+
+With the new process do NOT generate the ocpn-plugins.xml file as this will be
+done automatically when the push is merged into the mainline.
 
 
 Developer info
 --------------
 
-The developer workflow includes generating new plugins, checking tarball
-xml data, testing  and creating a new ocpn-plugins.xml. This is described
-in TESTING.md.
-
-
-[1] https://github.com/OpenCPN/OpenCPN/pull/1457
+The developer workflow includes expanded info on generating new plugins,
+checking tarball xml data, testing and creating a new ocpn-plugins.xml.
+This is described in TESTING.md.

--- a/TESTING.md
+++ b/TESTING.md
@@ -27,15 +27,8 @@ that the directory tree layout matches the specs in the
 Local installation
 ------------------
 
-The new tarball can be installed directly using the  _ocpn-install.sh_.
-For example:
-
-    $ tools/ocpn-install.sh \
-         /path/to/plugin/build/oesenc-pi-1.2.0-3-flatpak-18.08.tar.gz
-
-The installed tarball can be uninstalled using the plugin manager or
-using _tools/ocpn-uninstall_.
-
+The new tarball can be installed  directly using the Import Plugin
+in the plugins tab in OpenCPN
 
 
 Checking xml file basic syntax
@@ -43,8 +36,8 @@ Checking xml file basic syntax
 
 Check that the new xml file is well-formed XML using
 
-    $ xmllint path/to/plugin/build/oesenc-plugin-flatpak-18.08.xml
-
+    $ xmllint --schema ocpn-plugin.xsd \
+         path/to/plugin/build/oesenc-plugin-flatpak-18.08.xml
 
 
 Checking urls in the xml file
@@ -55,35 +48,18 @@ web. The xml metadata file contains an url to this tarball location.
 
 Check that all urls in the xml file are sane:
 
-    $ tools/check-metadata-urls  \
+    $ python tools/check-metadata-urls  \
          /path/to/plugin/build/oesenc-plugin-flatpak-18.08.xml
-
-
-Checking all XML files for validity against XSD
------------------------------------
-
-Check that all files about to be pushed to upstream repository (main repository) will pass validation checks
-
-	$ ./validate_xml.sh plugin_name plugin_version
-	i.e. ./validate_xml.sh testplugin_pi 1.0.120.0
-
-This will show all good xml files and identify any that do not meet the XSD. If in doubt make sure you have the latest
-version of the plugins master, Alpha, Beta or Experimental branch that you are working with. Occasionally there are
-changes to the XSD. The same script will be run when you generate a Pull request and if the Pull fails this test 
-it will not be merged.
 
 
 Create a new ocpn-plugins.xml
 ------------------------------
-This process is only needed if you really want to have the ocpn-plugins.xml file. In the current version of OCPN
-this is not needed as there is a button on the plugins page of the OCPN options that will let you directly
-import the '*tar.gz' file. This is much easer and cleaner than createing ocpn-pluginxs.xml file.
+This process is only required if a new ocpn-plugins.xml is needed.
+The current OpenCPN version supports importing a tarball directly using
+the Import Plugin button, which usually is sufficient to test a plugin.
 
-Any time you push your xml files to the plugins repository and they are accepted the ocpn-plugins.xml file is 
-updated on the git repository as part of the merge process.
-
-To create a new, modified ocpn-plugins.xml first create a private set
-of xml source files,
+Should a new, modified ocpn-plugins.xml be required anyway first create a
+private set of xml source files:
 
     $ python tools/ocpn-metadata copy
     New xml sources copied to /home/al/.opencpn/plugins-metadata
@@ -102,16 +78,17 @@ and rebuild ocpn-plugins.xml:
 Check xml syntax:
 -----------------
 
-Check the generated file for syntax errors:
+Check the generated file for syntax errors
 
     $ xmllint --schema ocpn-plugins.xsd  ~/.opencpn/ocpn-plugins.xml --noout
-
 
 
 Test the new catalog:
 ---------------------
 
 Done like in _Create a new ocpn-plugins.xml_, the generated ocpn-plugins.xml
+will be used when copied to the _User config path_ as described in the
+[wiki](https://github.com/leamas/OpenCPN/wiki/Terminology).  The new catalog
 will be used when opencpn is started as long as the plugin catalog isn't updated.
 
 The catalog can also be uploaded on the web and used as _Custom URL_ in the

--- a/ocpn-plugin.xsd
+++ b/ocpn-plugin.xsd
@@ -27,6 +27,9 @@
   </xs:complexType>
 </xs:element>
 
+<!-- Metadata files uses opencpn-plugin, ocpn-plugins.xml uses plugin. -->
+<xs:element name="opencpn-plugin" substitutionGroup="plugin"/>
+
 <xs:element name="summary">
   <xs:simpleType>
     <xs:restriction base="xs:token">

--- a/ocpn-plugin.xsd
+++ b/ocpn-plugin.xsd
@@ -45,6 +45,7 @@
       <xs:enumeration value = "x86_64"/>
       <xs:enumeration value = "armhf"/>
       <xs:enumeration value = "arm64"/>
+      <xs:enumeration value = "noarch"/>
     </xs:restriction>
   </xs:simpleType>
 </xs:element> 
@@ -52,6 +53,7 @@
 <xs:element name="target">
   <xs:simpleType>
     <xs:restriction base = "xs:string">
+      <xs:enumeration value = "all"/>
       <xs:enumeration value = "darwin"/>
       <xs:enumeration value = "debian-armhf"/>
       <xs:enumeration value = "debian-x86_64"/>

--- a/ocpn-plugin.xsd
+++ b/ocpn-plugin.xsd
@@ -39,7 +39,6 @@
 <xs:element name="target-arch">
   <xs:simpleType>
     <xs:restriction base = "xs:string">
-      <xs:enumeration value = "i386"/>
       <xs:enumeration value = "x86_64"/>
       <xs:enumeration value = "armhf"/>
       <xs:enumeration value = "arm64"/>
@@ -53,7 +52,6 @@
       <xs:enumeration value = "darwin"/>
       <xs:enumeration value = "debian-armhf"/>
       <xs:enumeration value = "debian-x86_64"/>
-      <xs:enumeration value = "flatpak"/>
       <xs:enumeration value = "flatpak-x86_64"/>
       <xs:enumeration value = "mingw"/>
       <xs:enumeration value = "msvc"/>

--- a/pre-commit
+++ b/pre-commit
@@ -9,13 +9,14 @@ function files_to_update()
 {
     git diff --cached --name-status | grep -v ^D | awk '$1 $2 { print $2}'
 }
-
 topdir=$( git rev-parse --show-toplevel )
+here=$(dirname $0)
 
 XML_SOURCES=( $( files_to_update | grep -E '\.xml$'))
 
 if [ -n "$XML_SOURCES" ]; then
-  xmllint --schema $topdir/ocpn-plugins.xsd  $XML_SOURCES --noout || exit 1
+  xmllint --schema $topdir/ocpn-plugin.xsd  $XML_SOURCES --noout || exit 1
+  python $here/../../tools/check-metadata-urls $XML_SOURCES  || exit 1
 fi
 
 # If there are whitespace errors, print the offending file names and fail.

--- a/tools/check-metadata-urls
+++ b/tools/check-metadata-urls
@@ -17,6 +17,7 @@ Arguments:
 
 import http.client as httplib
 import xml.etree.ElementTree as ET
+import socket
 import sys
 
 from http.client import HTTPException
@@ -43,7 +44,7 @@ def get_status_code(urlstring):
             conn = httplib.HTTPConnection(url.hostname)
         conn.request("HEAD", url.path, None, headers)
         return conn.getresponse().status
-    except HTTPException:
+    except (HTTPException, socket.gaierror):
         return None
 
 
@@ -78,6 +79,8 @@ def main():
     tree = ET.parse(path)
     urls = tree.findall('*/info-url')
     urls.extend(tree.findall('*/tarball-url'))
+    urls.extend(tree.findall('info-url'))
+    urls.extend(tree.findall('tarball-url'))
     bad_urls = check_urls(urls)
     print("\n%d urls checked, %d errors" % (len(urls), len(bad_urls)))
     for url in bad_urls:

--- a/tools/ocpn-metadata
+++ b/tools/ocpn-metadata
@@ -87,7 +87,12 @@ def generate(sourcedir, destfile, version):
     date_elem = ET.SubElement(tree, "date")
     date_elem.text = datetime.datetime.now().strftime('%Y-%m-%d %H:%M')
     for path in Path(sourcedir).glob("*.xml"):
-        subtree = ET.parse(str(path))
+        try:
+            subtree = ET.parse(str(path))
+        except ET.ParseError as ex:
+            print("Error processing %s at line %d" % (path, ex.position[0]))
+            print("Aborted")
+            sys.exit(1)
         subtree.getroot().tag = 'plugin'
         tree.append(subtree.getroot())
     dom = minidom.parseString(ET.tostring(tree))

--- a/tools/ocpn-metadata
+++ b/tools/ocpn-metadata
@@ -87,7 +87,6 @@ def generate(sourcedir, destfile, version):
     date_elem = ET.SubElement(tree, "date")
     date_elem.text = datetime.datetime.now().strftime('%Y-%m-%d %H:%M')
     for path in Path(sourcedir).glob("*.xml"):
-        print(" Processing: {path}")
         subtree = ET.parse(str(path))
         subtree.getroot().tag = 'plugin'
         tree.append(subtree.getroot())

--- a/tools/ocpn-metadata
+++ b/tools/ocpn-metadata
@@ -13,6 +13,10 @@ import xml.dom.minidom as minidom
 from sys import platform
 from pathlib import Path
 
+def errprint(*args):
+    """ Print to stderr shorthand. """
+    sys.stderr.write(' '.join(map(str,args)) + '\n')
+
 
 def get_paths():
     """Return dict of platform-dependent default paths."""
@@ -90,8 +94,8 @@ def generate(sourcedir, destfile, version):
         try:
             subtree = ET.parse(str(path))
         except ET.ParseError as ex:
-            print("Error processing %s at line %d" % (path, ex.position[0]))
-            print("Aborted")
+            errprint("Error processing %s at line %d" % (path, ex.position[0]))
+            errprint("Aborted")
             sys.exit(1)
         subtree.getroot().tag = 'plugin'
         tree.append(subtree.getroot())
@@ -108,31 +112,31 @@ def main():
     paths = get_paths()
     args = get_args(paths)
     if not args.mode:
-        print("Error: no mode specified. Use -h for help.")
+        errprint("Error: no mode specified. Use -h for help.")
         sys.exit(1)
     if args.mode == "copy":
         if not os.path.exists(args.systemdir):
-            print("Cannot find system metadata directory " + args.systemdir)
-            print("Consider using --systemdir option.")
+            errprint("Cannot find system metadata directory " + args.systemdir)
+            errprint("Consider using --systemdir option.")
             sys.exit(1)
         if os.path.exists(args.destdir) and args.force:
             shutil.rmtree(args.destdir)
         if os.path.exists(args.destdir):
-            print("The directory %s is in the way" % args.destdir)
-            print("Please remove or use --force")
+            errprint("The directory %s is in the way" % args.destdir)
+            errprint("Please remove or use --force")
             sys.exit(1)
         shutil.copytree(args.systemdir, args.destdir)
         print("New xml sources copied to " + args.destdir)
     else:
         if not os.path.exists(args.userdir):
-            print("No private sources found. Did you forget to run copy first?")
-            print("Otherwise consider using --userdir.")
+            errprint("No private sources found. Did you forget to run copy first?")
+            errprint("Otherwise consider using --userdir.")
             sys.exit(1)
         if os.path.exists(args.destfile) and args.force:
             os.remove(args.destfile)
         if os.path.exists(args.destfile):
-            print("The file %s is in the way" % args.destfile)
-            print("Please remove or use --force")
+            errprint("The file %s is in the way" % args.destfile)
+            errprint("Please remove or use --force")
             sys.exit(1)
         generate(args.userdir, args.destfile, args.version)
         print("Generated new ocpn-plugins.xml at " + args.destfile)

--- a/tools/ocpn-metadata
+++ b/tools/ocpn-metadata
@@ -95,8 +95,8 @@ def generate(sourcedir, destfile, version):
             subtree = ET.parse(str(path))
         except ET.ParseError as ex:
             errprint("Error processing %s at line %d" % (path, ex.position[0]))
-            errprint("Aborted")
-            sys.exit(1)
+            errprint("Skipping file")
+            continue
         subtree.getroot().tag = 'plugin'
         tree.append(subtree.getroot())
     dom = minidom.parseString(ET.tostring(tree))


### PR DESCRIPTION
EDIT: Updated the PR which now 
  - Removes illegal archs  and targets (https://github.com/OpenCPN/OpenCPN/issues/2003)
  - Fixes for check-metadata-urls to accept a single metadata file.
  - Fixes for pre-commit to also check urls.
  - Add a check-urls Makefile convenience target.
  - Documentation updates, partly after discussions in https://github.com/OpenCPN/OpenCPN/issues/2031. This PR should close that discussion.
EDIT2: 
  - Improves parsing  error messages from ocpn-metadata
EDIT3:
  - Fix for xsd schema so it can be used to validate a single plugin metadata file.
EDIT4:
  - Add xsd support for data-only plugins for all targets.
  - Let ocpn-metadata keep going on parse errors.