### PR TITLE
ci: Add an automated ci url check.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,6 @@ jobs:
   urlcheck:
     docker:
       - image: circleci/buildpack-deps:focal-scm
-    environment:
-      - OCPN_TARGET: focal
     steps:
       - checkout
       - run: tools/ci-check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,17 @@
+---
+version: 2.1
+
+jobs:
+  urlcheck:
+    docker:
+      - image: circleci/buildpack-deps:focal-scm
+    environment:
+      - OCPN_TARGET: focal
+    steps:
+      - checkout
+      - run: tools/ci-check
+workflows:
+  version: 2
+  build_all:
+    jobs:
+      - urlcheck

--- a/tools/ci-check
+++ b/tools/ci-check
@@ -13,9 +13,17 @@ if ! git ls-remote --exit-code --heads upstream $branch; then
 fi
 git fetch upstream $branch
 
+if [ "$(git rev-parse upstream/$branch)" = "$(git rev-parse HEAD)" ]; then
+    base=$(git hash-object -t tree /dev/null)  # compare against an empty tree
+else
+    base="upstream/$branch"
+fi
+
 topdir=$(git rev-parse --show-toplevel)
-for f in $(git diff --name-only --diff-filter=ACMR upstream/$branch HEAD); do
+return_code=0
+for f in $(git diff --name-only --diff-filter=ACMR $base HEAD); do
     if [[ $f != *.xml ]]; then continue; fi
-    xmllint --schema $topdir/ocpn-plugin.xsd  $f --noout || exit 1
-    python $topdir/tools/check-metadata-urls $f || exit 1
+    xmllint --schema $topdir/ocpn-plugin.xsd  $f --noout || return_code=1
+    python $topdir/tools/check-metadata-urls $f || return_code=1
 done
+exit $return_code

--- a/tools/ci-check
+++ b/tools/ci-check
@@ -7,6 +7,10 @@ sudo apt install -y libxml2-utils python3
 sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.*  2
 
 git remote add upstream https://github.com/OpenCPN/plugins.git
+if ! git ls-remote --exit-code --heads upstream $branch; then
+    echo "Branch $branch can not be found on upstream, no checks done"
+    exit 0;
+fi
 git fetch upstream $branch
 
 topdir=$(git rev-parse --show-toplevel)

--- a/tools/ci-check
+++ b/tools/ci-check
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+branch=$CIRCLE_BRANCH
+
+sudo apt update
+sudo apt install -y libxml2-utils python3
+sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.*  2
+
+git remote add upstream https://github.com/OpenCPN/plugins.git
+git fetch upstream $branch
+
+topdir=$(git rev-parse --show-toplevel)
+for f in $(git diff --name-only --diff-filter=ACMR upstream/$branch HEAD); do
+    if [[ $f != *.xml ]]; then continue; fi
+    xmllint --schema $topdir/ocpn-plugin.xsd  $f --noout || exit 1
+    python $topdir/tools/check-metadata-urls $f || exit 1
+done


### PR DESCRIPTION
Add a circleci job which checks all updated urls (as compared with upstream).

Obviously, this means that circleci must be configured to build this project, but that should be enough to have all PR:s checked.

This approach actually allows checking also checksums (which means downloading all plugins and comparing). it's a bit slow, but it should be acceptable in this context. 