### PR TITLE
Update TideFinder to correct Typo

### DIFF
--- a/metadata/TideFinder-1.4-darwin-10.13.6.xml
+++ b/metadata/TideFinder-1.4-darwin-10.13.6.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> TideFinder </name>
-  <version> 1.4.2+1263.v1.4.2-beta </version>
+  <version> 1.4.3+1312.v1.4.3-beta </version>
   <release> 1 </release>
   <summary> Tidal HW/LW prediction into the future </summary>
 
@@ -18,6 +18,6 @@ easier future predictions.
   <target>darwin</target>
   <target-version>10.13.6</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-darwin-10.13.6-tarball/versions/1.4.2+1263.v1.4.2-beta/TideFinder-1.4.2+1263.v1.4.2-beta_darwin-10.13.6-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 7e1d4eaf0fab3af467bc736ad802f33dea82eabd7d5d8356357461e587d7d1de </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-darwin-10.13.6-tarball/versions/1.4.3+1312.v1.4.3-beta/TideFinder-1.4.3+1312.v1.4.3-beta_darwin-10.13.6-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> e2e6aebb0aaec7217873eb92735687e23e41174628409ffd39f3d1f86854c603 </tarball-checksum>
 </plugin>

--- a/metadata/TideFinder-1.4-debian-10.xml
+++ b/metadata/TideFinder-1.4-debian-10.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> TideFinder </name>
-  <version> 1.4.2+1271.v1.4.2-beta </version>
+  <version> 1.4.3+1309.v1.4.3-beta </version>
   <release> 1 </release>
   <summary> Tidal HW/LW prediction into the future </summary>
 
@@ -18,6 +18,6 @@ easier future predictions.
   <target>debian-x86_64</target>
   <target-version>10</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-debian-10-tarball/versions/1.4.2+1271.v1.4.2-beta/TideFinder-1.4.2+1271.v1.4.2-beta_debian-10-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> e6b4268c4cac5c42ce8d926b4c0ad19e735197a56a6d6053812e00b09c90cafe </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-debian-10-tarball/versions/1.4.3+1309.v1.4.3-beta/TideFinder-1.4.3+1309.v1.4.3-beta_debian-10-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 8a5198d04aca16fdfc5451cb4699da0d1ff1ecce7b026aadb5e0b909d0fe8f0b </tarball-checksum>
 </plugin>

--- a/metadata/TideFinder-1.4-flatpak-18.08.xml
+++ b/metadata/TideFinder-1.4-flatpak-18.08.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> TideFinder </name>
-  <version> 1.4.2+1266.v1.4.2-beta </version>
+  <version> 1.4.3+1313.v1.4.3-beta </version>
   <release> 1 </release>
   <summary> Tidal HW/LW prediction into the future </summary>
 
@@ -18,6 +18,6 @@ easier future predictions.
   <target>flatpak-x86_64</target>
   <target-version>18.08</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-flatpak-18.08-tarball/versions/1.4.2+1266.v1.4.2-beta/TideFinder-1.4.2+1266.v1.4.2-beta_flatpak-18.08-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> fd7a31b34e39c4c33c344be621f8801d3525bab5c7ef34492476520ed2bb9994 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-flatpak-18.08-tarball/versions/1.4.3+1313.v1.4.3-beta/TideFinder-1.4.3+1313.v1.4.3-beta_flatpak-18.08-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 78a38a95d212c15621ce7d64ae7fb9ac7c3888cfd9d22ae62ebc7f0c632a50cf </tarball-checksum>
 </plugin>

--- a/metadata/TideFinder-1.4-mingw-10.xml
+++ b/metadata/TideFinder-1.4-mingw-10.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> TideFinder </name>
-  <version> 1.4.1+1255.v1.4.1-beta </version>
+  <version> 1.4.3+1316.v1.4.3-beta </version>
   <release> 1 </release>
   <summary> Tidal HW/LW prediction into the future </summary>
 
@@ -18,6 +18,6 @@ easier future predictions.
   <target>mingw-x86_64</target>
   <target-version>10</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-mingw-10-tarball/versions/1.4.1+1255.v1.4.1-beta/TideFinder-1.4.1+1255.v1.4.1-beta_mingw-10-win32.tar.gz </tarball-url>
-  <tarball-checksum> e4c8d8e5f1da97a8abdc193790dc721df41cfe31a60af8cc67f5b82222e778bf </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-mingw-10-tarball/versions/1.4.3+1316.v1.4.3-beta/TideFinder-1.4.3+1316.v1.4.3-beta_mingw-10-win32.tar.gz </tarball-url>
+  <tarball-checksum> 82a82c81e2189b48143afd8c0dad358b7729df87697caeb5f100fc79e77a8c26 </tarball-checksum>
 </plugin>

--- a/metadata/TideFinder-1.4-msvc-10.0.14393.xml
+++ b/metadata/TideFinder-1.4-msvc-10.0.14393.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> TideFinder </name>
-  <version> 1.4.2+147.v1.4.2-beta </version>
+  <version> 1.4.3+152.v1.4.3-beta </version>
   <release> 1 </release>
   <summary> Tidal HW/LW prediction into the future </summary>
 
@@ -18,6 +18,6 @@ easier future predictions.
   <target>msvc</target>
   <target-version>10.0.14393</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-msvc-10.0.14393-tarball/versions/1.4.2+147.v1.4.2-beta/TideFinder-1.4.2+147.v1.4.2-beta_msvc-10.0.14393-win32.tar.gz </tarball-url>
-  <tarball-checksum> 9a9bafaa46e998658123ab77757146332e7ed06479102da9d29ed56acd5c0b34 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-msvc-10.0.14393-tarball/versions/1.4.3+152.v1.4.3-beta/TideFinder-1.4.3+152.v1.4.3-beta_msvc-10.0.14393-win32.tar.gz </tarball-url>
+  <tarball-checksum> d3c80960a7936f08b74d0d4c121c3002d86050b52886f7448d39a290a6eb3f25 </tarball-checksum>
 </plugin>

--- a/metadata/TideFinder-1.4-raspbian-10.xml
+++ b/metadata/TideFinder-1.4-raspbian-10.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> TideFinder </name>
-  <version> 1.4.1+1253.v1.4.1-beta </version>
+  <version> 1.4.3+1310.v1.4.3-beta </version>
   <release> 1 </release>
   <summary> Tidal HW/LW prediction into the future </summary>
 
