### PR TITLE
Create ShipDriver v2.8.6 in master catalog

### DIFF
--- a/metadata/ShipDriver-v2.8.6.0-android-arm64-A64-16.xml
+++ b/metadata/ShipDriver-v2.8.6.0-android-arm64-A64-16.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/3883 -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> 2.7.1.0-+3288.v2.7.1.0 </version>
+  <version> 2.8.6.0+3883.v2.8.6.0 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -17,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>ubuntu-x86_64</target>
-  <target-version>18.04</target-version>
-  <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-ubuntu-18.04-tarball/versions/2.7.1.0-+3288.v2.7.1.0/ShipDriver-2.7.1.0-+3288.v2.7.1.0_ubuntu-18.04-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> b109700751b7e15330c47ada4e1912e905dd0c9a8cf855a1841734f2254725e4 </tarball-checksum>
+  <target>android-arm64</target>
+  <target-version>16</target-version>
+  <target-arch>arm64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-android-arm64-A64-16-tarball/versions/2.8.6.0+3883.v2.8.6.0/ShipDriver-v2.8.6.0_android-arm64-16-arm64.tar.gz </tarball-url>
+  <tarball-checksum> 40c5d008bb9eacbd3206ba4ad524424352f3e7c6d37e1197f63b8cceabe744e7 </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v2.8.6.0-android-armhf-16.xml
+++ b/metadata/ShipDriver-v2.8.6.0-android-armhf-16.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/3890 -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> 2.7.1.0-+610.v2.7.1.0 </version>
+  <version> 2.8.6.0+3890.v2.8.6.0 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -17,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>msvc</target>
-  <target-version>10.0.14393</target-version>
-  <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-msvc-10.0.14393-tarball/versions/2.7.1.0-+610.v2.7.1.0/ShipDriver-2.7.1.0-+610.v2.7.1.0_msvc-10.0.14393-win32.tar.gz </tarball-url>
-  <tarball-checksum> 39571b1df74be3109a298ad07e88ef983b74a7313b30ac31bbb9b41e0bf348dc </tarball-checksum>
+  <target>android-armhf</target>
+  <target-version>16</target-version>
+  <target-arch>armhf</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-android-armhf-16-tarball/versions/2.8.6.0+3890.v2.8.6.0/ShipDriver-v2.8.6.0_android-armhf-16-armhf.tar.gz </tarball-url>
+  <tarball-checksum> 7c868d9269b74d4bea58386c0a3973765c5cf37008c5e37fdaaedbb151f4d646 </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v2.8.6.0-darwin-10.13.6.xml
+++ b/metadata/ShipDriver-v2.8.6.0-darwin-10.13.6.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/3884 -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> 2.7.1.0-+3294.v2.7.1.0 </version>
+  <version> 2.8.6.0+3884.v2.8.6.0 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -17,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>flatpak-x86_64</target>
-  <target-version>18.08</target-version>
+  <target>darwin</target>
+  <target-version>10.13.6</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-flatpak-18.08-tarball/versions/2.7.1.0-+3294.v2.7.1.0/ShipDriver-2.7.1.0-+3294.v2.7.1.0_flatpak-18.08-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> f5fb849f5ac89ec9abd3a373285773bf93daa431cdcde3e3176d3dfbfed6af5c </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-darwin-10.13.6-tarball/versions/2.8.6.0+3884.v2.8.6.0/ShipDriver-v2.8.6.0_darwin-10.13.6-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 05ae4873a8199a2d857aa5d824e77e72bb88ab7b8248c315303f7653f1243b6e </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v2.8.6.0-debian-10.xml
+++ b/metadata/ShipDriver-v2.8.6.0-debian-10.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/3881 -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> 2.7.1.0-+3291.v2.7.1.0 </version>
+  <version> 2.8.6.0+3881.v2.8.6.0 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -20,6 +21,6 @@ data from itself. This can be replayed to simulate collision situations.
   <target>debian-x86_64</target>
   <target-version>10</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-debian-10-tarball/versions/2.7.1.0-+3291.v2.7.1.0/ShipDriver-2.7.1.0-+3291.v2.7.1.0_debian-10-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> b37390e17b7a4c841e1eaff4b1a7d7a89c3cf94209f5afb9571a5da10e3dccd8 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-debian-10-tarball/versions/2.8.6.0+3881.v2.8.6.0/ShipDriver-v2.8.6.0_debian-10-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 72ef2d161a5b66f95d048c489ef853e4364e4d35ad90986d4a6ea139b2509bfd </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v2.8.6.0-flatpak-18.08.xml
