### PR TITLE
Update for ShipDriver following attempts to rectify Raspbian problems

### DIFF
--- a/metadata/ShipDriver-2.7-android-arm64-A64-16.xml
+++ b/metadata/ShipDriver-2.7-android-arm64-A64-16.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+  <name> ShipDriver </name>
+  <version> 2.7.1.0-+3290.v2.7.1.0 </version>
+  <release> 0 </release>
+  <summary> Simulate ship movements </summary>
+
+  <api-version> 1.16 </api-version>
+  <open-source> yes </open-source>
+  <author> Mike Rossiter </author>
+  <source> https://github.com/Rasbats/shipdriver_pi </source>
+  <info-url> https://opencpn.org/OpenCPN/plugins/shipdriver.html </info-url>
+
+  <description> Simulates navigation of a vessel. Using the sail option and a current
+grib file for wind data, simulates how a sailing vessel might react in
+those conditions. Using 'Preferences' the simulator is able to record AIS
+data from itself. This can be replayed to simulate collision situations.
+ </description>
+
+  <target>android-arm64</target>
+  <target-version>16</target-version>
+  <target-arch>arm64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-android-arm64-A64-16-tarball/versions/2.7.1.0-+3290.v2.7.1.0/ShipDriver-2.7.1.0-+3290.v2.7.1.0_android-arm64-16-arm64.tar.gz </tarball-url>
+  <tarball-checksum> 31dfd09bc150cc100dbe734a9b5f7059e6bdf0bacce037cd8a1555e64dc9929c </tarball-checksum>
+</plugin>

--- a/metadata/ShipDriver-2.7-android-armhf-16.xml
+++ b/metadata/ShipDriver-2.7-android-armhf-16.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> 2.6.2.0+1854.v2.6.2.0 </version>
-  <release> 1 </release>
-  <summary> Ship movements simulator - or is it a game? </summary>
+  <version> 2.7.1.0-+3295.v2.7.1.0 </version>
+  <release> 0 </release>
+  <summary> Simulate ship movements </summary>
 
   <api-version> 1.16 </api-version>
   <open-source> yes </open-source>
@@ -17,9 +17,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>flatpak-x86_64</target>
-  <target-version>18.08</target-version>
-  <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.6-flatpak-18.08-tarball/versions/2.6.2.0+1854.v2.6.2.0/ShipDriver-2.6.2.0+1854.v2.6.2.0_flatpak-18.08-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 5235fc26ff03b4c4aa6ae730518c3218b7e8cc43b703d64aade639493198e915 </tarball-checksum>
+  <target>android-armhf</target>
+  <target-version>16</target-version>
+  <target-arch>armhf</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-android-armhf-16-tarball/versions/2.7.1.0-+3295.v2.7.1.0/ShipDriver-2.7.1.0-+3295.v2.7.1.0_android-armhf-16-armhf.tar.gz </tarball-url>
+  <tarball-checksum> a8ce5da8cd6149a827ef14039a43d0f63b3717de8ebdfa1ed4c4705efc98c233 </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-2.7-darwin-10.13.6.xml
+++ b/metadata/ShipDriver-2.7-darwin-10.13.6.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> 2.6.2.0+1850.v2.6.2.0 </version>
-  <release> 1 </release>
-  <summary> Ship movements simulator - or is it a game? </summary>
+  <version> 2.7.1.0-+3289.v2.7.1.0 </version>
+  <release> 0 </release>
+  <summary> Simulate ship movements </summary>
 
   <api-version> 1.16 </api-version>
   <open-source> yes </open-source>