@@ -18,6 +18,6 @@ easier future predictions.
   <target>raspbian-armhf</target>
   <target-version>10</target-version>
   <target-arch>armhf</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-raspbian-10-tarball/versions/1.4.1+1253.v1.4.1-beta/TideFinder-1.4.1+1253.v1.4.1-beta_raspbian-10-armhf.tar.gz </tarball-url>
-  <tarball-checksum> b47b68db1c1db541066e6bd52911e3d1b2ad095d454bd66e62c2e285fb86e100 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-raspbian-10-tarball/versions/1.4.3+1310.v1.4.3-beta/TideFinder-1.4.3+1310.v1.4.3-beta_raspbian-10-armhf.tar.gz </tarball-url>
+  <tarball-checksum> 4debb26687970fce3b254ab101e3058ab6d594a8278480a1936b798a89a82bd4 </tarball-checksum>
 </plugin>

--- a/metadata/TideFinder-1.4-raspbian-9.13.xml
+++ b/metadata/TideFinder-1.4-raspbian-9.13.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> TideFinder </name>
-  <version> 1.4.1+1259.v1.4.1-beta </version>
+  <version> 1.4.3+1311.v1.4.3-beta </version>
   <release> 1 </release>
   <summary> Tidal HW/LW prediction into the future </summary>
 
@@ -18,6 +18,6 @@ easier future predictions.
   <target>raspbian-armhf</target>
   <target-version>9.13</target-version>
   <target-arch>armhf</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-raspbian-9.13-tarball/versions/1.4.1+1259.v1.4.1-beta/TideFinder-1.4.1+1259.v1.4.1-beta_raspbian-9.13-armhf.tar.gz </tarball-url>
-  <tarball-checksum> 5f3cf838bdc1cf0bde824ecfa2b2cb4a6150749562e22916906d1a74fc9f1ce5 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-raspbian-9.13-tarball/versions/1.4.3+1311.v1.4.3-beta/TideFinder-1.4.3+1311.v1.4.3-beta_raspbian-9.13-armhf.tar.gz </tarball-url>
+  <tarball-checksum> f06922fc8155c3e8ff7a2ef7216f3cf0db59d769ef8174714ae7ed27ceb52cf5 </tarball-checksum>
 </plugin>

--- a/metadata/TideFinder-1.4-ubuntu-16.04.xml
+++ b/metadata/TideFinder-1.4-ubuntu-16.04.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> TideFinder </name>
-  <version> 1.4.1+1254.v1.4.1-beta </version>
+  <version> 1.4.3+1308.v1.4.3-beta </version>
   <release> 1 </release>
   <summary> Tidal HW/LW prediction into the future </summary>
 
@@ -18,6 +18,6 @@ easier future predictions.
   <target>ubuntu-x86_64</target>
   <target-version>16.04</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-ubuntu-16.04-tarball/versions/1.4.1+1254.v1.4.1-beta/TideFinder-1.4.1+1254.v1.4.1-beta_ubuntu-16.04-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> f84114b21eba0727d52d6d7e8f04f505859fe98995b507dbacbdd4e17b7bda67 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-ubuntu-16.04-tarball/versions/1.4.3+1308.v1.4.3-beta/TideFinder-1.4.3+1308.v1.4.3-beta_ubuntu-16.04-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 8461bb79cd79d1f42add37f3359e047c43f87fa1875e5207ee5624738676fe34 </tarball-checksum>
 </plugin>

--- a/metadata/TideFinder-1.4-ubuntu-18.04.xml
+++ b/metadata/TideFinder-1.4-ubuntu-18.04.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> TideFinder </name>
-  <version> 1.4.2+1270.v1.4.2-beta </version>
+  <version> 1.4.3+1314.v1.4.3-beta </version>
   <release> 1 </release>
   <summary> Tidal HW/LW prediction into the future </summary>
 
@@ -18,6 +18,6 @@ easier future predictions.
   <target>ubuntu-x86_64</target>
   <target-version>18.04</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-ubuntu-18.04-tarball/versions/1.4.2+1270.v1.4.2-beta/TideFinder-1.4.2+1270.v1.4.2-beta_ubuntu-18.04-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> b0627827b5bacfc19e7457350f98a43905b5e8c74a908614d93edde423b8ff1f </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-ubuntu-18.04-tarball/versions/1.4.3+1314.v1.4.3-beta/TideFinder-1.4.3+1314.v1.4.3-beta_ubuntu-18.04-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 800f58962c6200dfc94f7967aa23208f7d1b3f151f290612391932e48de3c46a </tarball-checksum>
 </plugin>

--- a/metadata/TideFinder-1.4-ubuntu-gtk3-18.04.xml
+++ b/metadata/TideFinder-1.4-ubuntu-gtk3-18.04.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> TideFinder </name>
-  <version> 1.4.2+1269.v1.4.2-beta </version>
+  <version> 1.4.3+1307.v1.4.3-beta </version>
   <release> 1 </release>
   <summary> Tidal HW/LW prediction into the future </summary>
 
@@ -18,6 +18,6 @@ easier future predictions.
   <target>ubuntu-gtk3-x86_64</target>
   <target-version>18.04</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-ubuntu-gtk3-18.04-tarball/versions/1.4.2+1269.v1.4.2-beta/TideFinder-1.4.2+1269.v1.4.2-beta_ubuntu-gtk3-18.04-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> aecbd072767946459827556c5df134782d0a94681eead9ecb7985f135ade35f9 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-ubuntu-gtk3-18.04-tarball/versions/1.4.3+1307.v1.4.3-beta/TideFinder-1.4.3+1307.v1.4.3-beta_ubuntu-gtk3-18.04-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 23d27d8179e5f2abb6aa2b61c2b8492881a1143004f087d065c2756b0159900d </tarball-checksum>
 </plugin>

--- a/metadata/TideFinder-1.4-ubuntu-gtk3-20.04.xml
+++ b/metadata/TideFinder-1.4-ubuntu-gtk3-20.04.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> TideFinder </name>
-  <version> 1.4.2+1265.v1.4.2-beta </version>
+  <version> 1.4.3+1315.v1.4.3-beta </version>
   <release> 1 </release>
   <summary> Tidal HW/LW prediction into the future </summary>
 