+++ b/metadata/ShipDriver-v2.8.6.0-flatpak-18.08.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/3885 -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> 2.7.1.0-+3287.v2.7.1.0 </version>
+  <version> 2.8.6.0+3885.v2.8.6.0 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -17,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>ubuntu-gtk3-x86_64</target>
-  <target-version>20.04</target-version>
+  <target>flatpak-x86_64</target>
+  <target-version>18.08</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-ubuntu-gtk3-20.04-tarball/versions/2.7.1.0-+3287.v2.7.1.0/ShipDriver-2.7.1.0-+3287.v2.7.1.0_ubuntu-gtk3-20.04-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 4593d28c9a4efab2f92fa640de2c7e3d7acefd3bb7a04e2b8be1cf2ced8359fd </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-flatpak-18.08-tarball/versions/2.8.6.0+3885.v2.8.6.0/ShipDriver-v2.8.6.0_flatpak-18.08-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 609f7a6d56478931fc0694097c26cea27ae18775bdf6b031c473e4f9c35c9363 </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v2.8.6.0-flatpak-20.08.xml
+++ b/metadata/ShipDriver-v2.8.6.0-flatpak-20.08.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/3891 -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> 2.7.1.0-+3293.v2.7.1.0 </version>
+  <version> 2.8.6.0+3891.v2.8.6.0 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -17,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>ubuntu-x86_64</target>
-  <target-version>16.04</target-version>
+  <target>flatpak-x86_64</target>
+  <target-version>20.08</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-ubuntu-16.04-tarball/versions/2.7.1.0-+3293.v2.7.1.0/ShipDriver-2.7.1.0-+3293.v2.7.1.0_ubuntu-16.04-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 2fa3e1ad67714d0262dd14410c775855ab40ce58441240998acaec1b330853b2 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-flatpak-20.08-tarball/versions/2.8.6.0+3891.v2.8.6.0/ShipDriver-v2.8.6.0_flatpak-20.08-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 80752ce96e2289db838deae5d7f73070520a0dde1832abc640abf42a83867310 </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v2.8.6.0-flatpak-A64-20.08.xml
+++ b/metadata/ShipDriver-v2.8.6.0-flatpak-A64-20.08.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/3882 -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> 2.7.1.0-+2106281409.fe00561 </version>
+  <version> 2.8.6.0+3882.v2.8.6.0 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -17,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>raspbian-armhf</target>
-  <target-version>10</target-version>
-  <target-arch>armhf</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-alpha/raw/names/ShipDriver-2.7-raspbian-10-tarball/versions/2.7.1.0-+2106281409.fe00561/ShipDriver-2.7.1.0-+2106281409.fe00561_raspbian-10-armhf.tar.gz </tarball-url>
-  <tarball-checksum> ae94108d4a26e0e8a36d06b8429bc1a11518fbc2c138698e7a71034fc2d82929 </tarball-checksum>
+  <target>flatpak-aarch64</target>
+  <target-version>20.08</target-version>
+  <target-arch>aarch64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-flatpak-A64-20.08-tarball/versions/2.8.6.0+3882.v2.8.6.0/ShipDriver-v2.8.6.0_flatpak-20.08-aarch64.tar.gz </tarball-url>
+  <tarball-checksum> 1de2c5446ae3ae7b67af511e9abf4ccc99ff607ccb38905454edef99ab39d915 </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v2.8.6.0-msvc-10.0.14393.xml
+++ b/metadata/ShipDriver-v2.8.6.0-msvc-10.0.14393.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- https://ci.appveyor.com/project/Rasbats/shipdriver-pi/builds/40391172 -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> 2.7.1.0-+3290.v2.7.1.0 </version>
+  <version> 2.8.6.0+713.v2.8.6.0 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -17,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>android-arm64</target>
-  <target-version>16</target-version>
-  <target-arch>arm64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-android-arm64-A64-16-tarball/versions/2.7.1.0-+3290.v2.7.1.0/ShipDriver-2.7.1.0-+3290.v2.7.1.0_android-arm64-16-arm64.tar.gz </tarball-url>
-  <tarball-checksum> 31dfd09bc150cc100dbe734a9b5f7059e6bdf0bacce037cd8a1555e64dc9929c </tarball-checksum>
+  <target>msvc</target>
+  <target-version>10.0.14393</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-msvc-10.0.14393-tarball/versions/2.8.6.0+713.v2.8.6.0/ShipDriver-v2.8.6.0_msvc-10.0.14393-win32.tar.gz </tarball-url>
+  <tarball-checksum> d566452150f694422fd451af51547292c9466be7f2ac331dd61667dbe5756b83 </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v2.8.6.0-raspbian-10.xml
+++ b/metadata/ShipDriver-v2.8.6.0-raspbian-10.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- https://cloud.drone.io/Rasbats/shipdriver_pi/280 -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> 2.7.1.0-+3295.v2.7.1.0 </version>
+  <version> 2.8.6.0+280.v2.8.6.0 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -17,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>android-armhf</target>
-  <target-version>16</target-version>
+  <target>raspbian-armhf</target>
+  <target-version>10</target-version>
   <target-arch>armhf</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-android-armhf-16-tarball/versions/2.7.1.0-+3295.v2.7.1.0/ShipDriver-2.7.1.0-+3295.v2.7.1.0_android-armhf-16-armhf.tar.gz </tarball-url>