@@ -17,9 +17,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>raspbian-armhf</target>
-  <target-version>9.13</target-version>
-  <target-arch>armhf</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.6-raspbian-9.13-tarball/versions/2.6.2.0+1850.v2.6.2.0/ShipDriver-2.6.2.0+1850.v2.6.2.0_raspbian-9.13-armhf.tar.gz </tarball-url>
-  <tarball-checksum> c127044e5b09cb0746d79742e83c3e5beac43e72617553c63229be61cb11fcc4 </tarball-checksum>
+  <target>darwin</target>
+  <target-version>10.13.6</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-darwin-10.13.6-tarball/versions/2.7.1.0-+3289.v2.7.1.0/ShipDriver-2.7.1.0-+3289.v2.7.1.0_darwin-10.13.6-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 594335989e7f280e7b1c03c7e75455bf7d41268654e2a10ced9bbef87ad51e69 </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-2.7-debian-10.xml
+++ b/metadata/ShipDriver-2.7-debian-10.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> 2.6.2.0+368.v2.6.2.0 </version>
-  <release> 1 </release>
-  <summary> Ship movements simulator - or is it a game? </summary>
+  <version> 2.7.1.0-+3291.v2.7.1.0 </version>
+  <release> 0 </release>
+  <summary> Simulate ship movements </summary>
 
   <api-version> 1.16 </api-version>
   <open-source> yes </open-source>
@@ -17,9 +17,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>msvc</target>
-  <target-version>10.0.14393</target-version>
+  <target>debian-x86_64</target>
+  <target-version>10</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.6-msvc-10.0.14393-tarball/versions/2.6.2.0+368.v2.6.2.0/ShipDriver-2.6.2.0+368.v2.6.2.0_msvc-10.0.14393-win32.tar.gz </tarball-url>
-  <tarball-checksum> aae346e7b22c273c66a3a65ff7f1481dc1410f8db4dfc14e154a711d9dd23697 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-debian-10-tarball/versions/2.7.1.0-+3291.v2.7.1.0/ShipDriver-2.7.1.0-+3291.v2.7.1.0_debian-10-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> b37390e17b7a4c841e1eaff4b1a7d7a89c3cf94209f5afb9571a5da10e3dccd8 </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-2.7-flatpak-18.08.xml
+++ b/metadata/ShipDriver-2.7-flatpak-18.08.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> 2.6.2.0+1852.v2.6.2.0 </version>
-  <release> 1 </release>
-  <summary> Ship movements simulator - or is it a game? </summary>
+  <version> 2.7.1.0-+3294.v2.7.1.0 </version>
+  <release> 0 </release>
+  <summary> Simulate ship movements </summary>
 
   <api-version> 1.16 </api-version>
   <open-source> yes </open-source>
@@ -17,9 +17,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>raspbian-armhf</target>
-  <target-version>10</target-version>
-  <target-arch>armhf</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.6-raspbian-10-tarball/versions/2.6.2.0+1852.v2.6.2.0/ShipDriver-2.6.2.0+1852.v2.6.2.0_raspbian-10-armhf.tar.gz </tarball-url>
-  <tarball-checksum> 52d83158fd651c3c1c89a55c1f1e69a6c8f8bd9f72a2aeee832e5df5c8b8997b </tarball-checksum>
+  <target>flatpak-x86_64</target>
+  <target-version>18.08</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-flatpak-18.08-tarball/versions/2.7.1.0-+3294.v2.7.1.0/ShipDriver-2.7.1.0-+3294.v2.7.1.0_flatpak-18.08-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> f5fb849f5ac89ec9abd3a373285773bf93daa431cdcde3e3176d3dfbfed6af5c </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-2.7-flatpak-20.08.xml
+++ b/metadata/ShipDriver-2.7-flatpak-20.08.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> 2.6.2.0+1849.v2.6.2.0 </version>
-  <release> 1 </release>
-  <summary> Ship movements simulator - or is it a game? </summary>
+  <version> 2.7.1.0-+3292.v2.7.1.0 </version>
+  <release> 0 </release>
+  <summary> Simulate ship movements </summary>
 
   <api-version> 1.16 </api-version>
   <open-source> yes </open-source>