@@ -18,6 +18,6 @@ easier future predictions.
   <target>ubuntu-gtk3-x86_64</target>
   <target-version>20.04</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-ubuntu-gtk3-20.04-tarball/versions/1.4.2+1265.v1.4.2-beta/TideFinder-1.4.2+1265.v1.4.2-beta_ubuntu-gtk3-20.04-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 13ba7d080694abc970cd5ff402bb3eaea3463b30b4a9c6ef46086890ac5ba882 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-ubuntu-gtk3-20.04-tarball/versions/1.4.3+1315.v1.4.3-beta/TideFinder-1.4.3+1315.v1.4.3-beta_ubuntu-gtk3-20.04-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 53156ef062a2468def4448638b71b990613e6090b5ba9a36939bb326e6c6f79c </tarball-checksum>
 </plugin>

--- a/ocpn-plugins.xml
+++ b/ocpn-plugins.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <plugins>
   <version>0.0.0</version>
-  <date>2021-02-12 00:31</date>
+  <date>2021-02-17 15:57</date>
   <plugin version="1">
     <name> Watchdog </name>
     <version> 2.4.22.0 </version>
@@ -65,6 +65,44 @@ https://dl.cloudsmith.io/public/opencpn/testplugin-prod/raw/names/testplugin_pi-
     <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:safety:odraw1.6_pi </info-url>
   </plugin>
   <plugin version="1">
+    <name> UKTides </name>
+    <version> 1.1.2+379.v1.1.2-beta </version>
+    <release> 1 </release>
+    <summary> Tides for UK Ports </summary>
+    <api-version> 1.16 </api-version>
+    <open-source> yes </open-source>
+    <author> Mike Rossiter </author>
+    <source> https://github.com/Rasbats/UKTides_pi </source>
+    <info-url> https://opencpn.org/OpenCPN/plugins/uktides.html </info-url>
+    <description>
+Tides for 600+ UK Ports from the UKHO
+  </description>
+    <target>msvc</target>
+    <target-version>10.0.14393</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/uktides-beta/raw/names/UKTides-1.1-msvc-10.0.14393-tarball/versions/1.1.2+379.v1.1.2-beta/UKTides-1.1.2+379.v1.1.2-beta_msvc-10.0.14393-win32.tar.gz </tarball-url>
+    <tarball-checksum> d57e88f30e31463a76e39f08964515331952ee6ac5f6158393a39c1f12622172 </tarball-checksum>
+  </plugin>
+  <plugin version="1">
+    <name> UKTides </name>
+    <version> 1.1.2+2539.v1.1.2-beta </version>
+    <release> 1 </release>
+    <summary> Tides for UK Ports </summary>
+    <api-version> 1.16 </api-version>
+    <open-source> yes </open-source>
+    <author> Mike Rossiter </author>
+    <source> https://github.com/Rasbats/UKTides_pi </source>
+    <info-url> https://opencpn.org/OpenCPN/plugins/uktides.html </info-url>
+    <description>
+Tides for 600+ UK Ports from the UKHO
+  </description>
+    <target>ubuntu-x86_64</target>
+    <target-version>16.04</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/uktides-beta/raw/names/UKTides-1.1-ubuntu-16.04-tarball/versions/1.1.2+2539.v1.1.2-beta/UKTides-1.1.2+2539.v1.1.2-beta_ubuntu-16.04-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> c20ee594b7df1b0500d84f1f845243a5168eb43b2965dde6a465d32aba5d20ea </tarball-checksum>
+  </plugin>
+  <plugin version="1">
     <name> Watchdog </name>
     <version> 2.4.22.0 </version>
     <release> 0 </release>
@@ -125,6 +163,25 @@ OCPN_DRAW (OD) is a plugin that extends the capability of OCPN to include non-st
 https://dl.cloudsmith.io/public/opencpn/ocpn_draw-beta/raw/names/ocpn_draw_pi-1.8.5.2-raspbian-armhf-9.13-stretch-armhf-tarball/versions/1.8.5.2+2393.416b2fe/ocpn_draw_pi-1.8.5.2-raspbian-armhf-9.13.tar.gz
 </tarball-url>
     <info-url> https://opencpn.org/OpenCPN/plugins/draw.html </info-url>
+  </plugin>
+  <plugin version="1">
+    <name> UKTides </name>
+    <version> 1.1.2+2536.v1.1.2-beta </version>
+    <release> 1 </release>
+    <summary> Tides for UK Ports </summary>
+    <api-version> 1.16 </api-version>
+    <open-source> yes </open-source>
+    <author> Mike Rossiter </author>
+    <source> https://github.com/Rasbats/UKTides_pi </source>
+    <info-url> https://opencpn.org/OpenCPN/plugins/uktides.html </info-url>
+    <description>
+Tides for 600+ UK Ports from the UKHO
+  </description>
+    <target>flatpak-x86_64</target>
+    <target-version>18.08</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/uktides-beta/raw/names/UKTides-1.1-flatpak-18.08-tarball/versions/1.1.2+2536.v1.1.2-beta/UKTides-1.1.2+2536.v1.1.2-beta_flatpak-18.08-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> 1e56066414c69902b259ef2e5b7149b2b0de31b34f9f5b8f03055266568342db </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name>Radar</name>
@@ -221,6 +278,24 @@ https://dl.cloudsmith.io/public/opencpn/ocpn_draw-beta/raw/names/ocpn_draw_pi-1.
     <info-url> https://opencpn.org/OpenCPN/plugins/draw.html </info-url>
   </plugin>
   <plugin version="1">
+    <name> otidalplan </name>
+    <version> 0.8.1+129.v0.8.1-beta </version>
+    <release> 1 </release>
+    <summary> Estimating Positions using tidal harmonics </summary>
+    <api-version> 1.16 </api-version>
+    <open-source> yes </open-source>
+    <author> Mike Rossiter </author>
+    <source> https://github.com/Rasbats/otidalplan_pi </source>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:otidalplan </info-url>
+    <description> Calculates Estimated Positions using tidal harmonics.
+ </description>
+    <target>ubuntu-gtk3-x86_64</target>
+    <target-version>18.04</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/otidalplan-beta/raw/names/otidalplan-0.8-ubuntu-gtk3-18.04-tarball/versions/0.8.1+129.v0.8.1-beta/otidalplan-0.8.1+129.v0.8.1-beta_ubuntu-gtk3-18.04-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> 4fad81308c0d2e75724bc9cf3d2e8e8ee333c9313d51001061322769a7f576c5 </tarball-checksum>
+  </plugin>
+  <plugin version="1">
     <name> OCPN Draw </name>
     <version> 1.8.5.2 </version>
     <release> 2 </release>