-  <tarball-checksum> a8ce5da8cd6149a827ef14039a43d0f63b3717de8ebdfa1ed4c4705efc98c233 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-raspbian-10-tarball/versions/2.8.6.0+280.v2.8.6.0/ShipDriver-v2.8.6.0_raspbian-10-armhf.tar.gz </tarball-url>
+  <tarball-checksum> 3490d730c53c29c035dfa9c6d82156a02e328a04ac0ea9242e1804a933b60739 </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v2.8.6.0-raspbian-9.13.xml
+++ b/metadata/ShipDriver-v2.8.6.0-raspbian-9.13.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- https://cloud.drone.io/Rasbats/shipdriver_pi/280 -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> 2.7.1.0-+3289.v2.7.1.0 </version>
+  <version> 2.8.6.0+280.v2.8.6.0 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -17,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>darwin</target>
-  <target-version>10.13.6</target-version>
-  <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-darwin-10.13.6-tarball/versions/2.7.1.0-+3289.v2.7.1.0/ShipDriver-2.7.1.0-+3289.v2.7.1.0_darwin-10.13.6-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 594335989e7f280e7b1c03c7e75455bf7d41268654e2a10ced9bbef87ad51e69 </tarball-checksum>
+  <target>raspbian-armhf</target>
+  <target-version>9.13</target-version>
+  <target-arch>armhf</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-raspbian-9.13-tarball/versions/2.8.6.0+280.v2.8.6.0/ShipDriver-v2.8.6.0_raspbian-9.13-armhf.tar.gz </tarball-url>
+  <tarball-checksum> f3c7b2783c2546f0021cd265bd8c39172ac305beb0302ef8bf04350175482b17 </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v2.8.6.0-ubuntu-16.04.xml
+++ b/metadata/ShipDriver-v2.8.6.0-ubuntu-16.04.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/3887 -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> 2.7.1.0-+3285.v2.7.1.0 </version>
+  <version> 2.8.6.0+3887.v2.8.6.0 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -17,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>ubuntu-gtk3-x86_64</target>
-  <target-version>18.04</target-version>
+  <target>ubuntu-x86_64</target>
+  <target-version>16.04</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-ubuntu-gtk3-18.04-tarball/versions/2.7.1.0-+3285.v2.7.1.0/ShipDriver-2.7.1.0-+3285.v2.7.1.0_ubuntu-gtk3-18.04-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> f4c4e0f7c9a0aeba9723a91ea035d598448537f22c0c28e6ca1109554a1eba67 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-ubuntu-16.04-tarball/versions/2.8.6.0+3887.v2.8.6.0/ShipDriver-v2.8.6.0_ubuntu-16.04-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 85d8004d095889b726924a6f39897bbba896eec340093b8a0524aba4320d164a </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v2.8.6.0-ubuntu-18.04.xml
+++ b/metadata/ShipDriver-v2.8.6.0-ubuntu-18.04.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/3889 -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> 2.7.1.0-+3286.v2.7.1.0 </version>
+  <version> 2.8.6.0+3889.v2.8.6.0 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -17,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>flatpak-aarch64</target>
-  <target-version>20.08</target-version>
-  <target-arch>aarch64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-flatpak-A64-20.08-tarball/versions/2.7.1.0-+3286.v2.7.1.0/ShipDriver-2.7.1.0-+3286.v2.7.1.0_flatpak-20.08-aarch64.tar.gz </tarball-url>
-  <tarball-checksum> 47805703a08362238ab962a5ab27a178ca982613f0452ccba6e8031581855a70 </tarball-checksum>
+  <target>ubuntu-x86_64</target>
+  <target-version>18.04</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-ubuntu-18.04-tarball/versions/2.8.6.0+3889.v2.8.6.0/ShipDriver-v2.8.6.0_ubuntu-18.04-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> a5c103bc8f7e754f98935d670f9d13633b00ebc01cd5fc8260265a3c60d69ec6 </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v2.8.6.0-ubuntu-gtk3-18.04.xml
+++ b/metadata/ShipDriver-v2.8.6.0-ubuntu-gtk3-18.04.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/3886 -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> 2.7.1.0-+3292.v2.7.1.0 </version>
+  <version> 2.8.6.0+3886.v2.8.6.0 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -17,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>flatpak-x86_64</target>
-  <target-version>20.08</target-version>
+  <target>ubuntu-gtk3-x86_64</target>
+  <target-version>18.04</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-flatpak-20.08-tarball/versions/2.7.1.0-+3292.v2.7.1.0/ShipDriver-2.7.1.0-+3292.v2.7.1.0_flatpak-20.08-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 510d27b86f47010dba634783d84e8403096602362ebd2a67ec5028058eb8ee93 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-ubuntu-gtk3-18.04-tarball/versions/2.8.6.0+3886.v2.8.6.0/ShipDriver-v2.8.6.0_ubuntu-gtk3-18.04-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> b5fbbde5e4ac4e712f5162adb52b5db61cfdbfae7413cae488f08355b6ecdca4 </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v2.8.6.0-ubuntu-gtk3-20.04.xml
+++ b/metadata/ShipDriver-v2.8.6.0-ubuntu-gtk3-20.04.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/3888 -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> 2.7.1.0-+2106281409.fe00561 </version>
+  <version> 2.8.6.0+3888.v2.8.6.0 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -17,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>raspbian-armhf</target>
-  <target-version>9.13</target-version>
-  <target-arch>armhf</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-alpha/raw/names/ShipDriver-2.7-raspbian-9.13-tarball/versions/2.7.1.0-+2106281409.fe00561/ShipDriver-2.7.1.0-+2106281409.fe00561_raspbian-9.13-armhf.tar.gz </tarball-url>
-  <tarball-checksum> df7effb4376c255c640f01d9a105f5037e4e3b74faf08df98ed012ff6cf834eb </tarball-checksum>
+  <target>ubuntu-gtk3-x86_64</target>
+  <target-version>20.04</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-ubuntu-gtk3-20.04-tarball/versions/2.8.6.0+3888.v2.8.6.0/ShipDriver-v2.8.6.0_ubuntu-gtk3-20.04-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> c93c76149fdda4baeae9ce23a1f85ab124287d57c4806a76e9cd86afc678e8da </tarball-checksum>
 </plugin>

