### PR TITLE
Add a nightly metadata check (#383)

### DIFF
--- a/.github/workflows/cronjob.yml
+++ b/.github/workflows/cronjob.yml
@@ -1,0 +1,12 @@
+---
+name: Nightly check
+on:
+  schedule:
+    - cron: '55 5 * * *'
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check metadata
+        run: tools/check-metadata-urls metadata/*xml


### PR DESCRIPTION
Add a nightly job which checks for broken metadata urls. This should
pick up cases where urls was ok when merged into the catalog, but later
broken when tarballs disappear from cloudsmith (which seems to happen).

An example on output is available at
https://github.com/leamas/plugins/runs/3283583545?check_suite_focus=true

This is the last part of planned PRs to handle #383