@@ -241,6 +316,24 @@ OCPN_DRAW (OD) is a plugin that extends the capability of OCPN to include non-st
 https://dl.cloudsmith.io/public/opencpn/ocpn_draw-beta/raw/names/ocpn_draw_pi-1.8.5.2-ubuntu-x86_64-14.04-trusty-tarball/versions/1.8.5.2+2395.416b2fe/ocpn_draw_pi-1.8.5.2-ubuntu-x86_64-14.04-trusty.tar.gz
 </tarball-url>
     <info-url> https://opencpn.org/OpenCPN/plugins/draw.html </info-url>
+  </plugin>
+  <plugin version="1">
+    <name> otidalplan </name>
+    <version> 0.8.1+132.v0.8.1-beta </version>
+    <release> 1 </release>
+    <summary> Estimating Positions using tidal harmonics </summary>
+    <api-version> 1.16 </api-version>
+    <open-source> yes </open-source>
+    <author> Mike Rossiter </author>
+    <source> https://github.com/Rasbats/otidalplan_pi </source>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:otidalplan </info-url>
+    <description> Calculates Estimated Positions using tidal harmonics.
+ </description>
+    <target>flatpak-x86_64</target>
+    <target-version>18.08</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/otidalplan-beta/raw/names/otidalplan-0.8-flatpak-18.08-tarball/versions/0.8.1+132.v0.8.1-beta/otidalplan-0.8.1+132.v0.8.1-beta_flatpak-18.08-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> 38e39b489f6e7317ffaf800f2d2eaf9b3aea2928eaa1985066265247e8d5bd12 </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name> testplugin </name>
@@ -304,7 +397,7 @@ https://dl.cloudsmith.io/public/opencpn/watchdog-prod/raw/names/watchdog_pi-2.4.
   </plugin>
   <plugin version="1">
     <name> TideFinder </name>
-    <version> 1.4.1+1257.v1.4.1-beta </version>
+    <version> 1.4.2+1266.v1.4.2-beta </version>
     <release> 1 </release>
     <summary> Tidal HW/LW prediction into the future </summary>
     <api-version> 1.16 </api-version>
@@ -318,12 +411,12 @@ easier future predictions.
     <target>flatpak-x86_64</target>
     <target-version>18.08</target-version>
     <target-arch>x86_64</target-arch>
-    <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-flatpak-18.08-tarball/versions/1.4.1+1257.v1.4.1-beta/TideFinder-1.4.1+1257.v1.4.1-beta_flatpak-18.08-x86_64.tar.gz </tarball-url>
-    <tarball-checksum> 5c250adebf75b55fa1d79ffb6eb5a7bef3f5e4372e1bb2e3c095d28e0b439b38 </tarball-checksum>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-flatpak-18.08-tarball/versions/1.4.2+1266.v1.4.2-beta/TideFinder-1.4.2+1266.v1.4.2-beta_flatpak-18.08-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> fd7a31b34e39c4c33c344be621f8801d3525bab5c7ef34492476520ed2bb9994 </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name> TideFinder </name>
-    <version> 1.4.1+1262.v1.4.1-beta </version>
+    <version> 1.4.2+1270.v1.4.2-beta </version>
     <release> 1 </release>
     <summary> Tidal HW/LW prediction into the future </summary>
     <api-version> 1.16 </api-version>
@@ -337,8 +430,8 @@ easier future predictions.
     <target>ubuntu-x86_64</target>
     <target-version>18.04</target-version>
     <target-arch>x86_64</target-arch>
-    <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-ubuntu-18.04-tarball/versions/1.4.1+1262.v1.4.1-beta/TideFinder-1.4.1+1262.v1.4.1-beta_ubuntu-18.04-x86_64.tar.gz </tarball-url>
-    <tarball-checksum> ed4532ee844bc03709eeeff2616b9a01b69a2811a62e6453dae2b6c353b86c6d </tarball-checksum>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-ubuntu-18.04-tarball/versions/1.4.2+1270.v1.4.2-beta/TideFinder-1.4.2+1270.v1.4.2-beta_ubuntu-18.04-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> b0627827b5bacfc19e7457350f98a43905b5e8c74a908614d93edde423b8ff1f </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name>Radar</name>
@@ -426,6 +519,24 @@ OCPN_DRAW (OD) is a plugin that extends the capability of OCPN to include non-st
 https://dl.cloudsmith.io/public/opencpn/ocpn_draw-beta/raw/names/ocpn_draw_pi-1.8.5.2-android-armhf-16-android-armhf-tarball/versions/1.8.5.2+2387.416b2fe/ocpn_draw_pi-1.8.5.2-android-armhf-16-android-armhf.tar.gz
 </tarball-url>
     <info-url> https://opencpn.org/OpenCPN/plugins/draw.html </info-url>
+  </plugin>
+  <plugin version="1">
+    <name> otidalplan </name>
+    <version> 0.8.1+124.v0.8.1-beta </version>
+    <release> 1 </release>
+    <summary> Estimating Positions using tidal harmonics </summary>
+    <api-version> 1.16 </api-version>
+    <open-source> yes </open-source>
+    <author> Mike Rossiter </author>
+    <source> https://github.com/Rasbats/otidalplan_pi </source>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:otidalplan </info-url>
+    <description> Calculates Estimated Positions using tidal harmonics.
+ </description>
+    <target>ubuntu-x86_64</target>
+    <target-version>18.04</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/otidalplan-beta/raw/names/otidalplan-0.8-ubuntu-18.04-tarball/versions/0.8.1+124.v0.8.1-beta/otidalplan-0.8.1+124.v0.8.1-beta_ubuntu-18.04-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> 66db16364cdb907733422d52287aab77ce759290974163ea06bcaf52a28590ed </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name> Watchdog </name>
@@ -718,6 +829,43 @@ https://dl.cloudsmith.io/public/opencpn/watchdog-prod/raw/names/watchdog_pi-2.4.
     <info-url> https://opencpn.org/OpenCPN/plugins/watchdog.html </info-url>
   </plugin>
   <plugin version="1">