--- a/ocpn-plugins.xml
+++ b/ocpn-plugins.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <plugins>
   <version>0.0.0</version>
-  <date>2021-08-16 02:10</date>
+  <date>2021-08-16 06:51</date>
   <plugin version="1">
     <name> Logbook </name>
     <version> 1.4.17.0+1017.v1.4.17.0 </version>
@@ -764,7 +764,7 @@ such as dual radar range and Doppler.
   </plugin>
   <plugin version="1">
     <name> ShipDriver </name>
-    <version> 2.7.1.0-+3290.v2.7.1.0 </version>
+    <version> 2.8.6.0+3883.v2.8.6.0 </version>
     <release> 0 </release>
     <summary> Simulate ship movements </summary>
     <api-version> 1.16 </api-version>
@@ -780,12 +780,12 @@ data from itself. This can be replayed to simulate collision situations.
     <target>android-arm64</target>
     <target-version>16</target-version>
     <target-arch>arm64</target-arch>
-    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-android-arm64-A64-16-tarball/versions/2.7.1.0-+3290.v2.7.1.0/ShipDriver-2.7.1.0-+3290.v2.7.1.0_android-arm64-16-arm64.tar.gz </tarball-url>
-    <tarball-checksum> 31dfd09bc150cc100dbe734a9b5f7059e6bdf0bacce037cd8a1555e64dc9929c </tarball-checksum>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-android-arm64-A64-16-tarball/versions/2.8.6.0+3883.v2.8.6.0/ShipDriver-v2.8.6.0_android-arm64-16-arm64.tar.gz </tarball-url>
+    <tarball-checksum> 40c5d008bb9eacbd3206ba4ad524424352f3e7c6d37e1197f63b8cceabe744e7 </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name> ShipDriver </name>
-    <version> 2.7.1.0-+3295.v2.7.1.0 </version>
+    <version> 2.8.6.0+3890.v2.8.6.0 </version>
     <release> 0 </release>
     <summary> Simulate ship movements </summary>
     <api-version> 1.16 </api-version>
