### PR TITLE
TwoCan plugin v1.9.1

### DIFF
--- a/metadata/twocan_plugin_pi-1.9.1.0-darwin-x86_64-10.13.6-macos.xml
+++ b/metadata/twocan_plugin_pi-1.9.1.0-darwin-x86_64-10.13.6-macos.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> TwoCan Plugin </name>
+<version> 1.9.1.0 </version>
+<release> 0 </release>
+<summary> TwoCan Plugin, integrates OpenCPN with NMEA 2000 networks </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/TwoCanPlugIn </source>
+
+<description>
+TwoCan Plugin, integrates OpenCPN with NMEA 2000 networks by converting NMEA 2000 messages to NMEA 183 sentences for use by OpenCPN
+</description>
+
+<target>darwin</target>
+<target-version>10.13.6</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/twocanplugin-prod/raw/names/twocan_plugin_pi-1.9.1.0-darwin-x86_64-10.13.6-macos-tarball/versions/V1.91/twocan_plugin_pi-1.9.1.0-darwin-x86_64-10.13.6-macos.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:twocan_pi </info-url>
+</plugin>

--- a/metadata/twocan_plugin_pi-1.9.1.0-debian-x86_64-10-buster.xml
+++ b/metadata/twocan_plugin_pi-1.9.1.0-debian-x86_64-10-buster.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> TwoCan Plugin </name>
+<version> 1.9.1.0 </version>
+<release> 0 </release>
+<summary> TwoCan Plugin, integrates OpenCPN with NMEA 2000 networks </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/TwoCanPlugIn </source>
+
+<description>
+TwoCan Plugin, integrates OpenCPN with NMEA 2000 networks by converting NMEA 2000 messages to NMEA 183 sentences for use by OpenCPN
+</description>
+
+<target>debian-x86_64</target>
+<target-version>10</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/twocanplugin-prod/raw/names/twocan_plugin_pi-1.9.1.0-debian-x86_64-10-buster-tarball/versions/V1.91/twocan_plugin_pi-1.9.1.0-debian-x86_64-10-buster.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:twocan_pi </info-url>
+</plugin>

--- a/metadata/twocan_plugin_pi-1.9.1.0-flatpak-x86_64-18.08-flatpak.xml
+++ b/metadata/twocan_plugin_pi-1.9.1.0-flatpak-x86_64-18.08-flatpak.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> TwoCan Plugin </name>
+<version> 1.9.1.0 </version>
+<release> 0 </release>
+<summary> TwoCan Plugin, integrates OpenCPN with NMEA 2000 networks </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/TwoCanPlugIn </source>
+
+<description>
+TwoCan Plugin, integrates OpenCPN with NMEA 2000 networks by converting NMEA 2000 messages to NMEA 183 sentences for use by OpenCPN
+</description>
+
+<target>flatpak-x86_64</target>
+<target-version>18.08</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/twocanplugin-prod/raw/names/twocan_plugin_pi-1.9.1.0-flatpak-x86_64-18.08-flatpak-tarball/versions/V1.91/twocan_plugin_pi-1.9.1.0-x86_64_flatpak-18.08.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:twocan_pi </info-url>
+</plugin>

--- a/metadata/twocan_plugin_pi-1.9.1.0-mingw-x86_64-10-mingw.xml
+++ b/metadata/twocan_plugin_pi-1.9.1.0-mingw-x86_64-10-mingw.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> TwoCan Plugin </name>
+<version> 1.9.1.0 </version>
+<release> 0 </release>
+<summary> TwoCan Plugin, integrates OpenCPN with NMEA 2000 networks </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/TwoCanPlugIn </source>
+
+<description>
+TwoCan Plugin, integrates OpenCPN with NMEA 2000 networks by converting NMEA 2000 messages to NMEA 183 sentences for use by OpenCPN
+</description>
+
+<target>mingw</target>
+<target-version>10</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/twocanplugin-prod/raw/names/twocan_plugin_pi-1.9.1.0-mingw-x86_64-10-mingw-tarball/versions/V1.91/twocan_plugin_pi-1.9.1.0-mingw-x86_64-10-mingw.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:twocan_pi </info-url>
+</plugin>

--- a/metadata/twocan_plugin_pi-1.9.1.0-msvc-x86_64-10.0.14393-MSVC.xml
+++ b/metadata/twocan_plugin_pi-1.9.1.0-msvc-x86_64-10.0.14393-MSVC.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> TwoCan Plugin </name>
+<version> 1.9.1.0 </version>
+<release> 0 </release>
+<summary> TwoCan Plugin, integrates OpenCPN with NMEA 2000 networks </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/TwoCanPlugIn </source>
+
+<description>
+TwoCan Plugin, integrates OpenCPN with NMEA 2000 networks by converting NMEA 2000 messages to NMEA 183 sentences for use by OpenCPN
+</description>
+
+<target>msvc</target>
+<target-version>10.0.14393</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/twocanplugin-prod/raw/names/twocan_plugin_pi-1.9.1.0-msvc-x86_64-10.0.14393-MSVC-tarball/versions/V1.91/twocan_plugin_pi-1.9.1.0-msvc-x86_64-10.0.14393-MSVC.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:twocan_pi </info-url>
+</plugin>