+    <name> UKTides </name>
+    <version> 1.1.2+2535.v1.1.2-beta </version>
+    <release> 1 </release>
+    <summary> Tides for UK Ports </summary>
+    <api-version> 1.16 </api-version>
+    <open-source> yes </open-source>
+    <author> Mike Rossiter </author>
+    <source> https://github.com/Rasbats/UKTides_pi </source>
+    <info-url> https://opencpn.org/OpenCPN/plugins/uktides.html </info-url>
+    <description>
+Tides for 600+ UK Ports from the UKHO
+  </description>
+    <target>raspbian-armhf</target>
+    <target-version>10</target-version>
+    <target-arch>armhf</target-arch>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/uktides-beta/raw/names/UKTides-1.1-raspbian-10-tarball/versions/1.1.2+2535.v1.1.2-beta/UKTides-1.1.2+2535.v1.1.2-beta_raspbian-10-armhf.tar.gz </tarball-url>
+    <tarball-checksum> f7fe3b34903be8ba2bc90dab6e71723aa136501c5b23f05543fa5382f99d2e69 </tarball-checksum>
+  </plugin>
+  <plugin version="1">
+    <name> otidalplan </name>
+    <version> 0.8.1+128.v0.8.1-beta </version>
+    <release> 1 </release>
+    <summary> Estimating Positions using tidal harmonics </summary>
+    <api-version> 1.16 </api-version>
+    <open-source> yes </open-source>
+    <author> Mike Rossiter </author>
+    <source> https://github.com/Rasbats/otidalplan_pi </source>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:otidalplan </info-url>
+    <description> Calculates Estimated Positions using tidal harmonics.
+ </description>
+    <target>raspbian-armhf</target>
+    <target-version>10</target-version>
+    <target-arch>armhf</target-arch>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/otidalplan-beta/raw/names/otidalplan-0.8-raspbian-10-tarball/versions/0.8.1+128.v0.8.1-beta/otidalplan-0.8.1+128.v0.8.1-beta_raspbian-10-armhf.tar.gz </tarball-url>
+    <tarball-checksum> 87adc0deed6dbfb71d987d687baf2c8f91c8580e4a738d0acc2d4ac368e28335 </tarball-checksum>
+  </plugin>
+  <plugin version="1">
     <name> OCPN Draw </name>
     <version> 1.8.5.3 </version>
     <release> 3 </release>
@@ -761,7 +909,7 @@ https://dl.cloudsmith.io/public/opencpn/pypilot-beta/raw/names/pypilot_pi-0.22.0
   </plugin>
   <plugin version="1">
     <name> TideFinder </name>
-    <version> 1.4.1+1256.v1.4.1-beta </version>
+    <version> 1.4.2+1263.v1.4.2-beta </version>
     <release> 1 </release>
     <summary> Tidal HW/LW prediction into the future </summary>
     <api-version> 1.16 </api-version>
@@ -775,8 +923,26 @@ easier future predictions.
     <target>darwin</target>
     <target-version>10.13.6</target-version>
     <target-arch>x86_64</target-arch>
-    <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-darwin-10.13.6-tarball/versions/1.4.1+1256.v1.4.1-beta/TideFinder-1.4.1+1256.v1.4.1-beta_darwin-10.13.6-x86_64.tar.gz </tarball-url>
-    <tarball-checksum> 49eb2eb974ffaf570613b497c30639bcd466acc8e987cf5ae9eb45a2a61d8b78 </tarball-checksum>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-darwin-10.13.6-tarball/versions/1.4.2+1263.v1.4.2-beta/TideFinder-1.4.2+1263.v1.4.2-beta_darwin-10.13.6-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> 7e1d4eaf0fab3af467bc736ad802f33dea82eabd7d5d8356357461e587d7d1de </tarball-checksum>
+  </plugin>
+  <plugin version="1">
+    <name> otidalplan </name>
+    <version> 0.8.1+130.v0.8.1-beta </version>
+    <release> 1 </release>
+    <summary> Estimating Positions using tidal harmonics </summary>
+    <api-version> 1.16 </api-version>
+    <open-source> yes </open-source>
+    <author> Mike Rossiter </author>
+    <source> https://github.com/Rasbats/otidalplan_pi </source>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:otidalplan </info-url>
+    <description> Calculates Estimated Positions using tidal harmonics.
+ </description>
+    <target>darwin</target>
+    <target-version>10.13.6</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/otidalplan-beta/raw/names/otidalplan-0.8-darwin-10.13.6-tarball/versions/0.8.1+130.v0.8.1-beta/otidalplan-0.8.1+130.v0.8.1-beta_darwin-10.13.6-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> 885f270a1f10dbf87a937b71ecf7f16b44802a55363cbbcbed027d48196c5aa5 </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name> OCPN Draw </name>
@@ -827,7 +993,7 @@ such as dual radar range and Doppler.
   </plugin>
   <plugin version="1">
     <name> TideFinder </name>
-    <version> 1.4.1+144.v1.4.1-beta </version>
+    <version> 1.4.2+147.v1.4.2-beta </version>
     <release> 1 </release>
     <summary> Tidal HW/LW prediction into the future </summary>
     <api-version> 1.16 </api-version>
@@ -841,8 +1007,8 @@ easier future predictions.
     <target>msvc</target>
     <target-version>10.0.14393</target-version>
     <target-arch>x86_64</target-arch>
-    <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-msvc-10.0.14393-tarball/versions/1.4.1+144.v1.4.1-beta/TideFinder-1.4.1+144.v1.4.1-beta_msvc-10.0.14393-win32.tar.gz </tarball-url>
-    <tarball-checksum> a8341334e2518e3be3a4c1dcf7fe0895af0a300499be3a79f10a0f1514f15cf7 </tarball-checksum>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-msvc-10.0.14393-tarball/versions/1.4.2+147.v1.4.2-beta/TideFinder-1.4.2+147.v1.4.2-beta_msvc-10.0.14393-win32.tar.gz </tarball-url>
+    <tarball-checksum> 9a9bafaa46e998658123ab77757146332e7ed06479102da9d29ed56acd5c0b34 </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name> Watchdog </name>
@@ -928,7 +1094,7 @@ https://dl.cloudsmith.io/public/opencpn/ocpn_draw-beta/raw/names/ocpn_draw_pi-1.
   </plugin>
   <plugin version="1">
     <name> TideFinder </name>
-    <version> 1.4.1+1261.v1.4.1-beta </version>
+    <version> 1.4.2+1271.v1.4.2-beta </version>
     <release> 1 </release>
     <summary> Tidal HW/LW prediction into the future </summary>
     <api-version> 1.16 </api-version>
@@ -942,8 +1108,8 @@ easier future predictions.
     <target>debian-x86_64</target>
     <target-version>10</target-version>
     <target-arch>x86_64</target-arch>