@@ -17,9 +17,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>ubuntu-x86_64</target>
-  <target-version>18.04</target-version>
+  <target>flatpak-x86_64</target>
+  <target-version>20.08</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.6-ubuntu-18.04-tarball/versions/2.6.2.0+1849.v2.6.2.0/ShipDriver-2.6.2.0+1849.v2.6.2.0_ubuntu-18.04-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 8429cd28ed2411a72cf26a6a79801e6faf5aa8243f4d0ee25656c8f518fa8ec1 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-flatpak-20.08-tarball/versions/2.7.1.0-+3292.v2.7.1.0/ShipDriver-2.7.1.0-+3292.v2.7.1.0_flatpak-20.08-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 510d27b86f47010dba634783d84e8403096602362ebd2a67ec5028058eb8ee93 </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-2.7-flatpak-A64-20.08.xml
+++ b/metadata/ShipDriver-2.7-flatpak-A64-20.08.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> 2.6.2.0+1847.v2.6.2.0 </version>
-  <release> 1 </release>
-  <summary> Ship movements simulator - or is it a game? </summary>
+  <version> 2.7.1.0-+3286.v2.7.1.0 </version>
+  <release> 0 </release>
+  <summary> Simulate ship movements </summary>
 
   <api-version> 1.16 </api-version>
   <open-source> yes </open-source>
@@ -17,9 +17,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>mingw-x86_64</target>
-  <target-version>10</target-version>
-  <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.6-mingw-10-tarball/versions/2.6.2.0+1847.v2.6.2.0/ShipDriver-2.6.2.0+1847.v2.6.2.0_mingw-10-win32.tar.gz </tarball-url>
-  <tarball-checksum> d59466980f737d81cc1f76c3011216e8ac753d9e0875ece06c4347cd176af670 </tarball-checksum>
+  <target>flatpak-aarch64</target>
+  <target-version>20.08</target-version>
+  <target-arch>aarch64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-flatpak-A64-20.08-tarball/versions/2.7.1.0-+3286.v2.7.1.0/ShipDriver-2.7.1.0-+3286.v2.7.1.0_flatpak-20.08-aarch64.tar.gz </tarball-url>
+  <tarball-checksum> 47805703a08362238ab962a5ab27a178ca982613f0452ccba6e8031581855a70 </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-2.7-msvc-10.0.14393.xml
+++ b/metadata/ShipDriver-2.7-msvc-10.0.14393.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+  <name> ShipDriver </name>
+  <version> 2.7.1.0-+610.v2.7.1.0 </version>
+  <release> 0 </release>
+  <summary> Simulate ship movements </summary>
+
+  <api-version> 1.16 </api-version>
+  <open-source> yes </open-source>
+  <author> Mike Rossiter </author>
+  <source> https://github.com/Rasbats/shipdriver_pi </source>
+  <info-url> https://opencpn.org/OpenCPN/plugins/shipdriver.html </info-url>
+
+  <description> Simulates navigation of a vessel. Using the sail option and a current
+grib file for wind data, simulates how a sailing vessel might react in
+those conditions. Using 'Preferences' the simulator is able to record AIS
+data from itself. This can be replayed to simulate collision situations.
+ </description>
+
+  <target>msvc</target>
+  <target-version>10.0.14393</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-msvc-10.0.14393-tarball/versions/2.7.1.0-+610.v2.7.1.0/ShipDriver-2.7.1.0-+610.v2.7.1.0_msvc-10.0.14393-win32.tar.gz </tarball-url>
+  <tarball-checksum> 39571b1df74be3109a298ad07e88ef983b74a7313b30ac31bbb9b41e0bf348dc </tarball-checksum>
+</plugin>

--- a/metadata/ShipDriver-2.7-raspbian-10.xml
+++ b/metadata/ShipDriver-2.7-raspbian-10.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> 2.6.2.0+1856.v2.6.2.0 </version>
-  <release> 1 </release>
-  <summary> Ship movements simulator - or is it a game? </summary>
+  <version> 2.7.1.0-+2106281409.fe00561 </version>
+  <release> 0 </release>
+  <summary> Simulate ship movements </summary>
 
   <api-version> 1.16 </api-version>
   <open-source> yes </open-source>
