### PR TITLE
plugin xsd: Add new ABT darwin-wx31

### DIFF
--- a/ocpn-plugin.xsd
+++ b/ocpn-plugin.xsd
@@ -59,6 +59,7 @@
       <xs:enumeration value = "android-arm64-v8a"/>
       <xs:enumeration value = "android-armeabi-v7a"/>
       <xs:enumeration value = "darwin"/>
+      <xs:enumeration value = "darwin-wx31"/>
       <xs:enumeration value = "debian-armhf"/>
       <xs:enumeration value = "debian-x86_64"/>
       <xs:enumeration value = "flatpak-aarch64"/>


### PR DESCRIPTION
After discussions on email thread. Add a new ABI specification for MacOS  using wxWidtgets 3.1.5