-    <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-debian-10-tarball/versions/1.4.1+1261.v1.4.1-beta/TideFinder-1.4.1+1261.v1.4.1-beta_debian-10-x86_64.tar.gz </tarball-url>
-    <tarball-checksum> 94307a87d86a2e270bfc453e6e956bb706afc00943a55860d1df2a4ecb5d7014 </tarball-checksum>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-debian-10-tarball/versions/1.4.2+1271.v1.4.2-beta/TideFinder-1.4.2+1271.v1.4.2-beta_debian-10-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> e6b4268c4cac5c42ce8d926b4c0ad19e735197a56a6d6053812e00b09c90cafe </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name> OCPN Draw </name>
@@ -991,7 +1157,7 @@ https://dl.cloudsmith.io/public/opencpn/ocpn_draw-beta/raw/names/ocpn_draw_pi-1.
   </plugin>
   <plugin version="1">
     <name> TideFinder </name>
-    <version> 1.4.1+1260.v1.4.1-beta </version>
+    <version> 1.4.2+1269.v1.4.2-beta </version>
     <release> 1 </release>
     <summary> Tidal HW/LW prediction into the future </summary>
     <api-version> 1.16 </api-version>
@@ -1005,8 +1171,8 @@ easier future predictions.
     <target>ubuntu-gtk3-x86_64</target>
     <target-version>18.04</target-version>
     <target-arch>x86_64</target-arch>
-    <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-ubuntu-gtk3-18.04-tarball/versions/1.4.1+1260.v1.4.1-beta/TideFinder-1.4.1+1260.v1.4.1-beta_ubuntu-gtk3-18.04-x86_64.tar.gz </tarball-url>
-    <tarball-checksum> 23d03c5ed49417ca98a6a0459af38bc0b84ca1c39422f190dacc384c36129e07 </tarball-checksum>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-ubuntu-gtk3-18.04-tarball/versions/1.4.2+1269.v1.4.2-beta/TideFinder-1.4.2+1269.v1.4.2-beta_ubuntu-gtk3-18.04-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> aecbd072767946459827556c5df134782d0a94681eead9ecb7985f135ade35f9 </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name> testplugin </name>
@@ -1027,6 +1193,24 @@ testplugin Plugin is used to test out the ODraw API and demonstrate how to use i
 https://dl.cloudsmith.io/public/opencpn/testplugin-prod/raw/names/testplugin_pi-1.0.137.0-ubuntu-x86_64-18.04-bionic-gtk3-tarball/versions/v1.0.137/testplugin_pi-1.0.137.0-ubuntu-x86_64-18.04-bionic-gtk3.tar.gz
 </tarball-url>
     <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:safety:odraw1.6_pi </info-url>
+  </plugin>
+  <plugin version="1">
+    <name> otidalplan </name>
+    <version> 0.8.1+14.v0.8.1-beta </version>
+    <release> 1 </release>
+    <summary> Estimating Positions using tidal harmonics </summary>
+    <api-version> 1.16 </api-version>
+    <open-source> yes </open-source>
+    <author> Mike Rossiter </author>
+    <source> https://github.com/Rasbats/otidalplan_pi </source>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:otidalplan </info-url>
+    <description> Calculates Estimated Positions using tidal harmonics.
+ </description>
+    <target>msvc</target>
+    <target-version>10.0.14393</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/otidalplan-beta/raw/names/otidalplan-0.8-msvc-10.0.14393-tarball/versions/0.8.1+14.v0.8.1-beta/otidalplan-0.8.1+14.v0.8.1-beta_msvc-10.0.14393-win32.tar.gz </tarball-url>
+    <tarball-checksum> 00318f4398776bc1de2918801519ae4a2c52226f97c6828a4571af3b0fbf41f6 </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name> OCPN Draw </name>
@@ -1241,6 +1425,24 @@ https://dl.cloudsmith.io/public/opencpn/pypilot-beta/raw/names/pypilot_pi-0.22.4
     <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:safety:odraw1.6_pi </info-url>
   </plugin>
   <plugin version="1">
+    <name> otidalplan </name>
+    <version> 0.8.1+125.v0.8.1-beta </version>
+    <release> 1 </release>
+    <summary> Estimating Positions using tidal harmonics </summary>
+    <api-version> 1.16 </api-version>
+    <open-source> yes </open-source>
+    <author> Mike Rossiter </author>
+    <source> https://github.com/Rasbats/otidalplan_pi </source>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:otidalplan </info-url>
+    <description> Calculates Estimated Positions using tidal harmonics.
+ </description>
+    <target>ubuntu-x86_64</target>
+    <target-version>16.04</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/otidalplan-beta/raw/names/otidalplan-0.8-ubuntu-16.04-tarball/versions/0.8.1+125.v0.8.1-beta/otidalplan-0.8.1+125.v0.8.1-beta_ubuntu-16.04-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> 51d77e8d807116073ec5639953ed758428219a5c17c185869b5000ce16b1afa4 </tarball-checksum>
+  </plugin>
+  <plugin version="1">
     <name> OCPN Draw </name>
     <version> 1.8.5.2 </version>
     <release> 2 </release>
@@ -1327,8 +1529,27 @@ https://dl.cloudsmith.io/public/opencpn/pypilot-beta/raw/names/pypilot_pi-0.22.4
     <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:safety:odraw1.6_pi </info-url>
   </plugin>
   <plugin version="1">
+    <name> UKTides </name>
+    <version> 1.1.2+2538.v1.1.2-beta </version>
+    <release> 1 </release>
+    <summary> Tides for UK Ports </summary>
+    <api-version> 1.16 </api-version>
+    <open-source> yes </open-source>
+    <author> Mike Rossiter </author>
+    <source> https://github.com/Rasbats/UKTides_pi </source>
+    <info-url> https://opencpn.org/OpenCPN/plugins/uktides.html </info-url>
+    <description>
+Tides for 600+ UK Ports from the UKHO
+  </description>
+    <target>debian-x86_64</target>
+    <target-version>10</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/uktides-beta/raw/names/UKTides-1.1-debian-10-tarball/versions/1.1.2+2538.v1.1.2-beta/UKTides-1.1.2+2538.v1.1.2-beta_debian-10-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> 53bce48862edcb0f4adbfcf2da9c81fd32018f191ee3f1943f82a7e2fb07d775 </tarball-checksum>
+  </plugin>
+  <plugin version="1">
     <name> TideFinder </name>
-    <version> 1.4.1+1258.v1.4.1-beta </version>
+    <version> 1.4.2+1265.v1.4.2-beta </version>
     <release> 1 </release>
     <summary> Tidal HW/LW prediction into the future </summary>
     <api-version> 1.16 </api-version>