@@ -17,9 +17,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>ubuntu-x86_64</target>
-  <target-version>16.04</target-version>
-  <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.6-ubuntu-16.04-tarball/versions/2.6.2.0+1856.v2.6.2.0/ShipDriver-2.6.2.0+1856.v2.6.2.0_ubuntu-16.04-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> b8b5992f6c7b5b5a8811296e65dc2f99e9b3cdb2454328eb4584d6898ca861d0 </tarball-checksum>
+  <target>raspbian-armhf</target>
+  <target-version>10</target-version>
+  <target-arch>armhf</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-alpha/raw/names/ShipDriver-2.7-raspbian-10-tarball/versions/2.7.1.0-+2106281409.fe00561/ShipDriver-2.7.1.0-+2106281409.fe00561_raspbian-10-armhf.tar.gz </tarball-url>
+  <tarball-checksum> ae94108d4a26e0e8a36d06b8429bc1a11518fbc2c138698e7a71034fc2d82929 </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-2.7-raspbian-9.13.xml
+++ b/metadata/ShipDriver-2.7-raspbian-9.13.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> 2.6.2.0+1848.v2.6.2.0 </version>
-  <release> 1 </release>
-  <summary> Ship movements simulator - or is it a game? </summary>
+  <version> 2.7.1.0-+2106281409.fe00561 </version>
+  <release> 0 </release>
+  <summary> Simulate ship movements </summary>
 
   <api-version> 1.16 </api-version>
   <open-source> yes </open-source>
@@ -17,9 +17,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>ubuntu-gtk3-x86_64</target>
-  <target-version>18.04</target-version>
-  <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.6-ubuntu-gtk3-18.04-tarball/versions/2.6.2.0+1848.v2.6.2.0/ShipDriver-2.6.2.0+1848.v2.6.2.0_ubuntu-gtk3-18.04-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 9492ac8da86d3309bb1d8dbe9e0be6e91ecfe6d9a9f6973fd64dce4789c4ee32 </tarball-checksum>
+  <target>raspbian-armhf</target>
+  <target-version>9.13</target-version>
+  <target-arch>armhf</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-alpha/raw/names/ShipDriver-2.7-raspbian-9.13-tarball/versions/2.7.1.0-+2106281409.fe00561/ShipDriver-2.7.1.0-+2106281409.fe00561_raspbian-9.13-armhf.tar.gz </tarball-url>
+  <tarball-checksum> df7effb4376c255c640f01d9a105f5037e4e3b74faf08df98ed012ff6cf834eb </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-2.7-ubuntu-16.04.xml
+++ b/metadata/ShipDriver-2.7-ubuntu-16.04.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> 2.6.2.0+1855.v2.6.2.0 </version>
-  <release> 1 </release>
-  <summary> Ship movements simulator - or is it a game? </summary>
+  <version> 2.7.1.0-+3293.v2.7.1.0 </version>
+  <release> 0 </release>
+  <summary> Simulate ship movements </summary>
 
   <api-version> 1.16 </api-version>
   <open-source> yes </open-source>
@@ -17,9 +17,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>ubuntu-gtk3-x86_64</target>
-  <target-version>20.04</target-version>
+  <target>ubuntu-x86_64</target>
+  <target-version>16.04</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.6-ubuntu-gtk3-20.04-tarball/versions/2.6.2.0+1855.v2.6.2.0/ShipDriver-2.6.2.0+1855.v2.6.2.0_ubuntu-gtk3-20.04-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 9895043410ca5f1a2021ecd5b1f498bbda8f089ebbf39d6f1a3c71a5789cec01 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-ubuntu-16.04-tarball/versions/2.7.1.0-+3293.v2.7.1.0/ShipDriver-2.7.1.0-+3293.v2.7.1.0_ubuntu-16.04-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 2fa3e1ad67714d0262dd14410c775855ab40ce58441240998acaec1b330853b2 </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-2.7-ubuntu-18.04.xml
+++ b/metadata/ShipDriver-2.7-ubuntu-18.04.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+  <name> ShipDriver </name>
+  <version> 2.7.1.0-+3288.v2.7.1.0 </version>
+  <release> 0 </release>
+  <summary> Simulate ship movements </summary>
+
+  <api-version> 1.16 </api-version>
+  <open-source> yes </open-source>
+  <author> Mike Rossiter </author>
+  <source> https://github.com/Rasbats/shipdriver_pi </source>
+  <info-url> https://opencpn.org/OpenCPN/plugins/shipdriver.html </info-url>
+
+  <description> Simulates navigation of a vessel. Using the sail option and a current
+grib file for wind data, simulates how a sailing vessel might react in
+those conditions. Using 'Preferences' the simulator is able to record AIS
+data from itself. This can be replayed to simulate collision situations.
+ </description>
+
+  <target>ubuntu-x86_64</target>
+  <target-version>18.04</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-ubuntu-18.04-tarball/versions/2.7.1.0-+3288.v2.7.1.0/ShipDriver-2.7.1.0-+3288.v2.7.1.0_ubuntu-18.04-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> b109700751b7e15330c47ada4e1912e905dd0c9a8cf855a1841734f2254725e4 </tarball-checksum>
+</plugin>

