### PR TITLE
Fix bad mingw target value (OpenCPN#2061).

### DIFF
--- a/ocpn-plugin.xsd
+++ b/ocpn-plugin.xsd
@@ -58,7 +58,8 @@
       <xs:enumeration value = "debian-armhf"/>
       <xs:enumeration value = "debian-x86_64"/>
       <xs:enumeration value = "flatpak-x86_64"/>
-      <xs:enumeration value = "mingw"/>
+      <xs:enumeration value = "mingw"/> <!-- transitional, see OpenCPN#2061 -->
+      <xs:enumeration value = "mingw-x86_64"/>
       <xs:enumeration value = "msvc"/>
       <xs:enumeration value = "raspbian-armhf"/>
       <xs:enumeration value = "ubuntu-arm64"/>


### PR DESCRIPTION
The correct value for the mingw target value is 'mingw-x86_64', but most
plugins are using the bad value 'mingw'. Allwo both values during a
transition window.

See: https://github.com/OpenCPN/OpenCPN/issues/2061.