@@ -1342,8 +1563,8 @@ easier future predictions.
     <target>ubuntu-gtk3-x86_64</target>
     <target-version>20.04</target-version>
     <target-arch>x86_64</target-arch>
-    <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-ubuntu-gtk3-20.04-tarball/versions/1.4.1+1258.v1.4.1-beta/TideFinder-1.4.1+1258.v1.4.1-beta_ubuntu-gtk3-20.04-x86_64.tar.gz </tarball-url>
-    <tarball-checksum> 97a87f06b653c2ee49fdb0aba970b1d878800a57fac25fc3ef8dcafa9032f7d2 </tarball-checksum>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/tidefinder-beta/raw/names/TideFinder-1.4-ubuntu-gtk3-20.04-tarball/versions/1.4.2+1265.v1.4.2-beta/TideFinder-1.4.2+1265.v1.4.2-beta_ubuntu-gtk3-20.04-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> 13ba7d080694abc970cd5ff402bb3eaea3463b30b4a9c6ef46086890ac5ba882 </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name> TideFinder </name>
@@ -1659,6 +1880,25 @@ https://dl.cloudsmith.io/public/opencpn/ocpn_draw-beta/raw/names/ocpn_draw_pi-1.
     <info-url> https://opencpn.org/OpenCPN/plugins/draw.html </info-url>
   </plugin>
   <plugin version="1">
+    <name> UKTides </name>
+    <version> 1.1.2+2541.v1.1.2-beta </version>
+    <release> 1 </release>
+    <summary> Tides for UK Ports </summary>
+    <api-version> 1.16 </api-version>
+    <open-source> yes </open-source>
+    <author> Mike Rossiter </author>
+    <source> https://github.com/Rasbats/UKTides_pi </source>
+    <info-url> https://opencpn.org/OpenCPN/plugins/uktides.html </info-url>
+    <description>
+Tides for 600+ UK Ports from the UKHO
+  </description>
+    <target>ubuntu-gtk3-x86_64</target>
+    <target-version>20.04</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/uktides-beta/raw/names/UKTides-1.1-ubuntu-gtk3-20.04-tarball/versions/1.1.2+2541.v1.1.2-beta/UKTides-1.1.2+2541.v1.1.2-beta_ubuntu-gtk3-20.04-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> 23ba8afd9ce60ee75423b8697f163d10bef70159275a9d08617402f6b8a22c14 </tarball-checksum>
+  </plugin>
+  <plugin version="1">
     <name> testplugin </name>
     <version> 1.0.137.0 </version>
     <release> 0 </release>
@@ -1677,6 +1917,24 @@ testplugin Plugin is used to test out the ODraw API and demonstrate how to use i
 https://dl.cloudsmith.io/public/opencpn/testplugin-prod/raw/names/testplugin_pi-1.0.137.0-ubuntu-arm64-18.04-bionic-armh64-tarball/versions/v1.0.137/testplugin_pi-1.0.137.0-ubuntu-arm64-18.04-bionic-armh64.tar.gz
 </tarball-url>
     <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:safety:odraw1.6_pi </info-url>
+  </plugin>
+  <plugin version="1">
+    <name> otidalplan </name>
+    <version> 0.8.1+131.v0.8.1-beta </version>
+    <release> 1 </release>
+    <summary> Estimating Positions using tidal harmonics </summary>
+    <api-version> 1.16 </api-version>
+    <open-source> yes </open-source>
+    <author> Mike Rossiter </author>
+    <source> https://github.com/Rasbats/otidalplan_pi </source>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:otidalplan </info-url>
+    <description> Calculates Estimated Positions using tidal harmonics.
+ </description>
+    <target>debian-x86_64</target>
+    <target-version>10</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/otidalplan-beta/raw/names/otidalplan-0.8-debian-10-tarball/versions/0.8.1+131.v0.8.1-beta/otidalplan-0.8.1+131.v0.8.1-beta_debian-10-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> 0dd9729eb7dd695e301397bb0af93626920c514e2b1c5e9f325f005af9ccae39 </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name> Watchdog </name>
@@ -1739,6 +1997,24 @@ OCPN_DRAW (OD) is a plugin that extends the capability of OCPN to include non-st
 https://dl.cloudsmith.io/public/opencpn/ocpn_draw-beta/raw/names/ocpn_draw_pi-1.8.5.2-mingw-x86_64-10-mingw-tarball/versions/1.8.5.2+2386.416b2fe/ocpn_draw_pi-1.8.5.2-mingw-x86_64-10-mingw.tar.gz
 </tarball-url>
     <info-url> https://opencpn.org/OpenCPN/plugins/draw.html </info-url>
+  </plugin>
+  <plugin version="1">
+    <name> otidalplan </name>
+    <version> 0.8.1+127.v0.8.1-beta </version>
+    <release> 1 </release>
+    <summary> Estimating Positions using tidal harmonics </summary>
+    <api-version> 1.16 </api-version>
+    <open-source> yes </open-source>
+    <author> Mike Rossiter </author>
+    <source> https://github.com/Rasbats/otidalplan_pi </source>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:otidalplan </info-url>
+    <description> Calculates Estimated Positions using tidal harmonics.
+ </description>
+    <target>ubuntu-gtk3-x86_64</target>
+    <target-version>20.04</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/otidalplan-beta/raw/names/otidalplan-0.8-ubuntu-gtk3-20.04-tarball/versions/0.8.1+127.v0.8.1-beta/otidalplan-0.8.1+127.v0.8.1-beta_ubuntu-gtk3-20.04-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> 820bdc029f527271020de1add767d2f8804d4912929b75a87d7eccc7979e3622 </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name> OCPN Draw </name>
@@ -1847,6 +2123,25 @@ https://dl.cloudsmith.io/public/opencpn/ocpn_draw-beta/raw/names/ocpn_draw_pi-1.
     <info-url> https://opencpn.org/OpenCPN/plugins/draw.html </info-url>
   </plugin>
   <plugin version="1">
