### PR TITLE
Alpha - update rg & jg meta-urls to be for Alpha branch and new xsd format

### DIFF
--- a/metadata/meta-url-alpha-rg-plugins.xml
+++ b/metadata/meta-url-alpha-rg-plugins.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <opencpn-plugin version="1">
-  <name> Jon Gough Alpha ODraw Plugin meta-url </name>
+  <name> Rick Gleason Alpha Plugins meta-url </name>
   <version> 1.0 </version>
   <release> 0 </release>
-  <summary> meta-url to Jon's Alpha Plugin ocpn_draw_pi </summary>
+  <summary> meta-url rgleason Alpha Plugins </summary>
   <api-version>  </api-version>
   <open-source> yes </open-source>
   <author>  </author>
@@ -13,5 +13,5 @@
   <target-version> </target-version>
   <target-arch>noarch</target-arch>
   <tarball-url>  </tarball-url>
-  <meta-url> https://raw.githubusercontent.com/jongough/plugins/Alpha/ocpn-plugins.xml </meta-url>
+  <meta-url> https://raw.githubusercontent.com/rgleason/plugins/Alpha/ocpn-plugins.xml </meta-url>
 </opencpn-plugin>

--- a/ocpn-plugins.xml
+++ b/ocpn-plugins.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <plugins>
   <version>0.0.0</version>
-  <date>2021-07-23 13:42</date>
+  <date>2021-07-26 00:02</date>
   <plugin version="1">
     <name> OCPN Draw </name>
     <version> 1.8.6.9 </version>


### PR DESCRIPTION
Thanks bdbcat.