--- a/metadata/twocan_plugin_pi-1.9.1.0-raspbian-armhf-10-buster-armhf.xml
+++ b/metadata/twocan_plugin_pi-1.9.1.0-raspbian-armhf-10-buster-armhf.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> TwoCan Plugin </name>
+<version> 1.9.1.0 </version>
+<release> 0 </release>
+<summary> TwoCan Plugin, integrates OpenCPN with NMEA 2000 networks </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/TwoCanPlugIn </source>
+
+<description>
+TwoCan Plugin, integrates OpenCPN with NMEA 2000 networks by converting NMEA 2000 messages to NMEA 183 sentences for use by OpenCPN
+</description>
+
+<target>raspbian-armhf</target>
+<target-version>10</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/twocanplugin-prod/raw/names/twocan_plugin_pi-1.9.1.0-raspbian-armhf-10-buster-armhf-tarball/versions/V1.91/twocan_plugin_pi-1.9.1.0-raspbian-armhf-10-buster-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:twocan_pi </info-url>
+</plugin>

--- a/metadata/twocan_plugin_pi-1.9.1.0-raspbian-armhf-9.4-stretch-armhf.xml
+++ b/metadata/twocan_plugin_pi-1.9.1.0-raspbian-armhf-9.4-stretch-armhf.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> TwoCan Plugin </name>
+<version> 1.9.1.0 </version>
+<release> 0 </release>
+<summary> TwoCan Plugin, integrates OpenCPN with NMEA 2000 networks </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/TwoCanPlugIn </source>
+
+<description>
+TwoCan Plugin, integrates OpenCPN with NMEA 2000 networks by converting NMEA 2000 messages to NMEA 183 sentences for use by OpenCPN
+</description>
+
+<target>raspbian-armhf</target>
+<target-version>9.4</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/twocanplugin-prod/raw/names/twocan_plugin_pi-1.9.1.0-raspbian-armhf-9.4-stretch-armhf-tarball/versions/V1.91/twocan_plugin_pi-1.9.1.0-raspbian-armhf-9.4-stretch-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:twocan_pi </info-url>
+</plugin>

--- a/metadata/twocan_plugin_pi-1.9.1.0-ubuntu-arm64-18.04-bionic-armh64.xml
+++ b/metadata/twocan_plugin_pi-1.9.1.0-ubuntu-arm64-18.04-bionic-armh64.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> TwoCan Plugin </name>
+<version> 1.9.1.0 </version>
+<release> 0 </release>
+<summary> TwoCan Plugin, integrates OpenCPN with NMEA 2000 networks </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/TwoCanPlugIn </source>
+
+<description>
+TwoCan Plugin, integrates OpenCPN with NMEA 2000 networks by converting NMEA 2000 messages to NMEA 183 sentences for use by OpenCPN
+</description>
+
+<target>ubuntu-arm64</target>
+<target-version>18.04</target-version>
+<target-arch>arm64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/twocanplugin-prod/raw/names/twocan_plugin_pi-1.9.1.0-ubuntu-arm64-18.04-bionic-armh64-tarball/versions/V1.91/twocan_plugin_pi-1.9.1.0-ubuntu-arm64-18.04-bionic-armh64.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:twocan_pi </info-url>
+</plugin>

--- a/metadata/twocan_plugin_pi-1.9.1.0-ubuntu-x86_64-14.04-trusty.xml
+++ b/metadata/twocan_plugin_pi-1.9.1.0-ubuntu-x86_64-14.04-trusty.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> TwoCan Plugin </name>
+<version> 1.9.1.0 </version>
+<release> 0 </release>
+<summary> TwoCan Plugin, integrates OpenCPN with NMEA 2000 networks </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/TwoCanPlugIn </source>
+
+<description>
+TwoCan Plugin, integrates OpenCPN with NMEA 2000 networks by converting NMEA 2000 messages to NMEA 183 sentences for use by OpenCPN
+</description>
+
+<target>ubuntu-x86_64</target>
+<target-version>14.04</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/twocanplugin-prod/raw/names/twocan_plugin_pi-1.9.1.0-ubuntu-x86_64-14.04-trusty-tarball/versions/V1.91/twocan_plugin_pi-1.9.1.0-ubuntu-x86_64-14.04-trusty.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:twocan_pi </info-url>
+</plugin>