+    <name> UKTides </name>
+    <version> 1.1.2+2540.v1.1.2-beta </version>
+    <release> 1 </release>
+    <summary> Tides for UK Ports </summary>
+    <api-version> 1.16 </api-version>
+    <open-source> yes </open-source>
+    <author> Mike Rossiter </author>
+    <source> https://github.com/Rasbats/UKTides_pi </source>
+    <info-url> https://opencpn.org/OpenCPN/plugins/uktides.html </info-url>
+    <description>
+Tides for 600+ UK Ports from the UKHO
+  </description>
+    <target>ubuntu-x86_64</target>
+    <target-version>18.04</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/uktides-beta/raw/names/UKTides-1.1-ubuntu-18.04-tarball/versions/1.1.2+2540.v1.1.2-beta/UKTides-1.1.2+2540.v1.1.2-beta_ubuntu-18.04-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> 142e081579aa0f8fe9756f4fcf14bb69964e1cb1aa581dbd52184effe9bdf228 </tarball-checksum>
+  </plugin>
+  <plugin version="1">
     <name> pypilot </name>
     <version> 0.22.4.0 </version>
     <release> 0 </release>
@@ -1909,6 +2204,25 @@ OCPN_DRAW (OD) is a plugin that extends the capability of OCPN to include non-st
 https://dl.cloudsmith.io/public/opencpn/ocpn_draw-beta/raw/names/ocpn_draw_pi-1.8.5.2-android-arm64-16-android-arm64-tarball/versions/1.8.5.2+2391.416b2fe/ocpn_draw_pi-1.8.5.2-android-arm64-16-android-arm64.tar.gz
 </tarball-url>
     <info-url> https://opencpn.org/OpenCPN/plugins/draw.html </info-url>
+  </plugin>
+  <plugin version="1">
+    <name> UKTides </name>
+    <version> 1.1.2+2534.v1.1.2-beta </version>
+    <release> 1 </release>
+    <summary> Tides for UK Ports </summary>
+    <api-version> 1.16 </api-version>
+    <open-source> yes </open-source>
+    <author> Mike Rossiter </author>
+    <source> https://github.com/Rasbats/UKTides_pi </source>
+    <info-url> https://opencpn.org/OpenCPN/plugins/uktides.html </info-url>
+    <description>
+Tides for 600+ UK Ports from the UKHO
+  </description>
+    <target>raspbian-armhf</target>
+    <target-version>9.13</target-version>
+    <target-arch>armhf</target-arch>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/uktides-beta/raw/names/UKTides-1.1-raspbian-9.13-tarball/versions/1.1.2+2534.v1.1.2-beta/UKTides-1.1.2+2534.v1.1.2-beta_raspbian-9.13-armhf.tar.gz </tarball-url>
+    <tarball-checksum> 1f58722651eef7e1806131e4b3ddcc75fb66f480a5e78dbd25e38442a094af79 </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name> Watchdog </name>
@@ -2031,5 +2345,61 @@ Control the free software autopilot pypilot. See http://pypilot.org for more det
 https://dl.cloudsmith.io/public/opencpn/pypilot-beta/raw/names/pypilot_pi-0.22.4.0-android-arm64-16-android-arm64-tarball/versions/v0.22.4.0/pypilot_pi-0.22.4.0-android-arm64-16.tar.gz
 </tarball-url>
     <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:safety:odraw1.6_pi </info-url>
+  </plugin>
+  <plugin version="1">
+    <name> UKTides </name>
+    <version> 1.1.2+2537.v1.1.2-beta </version>
+    <release> 1 </release>
+    <summary> Tides for UK Ports </summary>
+    <api-version> 1.16 </api-version>
+    <open-source> yes </open-source>
+    <author> Mike Rossiter </author>
+    <source> https://github.com/Rasbats/UKTides_pi </source>
+    <info-url> https://opencpn.org/OpenCPN/plugins/uktides.html </info-url>
+    <description>
+Tides for 600+ UK Ports from the UKHO
+  </description>
+    <target>ubuntu-gtk3-x86_64</target>
+    <target-version>18.04</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/uktides-beta/raw/names/UKTides-1.1-ubuntu-gtk3-18.04-tarball/versions/1.1.2+2537.v1.1.2-beta/UKTides-1.1.2+2537.v1.1.2-beta_ubuntu-gtk3-18.04-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> 0b0fa9fc6e9cd0b11d303b3bf18a8a2185aedf64748cf86b422f8d93b6bdfe27 </tarball-checksum>
+  </plugin>
+  <plugin version="1">
+    <name> otidalplan </name>
+    <version> 0.8.1+126.v0.8.1-beta </version>
+    <release> 1 </release>
+    <summary> Estimating Positions using tidal harmonics </summary>
+    <api-version> 1.16 </api-version>
+    <open-source> yes </open-source>
+    <author> Mike Rossiter </author>
+    <source> https://github.com/Rasbats/otidalplan_pi </source>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:otidalplan </info-url>
+    <description> Calculates Estimated Positions using tidal harmonics.
+ </description>
+    <target>raspbian-armhf</target>
+    <target-version>9.13</target-version>
+    <target-arch>armhf</target-arch>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/otidalplan-beta/raw/names/otidalplan-0.8-raspbian-9.13-tarball/versions/0.8.1+126.v0.8.1-beta/otidalplan-0.8.1+126.v0.8.1-beta_raspbian-9.13-armhf.tar.gz </tarball-url>
+    <tarball-checksum> 5d84ae9cccb3c348ca97532a67d8e41d45f4352bc59fd6a920dc9017d540296f </tarball-checksum>
+  </plugin>
+  <plugin version="1">
+    <name> UKTides </name>
+    <version> 1.1.2+2533.v1.1.2-beta </version>
+    <release> 1 </release>
+    <summary> Tides for UK Ports </summary>
+    <api-version> 1.16 </api-version>
+    <open-source> yes </open-source>
+    <author> Mike Rossiter </author>
+    <source> https://github.com/Rasbats/UKTides_pi </source>
+    <info-url> https://opencpn.org/OpenCPN/plugins/uktides.html </info-url>
+    <description>
+Tides for 600+ UK Ports from the UKHO
+  </description>
+    <target>darwin</target>
+    <target-version>10.13.6</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/uktides-beta/raw/names/UKTides-1.1-darwin-10.13.6-tarball/versions/1.1.2+2533.v1.1.2-beta/UKTides-1.1.2+2533.v1.1.2-beta_darwin-10.13.6-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> 57ab8f518f0d0238c7169a2dc7b4dfec80a6fba03538c75b20a33ba4c98f8f2b </tarball-checksum>
   </plugin>
 </plugins>


### PR DESCRIPTION
v1.4.3

Sorry... this is to correct a typo. Tide Finder now replaced by TideFinder for the common name. Without this the plugin list had problems.

Dave... Is the Beta Catalog being removed from OpenCPN? Not seen in a recent compilation of the master code.