### PR TITLE
radar_pi 5.2.0-beta4

### DIFF
--- a/cloudsmith-sync.sh
+++ b/cloudsmith-sync.sh
@@ -19,7 +19,13 @@ CLOUDSMITH_REPO="${3}"
 QUERY="${4}"
 TOPDIR="${PWD}"
 
+
+echo "Running: curl -s -S 'https://api.cloudsmith.io/packages/${CLOUDSMITH_USER}/${CLOUDSMITH_REPO}/?page_size=9999&query=${QUERY}'"
+
 cd metadata
+
+rm "${PROJECT}"*.xml 2>/dev/null || :
+
 for url in $(
 curl -s -S "https://api.cloudsmith.io/packages/${CLOUDSMITH_USER}/${CLOUDSMITH_REPO}/?page_size=9999&query=${QUERY}" |
   jq -r '.[] |
@@ -31,5 +37,7 @@ do
   # -r to clobber existing file
   file=$(basename "${url}")
   curl -s -S -o "${file}" "${url}"
-  xmllint --schema "${TOPDIR}/ocpn-plugins.xsd" "${file}"
+  xmllint --schema "${TOPDIR}/ocpn-plugins.xsd" --noout "${file}"
 done
+
+git status

--- a/metadata/radar_pi-5.2.0-beta4-ov51-darwin-10.15.1.xml
+++ b/metadata/radar_pi-5.2.0-beta4-ov51-darwin-10.15.1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name>Radar</name>
-<version>5.2.0-beta3</version>
+<version>5.2.0-beta4</version>
 <release>0</release>
 <summary>Overlays the radar picture on OpenCPN</summary>
 <api-version>1.16</api-version>
@@ -22,9 +22,9 @@ Supports MARPA (even on radars that do not support this themselves),
 Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
 </description>
-<target>ubuntu-gtk3-x86_64</target>
-<target-version>20.04</target-version>
+<target>darwin</target>
+<target-version>10.15.1</target-version>
 <target-arch>x86_64</target-arch>
-<tarball-url>https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/radar-ubuntu-gtk3-x86_64-20.04-tarball/versions/5.2.0-beta3.0.28b90a5/radar_pi-5.2.0-beta3-ov51-ubuntu-gtk3-x86_64-20.04.tar.gz</tarball-url>
+<tarball-url>https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/radar-darwin-10.15.1-tarball/versions/5.2.0-beta4.0.eecba41/radar_pi-5.2.0-beta4-ov51-darwin-10.15.1.tar.gz</tarball-url>
 <info-url>https://opencpn.org/OpenCPN/plugins/radarPI.html</info-url>
 </plugin>

--- a/metadata/radar_pi-5.2.0-beta4-ov51-debian-x86_64-10.xml
+++ b/metadata/radar_pi-5.2.0-beta4-ov51-debian-x86_64-10.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name>Radar</name>
-<version>5.2.0-beta3</version>
+<version>5.2.0-beta4</version>
 <release>0</release>
 <summary>Overlays the radar picture on OpenCPN</summary>
 <api-version>1.16</api-version>
@@ -22,9 +22,9 @@ Supports MARPA (even on radars that do not support this themselves),
 Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
 </description>
-<target>mingw</target>
+<target>debian-x86_64</target>
 <target-version>10</target-version>
 <target-arch>x86_64</target-arch>
-<tarball-url>https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/radar-mingw-10-tarball/versions/5.2.0-beta3.0.28b90a5/radar_pi-5.2.0-beta3-ov51-mingw-10.tar.gz</tarball-url>
+<tarball-url>https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/radar-debian-x86_64-10-tarball/versions/5.2.0-beta4.0.eecba41/radar_pi-5.2.0-beta4-ov51-debian-x86_64-10.tar.gz</tarball-url>
 <info-url>https://opencpn.org/OpenCPN/plugins/radarPI.html</info-url>
 </plugin>

--- a/metadata/radar_pi-5.2.0-beta4-ov51-mingw-10.xml
+++ b/metadata/radar_pi-5.2.0-beta4-ov51-mingw-10.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name>Radar</name>
-<version>5.2.0-beta3</version>
+<version>5.2.0-beta4</version>
 <release>0</release>
 <summary>Overlays the radar picture on OpenCPN</summary>
 <api-version>1.16</api-version>
@@ -22,9 +22,9 @@ Supports MARPA (even on radars that do not support this themselves),
 Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
 </description>
-<target>raspbian-armhf</target>
-<target-version>9.4</target-version>
-<target-arch>armhf</target-arch>
-<tarball-url>https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/radar-raspbian-armhf-9.4-tarball/versions/5.2.0-beta3.0.28b90a5/radar_pi-5.2.0-beta3-ov51-raspbian-armhf-9.4.tar.gz</tarball-url>
+<target>mingw</target>
+<target-version>10</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/radar-mingw-10-tarball/versions/5.2.0-beta4.0.eecba41/radar_pi-5.2.0-beta4-ov51-mingw-10.tar.gz</tarball-url>
 <info-url>https://opencpn.org/OpenCPN/plugins/radarPI.html</info-url>
 </plugin>

--- a/metadata/radar_pi-5.2.0-beta4-ov51-msvc-10.0.14393.xml
+++ b/metadata/radar_pi-5.2.0-beta4-ov51-msvc-10.0.14393.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name>Radar</name>
-<version>5.2.0-beta3</version>
+<version>5.2.0-beta4</version>
 <release>0</release>
 <summary>Overlays the radar picture on OpenCPN</summary>
 <api-version>1.16</api-version>
@@ -22,9 +22,9 @@ Supports MARPA (even on radars that do not support this themselves),
 Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
 </description>
-<target>raspbian-armhf</target>
-<target-version>10</target-version>
-<target-arch>armhf</target-arch>
-<tarball-url>https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/radar-raspbian-armhf-10-tarball/versions/5.2.0-beta3.0.28b90a5/radar_pi-5.2.0-beta3-ov51-raspbian-armhf-10.tar.gz</tarball-url>
+<target>msvc</target>
+<target-version>10.0.14393</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/radar-msvc-10.0.14393-tarball/versions/5.2.0-beta4.0.eecba41/radar_pi-5.2.0-beta4-ov51-msvc-10.0.14393.tar.gz</tarball-url>
 <info-url>https://opencpn.org/OpenCPN/plugins/radarPI.html</info-url>
 </plugin>

--- a/metadata/radar_pi-5.2.0-beta4-ov51-raspbian-armhf-10.xml
+++ b/metadata/radar_pi-5.2.0-beta4-ov51-raspbian-armhf-10.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name>Radar</name>
-<version>5.2.0-beta3</version>
+<version>5.2.0-beta4</version>
 <release>0</release>
 <summary>Overlays the radar picture on OpenCPN</summary>
 <api-version>1.16</api-version>
@@ -22,9 +22,9 @@ Supports MARPA (even on radars that do not support this themselves),
 Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
 </description>
-<target>darwin</target>
-<target-version>10.15.1</target-version>
-<target-arch>x86_64</target-arch>
-<tarball-url>https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/radar-darwin-10.15.1-tarball/versions/5.2.0-beta3.0.28b90a5/radar_pi-5.2.0-beta3-ov51-darwin-10.15.1.tar.gz</tarball-url>
+<target>raspbian-armhf</target>
+<target-version>10</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/radar-raspbian-armhf-10-tarball/versions/5.2.0-beta4.0.eecba41/radar_pi-5.2.0-beta4-ov51-raspbian-armhf-10.tar.gz</tarball-url>
 <info-url>https://opencpn.org/OpenCPN/plugins/radarPI.html</info-url>
 </plugin>

--- a/metadata/radar_pi-5.2.0-beta4-ov51-raspbian-armhf-9.4.xml
+++ b/metadata/radar_pi-5.2.0-beta4-ov51-raspbian-armhf-9.4.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name>Radar</name>
-<version>5.2.0-beta3</version>
+<version>5.2.0-beta4</version>
 <release>0</release>
 <summary>Overlays the radar picture on OpenCPN</summary>
 <api-version>1.16</api-version>
@@ -22,9 +22,9 @@ Supports MARPA (even on radars that do not support this themselves),
 Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
 </description>
-<target>msvc</target>
-<target-version>10.0.14393</target-version>
-<target-arch>x86_64</target-arch>
-<tarball-url>https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/radar-msvc-10.0.14393-tarball/versions/5.2.0-beta3.0.28b90a5/radar_pi-5.2.0-beta3-ov51-msvc-10.0.14393.tar.gz</tarball-url>
+<target>raspbian-armhf</target>
+<target-version>9.4</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/radar-raspbian-armhf-9.4-tarball/versions/5.2.0-beta4.0.eecba41/radar_pi-5.2.0-beta4-ov51-raspbian-armhf-9.4.tar.gz</tarball-url>
 <info-url>https://opencpn.org/OpenCPN/plugins/radarPI.html</info-url>
 </plugin>

--- a/metadata/radar_pi-5.2.0-beta4-ov51-ubuntu-gtk3-x86_64-20.04.xml
+++ b/metadata/radar_pi-5.2.0-beta4-ov51-ubuntu-gtk3-x86_64-20.04.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name>Radar</name>
-<version>5.2.0-beta3</version>
+<version>5.2.0-beta4</version>
 <release>0</release>
 <summary>Overlays the radar picture on OpenCPN</summary>
 <api-version>1.16</api-version>
@@ -22,9 +22,9 @@ Supports MARPA (even on radars that do not support this themselves),
 Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
 </description>
-<target>debian-x86_64</target>
-<target-version>10</target-version>
+<target>ubuntu-gtk3-x86_64</target>
+<target-version>20.04</target-version>
 <target-arch>x86_64</target-arch>
-<tarball-url>https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/radar-debian-x86_64-10-tarball/versions/5.2.0-beta3.0.28b90a5/radar_pi-5.2.0-beta3-ov51-debian-x86_64-10.tar.gz</tarball-url>
+<tarball-url>https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/radar-ubuntu-gtk3-x86_64-20.04-tarball/versions/5.2.0-beta4.0.eecba41/radar_pi-5.2.0-beta4-ov51-ubuntu-gtk3-x86_64-20.04.tar.gz</tarball-url>
 <info-url>https://opencpn.org/OpenCPN/plugins/radarPI.html</info-url>
 </plugin>

--- a/metadata/radar_pi-5.2.0-beta4-ov51-ubuntu-x86_64-16.04.xml
+++ b/metadata/radar_pi-5.2.0-beta4-ov51-ubuntu-x86_64-16.04.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name>Radar</name>
-<version>5.2.0-beta3</version>
+<version>5.2.0-beta4</version>
 <release>0</release>
 <summary>Overlays the radar picture on OpenCPN</summary>
 <api-version>1.16</api-version>
@@ -25,6 +25,6 @@ such as dual radar range and Doppler.
 <target>ubuntu-x86_64</target>
 <target-version>16.04</target-version>
 <target-arch>x86_64</target-arch>
-<tarball-url>https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/radar-ubuntu-x86_64-16.04-tarball/versions/5.2.0-beta3.0.28b90a5/radar_pi-5.2.0-beta3-ov51-ubuntu-x86_64-16.04.tar.gz</tarball-url>
+<tarball-url>https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/radar-ubuntu-x86_64-16.04-tarball/versions/5.2.0-beta4.0.eecba41/radar_pi-5.2.0-beta4-ov51-ubuntu-x86_64-16.04.tar.gz</tarball-url>
 <info-url>https://opencpn.org/OpenCPN/plugins/radarPI.html</info-url>
 </plugin>

--- a/metadata/radar_pi-5.2.0-beta4-ov51-ubuntu-x86_64-18.04.xml
+++ b/metadata/radar_pi-5.2.0-beta4-ov51-ubuntu-x86_64-18.04.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name>Radar</name>
-<version>5.2.0-beta3</version>
+<version>5.2.0-beta4</version>
 <release>0</release>
 <summary>Overlays the radar picture on OpenCPN</summary>
 <api-version>1.16</api-version>
@@ -25,6 +25,6 @@ such as dual radar range and Doppler.
 <target>ubuntu-x86_64</target>
 <target-version>18.04</target-version>
 <target-arch>x86_64</target-arch>
-<tarball-url>https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/radar-ubuntu-x86_64-18.04-tarball/versions/5.2.0-beta3.0.28b90a5/radar_pi-5.2.0-beta3-ov51-ubuntu-x86_64-18.04.tar.gz</tarball-url>
+<tarball-url>https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/radar-ubuntu-x86_64-18.04-tarball/versions/5.2.0-beta4.0.eecba41/radar_pi-5.2.0-beta4-ov51-ubuntu-x86_64-18.04.tar.gz</tarball-url>
 <info-url>https://opencpn.org/OpenCPN/plugins/radarPI.html</info-url>
 </plugin>


### PR DESCRIPTION
Another beta for the plugin. This fixes version number detection on newer HALOs and enables Doppler in a non-chartplotter scenario.