@@ -801,12 +801,12 @@ data from itself. This can be replayed to simulate collision situations.
     <target>android-armhf</target>
     <target-version>16</target-version>
     <target-arch>armhf</target-arch>
-    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-android-armhf-16-tarball/versions/2.7.1.0-+3295.v2.7.1.0/ShipDriver-2.7.1.0-+3295.v2.7.1.0_android-armhf-16-armhf.tar.gz </tarball-url>
-    <tarball-checksum> a8ce5da8cd6149a827ef14039a43d0f63b3717de8ebdfa1ed4c4705efc98c233 </tarball-checksum>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-android-armhf-16-tarball/versions/2.8.6.0+3890.v2.8.6.0/ShipDriver-v2.8.6.0_android-armhf-16-armhf.tar.gz </tarball-url>
+    <tarball-checksum> 7c868d9269b74d4bea58386c0a3973765c5cf37008c5e37fdaaedbb151f4d646 </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name> ShipDriver </name>
-    <version> 2.7.1.0-+3289.v2.7.1.0 </version>
+    <version> 2.8.6.0+3884.v2.8.6.0 </version>
     <release> 0 </release>
     <summary> Simulate ship movements </summary>
     <api-version> 1.16 </api-version>
@@ -822,12 +822,12 @@ data from itself. This can be replayed to simulate collision situations.
     <target>darwin</target>
     <target-version>10.13.6</target-version>
     <target-arch>x86_64</target-arch>
-    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-darwin-10.13.6-tarball/versions/2.7.1.0-+3289.v2.7.1.0/ShipDriver-2.7.1.0-+3289.v2.7.1.0_darwin-10.13.6-x86_64.tar.gz </tarball-url>
-    <tarball-checksum> 594335989e7f280e7b1c03c7e75455bf7d41268654e2a10ced9bbef87ad51e69 </tarball-checksum>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-darwin-10.13.6-tarball/versions/2.8.6.0+3884.v2.8.6.0/ShipDriver-v2.8.6.0_darwin-10.13.6-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> 05ae4873a8199a2d857aa5d824e77e72bb88ab7b8248c315303f7653f1243b6e </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name> ShipDriver </name>
-    <version> 2.7.1.0-+3291.v2.7.1.0 </version>
+    <version> 2.8.6.0+3881.v2.8.6.0 </version>
     <release> 0 </release>
     <summary> Simulate ship movements </summary>
     <api-version> 1.16 </api-version>
@@ -843,12 +843,12 @@ data from itself. This can be replayed to simulate collision situations.
     <target>debian-x86_64</target>
     <target-version>10</target-version>
     <target-arch>x86_64</target-arch>
-    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-debian-10-tarball/versions/2.7.1.0-+3291.v2.7.1.0/ShipDriver-2.7.1.0-+3291.v2.7.1.0_debian-10-x86_64.tar.gz </tarball-url>
-    <tarball-checksum> b37390e17b7a4c841e1eaff4b1a7d7a89c3cf94209f5afb9571a5da10e3dccd8 </tarball-checksum>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-debian-10-tarball/versions/2.8.6.0+3881.v2.8.6.0/ShipDriver-v2.8.6.0_debian-10-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> 72ef2d161a5b66f95d048c489ef853e4364e4d35ad90986d4a6ea139b2509bfd </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name> ShipDriver </name>
-    <version> 2.7.1.0-+3294.v2.7.1.0 </version>
+    <version> 2.8.6.0+3885.v2.8.6.0 </version>
     <release> 0 </release>
     <summary> Simulate ship movements </summary>
     <api-version> 1.16 </api-version>