--- a/metadata/twocan_plugin_pi-1.9.1.0-ubuntu-x86_64-16.04-xenial.xml
+++ b/metadata/twocan_plugin_pi-1.9.1.0-ubuntu-x86_64-16.04-xenial.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> TwoCan Plugin </name>
+<version> 1.9.1.0 </version>
+<release> 0 </release>
+<summary> TwoCan Plugin, integrates OpenCPN with NMEA 2000 networks </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/TwoCanPlugIn </source>
+
+<description>
+TwoCan Plugin, integrates OpenCPN with NMEA 2000 networks by converting NMEA 2000 messages to NMEA 183 sentences for use by OpenCPN
+</description>
+
+<target>ubuntu-x86_64</target>
+<target-version>16.04</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/twocanplugin-prod/raw/names/twocan_plugin_pi-1.9.1.0-ubuntu-x86_64-16.04-xenial-tarball/versions/V1.91/twocan_plugin_pi-1.9.1.0-ubuntu-x86_64-16.04-xenial.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:twocan_pi </info-url>
+</plugin>

--- a/metadata/twocan_plugin_pi-1.9.1.0-ubuntu-x86_64-18.04-bionic-gtk3.xml
+++ b/metadata/twocan_plugin_pi-1.9.1.0-ubuntu-x86_64-18.04-bionic-gtk3.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> TwoCan Plugin </name>
+<version> 1.9.1.0 </version>
+<release> 0 </release>
+<summary> TwoCan Plugin, integrates OpenCPN with NMEA 2000 networks </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/TwoCanPlugIn </source>
+
+<description>
+TwoCan Plugin, integrates OpenCPN with NMEA 2000 networks by converting NMEA 2000 messages to NMEA 183 sentences for use by OpenCPN
+</description>
+
+<target>ubuntu-gtk3-x86_64</target>
+<target-version>18.04</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/twocanplugin-prod/raw/names/twocan_plugin_pi-1.9.1.0-ubuntu-x86_64-18.04-bionic-gtk3-tarball/versions/V1.91/twocan_plugin_pi-1.9.1.0-ubuntu-x86_64-18.04-bionic-gtk3.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:twocan_pi </info-url>
+</plugin>

--- a/metadata/twocan_plugin_pi-1.9.1.0-ubuntu-x86_64-18.04-bionic.xml
+++ b/metadata/twocan_plugin_pi-1.9.1.0-ubuntu-x86_64-18.04-bionic.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> TwoCan Plugin </name>
+<version> 1.9.1.0 </version>
+<release> 0 </release>
+<summary> TwoCan Plugin, integrates OpenCPN with NMEA 2000 networks </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/TwoCanPlugIn </source>
+
+<description>
+TwoCan Plugin, integrates OpenCPN with NMEA 2000 networks by converting NMEA 2000 messages to NMEA 183 sentences for use by OpenCPN
+</description>
+
+<target>ubuntu-x86_64</target>
+<target-version>18.04</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/twocanplugin-prod/raw/names/twocan_plugin_pi-1.9.1.0-ubuntu-x86_64-18.04-bionic-tarball/versions/V1.91/twocan_plugin_pi-1.9.1.0-ubuntu-x86_64-18.04-bionic.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:twocan_pi </info-url>
+</plugin>

--- a/metadata/twocan_plugin_pi-1.9.1.0-ubuntu-x86_64-20.04-focal-gtk3.xml
+++ b/metadata/twocan_plugin_pi-1.9.1.0-ubuntu-x86_64-20.04-focal-gtk3.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> TwoCan Plugin </name>
+<version> 1.9.1.0 </version>
+<release> 0 </release>
+<summary> TwoCan Plugin, integrates OpenCPN with NMEA 2000 networks </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/TwoCanPlugIn </source>
+
+<description>
+TwoCan Plugin, integrates OpenCPN with NMEA 2000 networks by converting NMEA 2000 messages to NMEA 183 sentences for use by OpenCPN
+</description>
+
+<target>ubuntu-gtk3-x86_64</target>
+<target-version>20.04</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/twocanplugin-prod/raw/names/twocan_plugin_pi-1.9.1.0-ubuntu-x86_64-20.04-focal-gtk3-tarball/versions/V1.91/twocan_plugin_pi-1.9.1.0-ubuntu-x86_64-20.04-focal-gtk3.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:twocan_pi </info-url>
+</plugin>


### PR DESCRIPTION
Minor update to TwoCan plugin.
1. Add support for PGN 129540 GNSS Satellites in View
2. Fix random GPS position fix (missing break statement)
3. Reliability improvement, when shutting down on an idle NMEA 2000 network,

XML metadata files pass XSD & URL validation checks 