--- a/metadata/ShipDriver-2.7-ubuntu-gtk3-18.04.xml
+++ b/metadata/ShipDriver-2.7-ubuntu-gtk3-18.04.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> 2.6.2.0+1853.v2.6.2.0 </version>
-  <release> 1 </release>
-  <summary> Ship movements simulator - or is it a game? </summary>
+  <version> 2.7.1.0-+3285.v2.7.1.0 </version>
+  <release> 0 </release>
+  <summary> Simulate ship movements </summary>
 
   <api-version> 1.16 </api-version>
   <open-source> yes </open-source>
@@ -17,9 +17,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>debian-x86_64</target>
-  <target-version>10</target-version>
+  <target>ubuntu-gtk3-x86_64</target>
+  <target-version>18.04</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.6-debian-10-tarball/versions/2.6.2.0+1853.v2.6.2.0/ShipDriver-2.6.2.0+1853.v2.6.2.0_debian-10-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 315c213c90905b022d6a592a2eeb8e38ab92e48d8f80393fa41ff6a1b1cfc911 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-ubuntu-gtk3-18.04-tarball/versions/2.7.1.0-+3285.v2.7.1.0/ShipDriver-2.7.1.0-+3285.v2.7.1.0_ubuntu-gtk3-18.04-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> f4c4e0f7c9a0aeba9723a91ea035d598448537f22c0c28e6ca1109554a1eba67 </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-2.7-ubuntu-gtk3-20.04.xml
+++ b/metadata/ShipDriver-2.7-ubuntu-gtk3-20.04.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> 2.6.2.0+1851.v2.6.2.0 </version>
-  <release> 1 </release>
-  <summary> Ship movements simulator - or is it a game? </summary>
+  <version> 2.7.1.0-+3287.v2.7.1.0 </version>
+  <release> 0 </release>
+  <summary> Simulate ship movements </summary>
 
   <api-version> 1.16 </api-version>
   <open-source> yes </open-source>
@@ -17,9 +17,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>darwin</target>
-  <target-version>10.13.6</target-version>
+  <target>ubuntu-gtk3-x86_64</target>
+  <target-version>20.04</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.6-darwin-10.13.6-tarball/versions/2.6.2.0+1851.v2.6.2.0/ShipDriver-2.6.2.0+1851.v2.6.2.0_darwin-10.13.6-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 45ec6f3c1e20a5d3377d72aaa0994b7e60c501977b6de5ad006e265e27b62a5c </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-ubuntu-gtk3-20.04-tarball/versions/2.7.1.0-+3287.v2.7.1.0/ShipDriver-2.7.1.0-+3287.v2.7.1.0_ubuntu-gtk3-20.04-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 4593d28c9a4efab2f92fa640de2c7e3d7acefd3bb7a04e2b8be1cf2ced8359fd </tarball-checksum>
 </plugin>


### PR DESCRIPTION
Raspbian still not building a prod version with Drone.io, only making an alpha in Cloudsmith. tbc.