@@ -864,12 +864,12 @@ data from itself. This can be replayed to simulate collision situations.
     <target>flatpak-x86_64</target>
     <target-version>18.08</target-version>
     <target-arch>x86_64</target-arch>
-    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-flatpak-18.08-tarball/versions/2.7.1.0-+3294.v2.7.1.0/ShipDriver-2.7.1.0-+3294.v2.7.1.0_flatpak-18.08-x86_64.tar.gz </tarball-url>
-    <tarball-checksum> f5fb849f5ac89ec9abd3a373285773bf93daa431cdcde3e3176d3dfbfed6af5c </tarball-checksum>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-flatpak-18.08-tarball/versions/2.8.6.0+3885.v2.8.6.0/ShipDriver-v2.8.6.0_flatpak-18.08-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> 609f7a6d56478931fc0694097c26cea27ae18775bdf6b031c473e4f9c35c9363 </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name> ShipDriver </name>
-    <version> 2.7.1.0-+3292.v2.7.1.0 </version>
+    <version> 2.8.6.0+3891.v2.8.6.0 </version>
     <release> 0 </release>
     <summary> Simulate ship movements </summary>
     <api-version> 1.16 </api-version>
@@ -885,12 +885,12 @@ data from itself. This can be replayed to simulate collision situations.
     <target>flatpak-x86_64</target>
     <target-version>20.08</target-version>
     <target-arch>x86_64</target-arch>
-    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-flatpak-20.08-tarball/versions/2.7.1.0-+3292.v2.7.1.0/ShipDriver-2.7.1.0-+3292.v2.7.1.0_flatpak-20.08-x86_64.tar.gz </tarball-url>
-    <tarball-checksum> 510d27b86f47010dba634783d84e8403096602362ebd2a67ec5028058eb8ee93 </tarball-checksum>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-flatpak-20.08-tarball/versions/2.8.6.0+3891.v2.8.6.0/ShipDriver-v2.8.6.0_flatpak-20.08-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> 80752ce96e2289db838deae5d7f73070520a0dde1832abc640abf42a83867310 </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name> ShipDriver </name>
-    <version> 2.7.1.0-+3286.v2.7.1.0 </version>
+    <version> 2.8.6.0+3882.v2.8.6.0 </version>
     <release> 0 </release>
     <summary> Simulate ship movements </summary>
     <api-version> 1.16 </api-version>
@@ -906,12 +906,12 @@ data from itself. This can be replayed to simulate collision situations.
     <target>flatpak-aarch64</target>
     <target-version>20.08</target-version>
     <target-arch>aarch64</target-arch>
-    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-flatpak-A64-20.08-tarball/versions/2.7.1.0-+3286.v2.7.1.0/ShipDriver-2.7.1.0-+3286.v2.7.1.0_flatpak-20.08-aarch64.tar.gz </tarball-url>
-    <tarball-checksum> 47805703a08362238ab962a5ab27a178ca982613f0452ccba6e8031581855a70 </tarball-checksum>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-flatpak-A64-20.08-tarball/versions/2.8.6.0+3882.v2.8.6.0/ShipDriver-v2.8.6.0_flatpak-20.08-aarch64.tar.gz </tarball-url>
+    <tarball-checksum> 1de2c5446ae3ae7b67af511e9abf4ccc99ff607ccb38905454edef99ab39d915 </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name> ShipDriver </name>
-    <version> 2.7.1.0-+610.v2.7.1.0 </version>
+    <version> 2.8.6.0+713.v2.8.6.0 </version>
     <release> 0 </release>
     <summary> Simulate ship movements </summary>
     <api-version> 1.16 </api-version>
@@ -927,12 +927,12 @@ data from itself. This can be replayed to simulate collision situations.
     <target>msvc</target>
     <target-version>10.0.14393</target-version>
     <target-arch>x86_64</target-arch>
-    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-msvc-10.0.14393-tarball/versions/2.7.1.0-+610.v2.7.1.0/ShipDriver-2.7.1.0-+610.v2.7.1.0_msvc-10.0.14393-win32.tar.gz </tarball-url>
-    <tarball-checksum> 39571b1df74be3109a298ad07e88ef983b74a7313b30ac31bbb9b41e0bf348dc </tarball-checksum>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-msvc-10.0.14393-tarball/versions/2.8.6.0+713.v2.8.6.0/ShipDriver-v2.8.6.0_msvc-10.0.14393-win32.tar.gz </tarball-url>
+    <tarball-checksum> d566452150f694422fd451af51547292c9466be7f2ac331dd61667dbe5756b83 </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name> ShipDriver </name>
-    <version> 2.7.1.0-+2106281409.fe00561 </version>
+    <version> 2.8.6.0+280.v2.8.6.0 </version>
     <release> 0 </release>
     <summary> Simulate ship movements </summary>
     <api-version> 1.16 </api-version>
@@ -948,12 +948,12 @@ data from itself. This can be replayed to simulate collision situations.
     <target>raspbian-armhf</target>
     <target-version>10</target-version>
     <target-arch>armhf</target-arch>
-    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-alpha/raw/names/ShipDriver-2.7-raspbian-10-tarball/versions/2.7.1.0-+2106281409.fe00561/ShipDriver-2.7.1.0-+2106281409.fe00561_raspbian-10-armhf.tar.gz </tarball-url>
-    <tarball-checksum> ae94108d4a26e0e8a36d06b8429bc1a11518fbc2c138698e7a71034fc2d82929 </tarball-checksum>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-raspbian-10-tarball/versions/2.8.6.0+280.v2.8.6.0/ShipDriver-v2.8.6.0_raspbian-10-armhf.tar.gz </tarball-url>
+    <tarball-checksum> 3490d730c53c29c035dfa9c6d82156a02e328a04ac0ea9242e1804a933b60739 </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name> ShipDriver </name>
-    <version> 2.7.1.0-+2106281409.fe00561 </version>
+    <version> 2.8.6.0+280.v2.8.6.0 </version>
     <release> 0 </release>
     <summary> Simulate ship movements </summary>
     <api-version> 1.16 </api-version>
@@ -969,12 +969,12 @@ data from itself. This can be replayed to simulate collision situations.
     <target>raspbian-armhf</target>
     <target-version>9.13</target-version>
     <target-arch>armhf</target-arch>
-    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-alpha/raw/names/ShipDriver-2.7-raspbian-9.13-tarball/versions/2.7.1.0-+2106281409.fe00561/ShipDriver-2.7.1.0-+2106281409.fe00561_raspbian-9.13-armhf.tar.gz </tarball-url>
-    <tarball-checksum> df7effb4376c255c640f01d9a105f5037e4e3b74faf08df98ed012ff6cf834eb </tarball-checksum>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-raspbian-9.13-tarball/versions/2.8.6.0+280.v2.8.6.0/ShipDriver-v2.8.6.0_raspbian-9.13-armhf.tar.gz </tarball-url>
+    <tarball-checksum> f3c7b2783c2546f0021cd265bd8c39172ac305beb0302ef8bf04350175482b17 </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name> ShipDriver </name>
-    <version> 2.7.1.0-+3293.v2.7.1.0 </version>
+    <version> 2.8.6.0+3887.v2.8.6.0 </version>
     <release> 0 </release>
     <summary> Simulate ship movements </summary>
     <api-version> 1.16 </api-version>
@@ -990,12 +990,12 @@ data from itself. This can be replayed to simulate collision situations.
     <target>ubuntu-x86_64</target>
     <target-version>16.04</target-version>
     <target-arch>x86_64</target-arch>
-    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-ubuntu-16.04-tarball/versions/2.7.1.0-+3293.v2.7.1.0/ShipDriver-2.7.1.0-+3293.v2.7.1.0_ubuntu-16.04-x86_64.tar.gz </tarball-url>
-    <tarball-checksum> 2fa3e1ad67714d0262dd14410c775855ab40ce58441240998acaec1b330853b2 </tarball-checksum>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-ubuntu-16.04-tarball/versions/2.8.6.0+3887.v2.8.6.0/ShipDriver-v2.8.6.0_ubuntu-16.04-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> 85d8004d095889b726924a6f39897bbba896eec340093b8a0524aba4320d164a </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name> ShipDriver </name>
-    <version> 2.7.1.0-+3288.v2.7.1.0 </version>
+    <version> 2.8.6.0+3889.v2.8.6.0 </version>
     <release> 0 </release>
     <summary> Simulate ship movements </summary>
     <api-version> 1.16 </api-version>
@@ -1011,12 +1011,12 @@ data from itself. This can be replayed to simulate collision situations.
     <target>ubuntu-x86_64</target>
     <target-version>18.04</target-version>
     <target-arch>x86_64</target-arch>
-    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-ubuntu-18.04-tarball/versions/2.7.1.0-+3288.v2.7.1.0/ShipDriver-2.7.1.0-+3288.v2.7.1.0_ubuntu-18.04-x86_64.tar.gz </tarball-url>
-    <tarball-checksum> b109700751b7e15330c47ada4e1912e905dd0c9a8cf855a1841734f2254725e4 </tarball-checksum>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-ubuntu-18.04-tarball/versions/2.8.6.0+3889.v2.8.6.0/ShipDriver-v2.8.6.0_ubuntu-18.04-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> a5c103bc8f7e754f98935d670f9d13633b00ebc01cd5fc8260265a3c60d69ec6 </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name> ShipDriver </name>
-    <version> 2.7.1.0-+3285.v2.7.1.0 </version>
+    <version> 2.8.6.0+3886.v2.8.6.0 </version>
     <release> 0 </release>
     <summary> Simulate ship movements </summary>
     <api-version> 1.16 </api-version>
@@ -1032,12 +1032,12 @@ data from itself. This can be replayed to simulate collision situations.
     <target>ubuntu-gtk3-x86_64</target>
     <target-version>18.04</target-version>
     <target-arch>x86_64</target-arch>
-    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-ubuntu-gtk3-18.04-tarball/versions/2.7.1.0-+3285.v2.7.1.0/ShipDriver-2.7.1.0-+3285.v2.7.1.0_ubuntu-gtk3-18.04-x86_64.tar.gz </tarball-url>
-    <tarball-checksum> f4c4e0f7c9a0aeba9723a91ea035d598448537f22c0c28e6ca1109554a1eba67 </tarball-checksum>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-ubuntu-gtk3-18.04-tarball/versions/2.8.6.0+3886.v2.8.6.0/ShipDriver-v2.8.6.0_ubuntu-gtk3-18.04-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> b5fbbde5e4ac4e712f5162adb52b5db61cfdbfae7413cae488f08355b6ecdca4 </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name> ShipDriver </name>
-    <version> 2.7.1.0-+3287.v2.7.1.0 </version>
+    <version> 2.8.6.0+3888.v2.8.6.0 </version>
     <release> 0 </release>
     <summary> Simulate ship movements </summary>
     <api-version> 1.16 </api-version>
@@ -1053,8 +1053,8 @@ data from itself. This can be replayed to simulate collision situations.
     <target>ubuntu-gtk3-x86_64</target>
     <target-version>20.04</target-version>
     <target-arch>x86_64</target-arch>
-    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-2.7-ubuntu-gtk3-20.04-tarball/versions/2.7.1.0-+3287.v2.7.1.0/ShipDriver-2.7.1.0-+3287.v2.7.1.0_ubuntu-gtk3-20.04-x86_64.tar.gz </tarball-url>
-    <tarball-checksum> 4593d28c9a4efab2f92fa640de2c7e3d7acefd3bb7a04e2b8be1cf2ced8359fd </tarball-checksum>
+    <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v2.8.6.0-ubuntu-gtk3-20.04-tarball/versions/2.8.6.0+3888.v2.8.6.0/ShipDriver-v2.8.6.0_ubuntu-gtk3-20.04-x86_64.tar.gz </tarball-url>
+    <tarball-checksum> c93c76149fdda4baeae9ce23a1f85ab124287d57c4806a76e9cd86afc678e8da </tarball-checksum>
   </plugin>
   <plugin version="1">
     <name> VDR </name>


### PR DESCRIPTION
This is an attempt to fix broken URLs in the master catalog.
v2.8.5.1 in the beta catalog will shortly be removed.