### PR TITLE
ais-vd_pi meta

### DIFF
--- a/metadata/ais-vd-v1.2.0-darwin-wx315-10.13.6.xml
+++ b/metadata/ais-vd-v1.2.0-darwin-wx315-10.13.6.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://circleci.com/gh/Hakansv/ais-vd_pi/140 -->
+<plugin version="1">
+  <name> ais-vd </name>
+  <version> 1.2.0+140.v1.2.0 </version>
+  <release>  </release>
+  <summary> Update AIS class A voyage data </summary>
+
+  <api-version> 1.16 </api-version>
+  <open-source> yes </open-source>
+  <author> Dirk R and Hakan S </author>
+  <source> https://github.com/Hakansv/ais-vd_pi </source>
+  <info-url> https://github.com/Hakansv/ais-vd_pi </info-url>
+
+  <description> Update AIS class A voyage static data as:
+Navigational status
+Destination, Time/Date of arrival,
+effective draught and persons on board
+using NMEA0183 ECVSD sentence.
+ </description>
+
+  <target>darwin-wx315</target>
+  <target-version>10.13.6</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/ais-vd-prod/raw/names/ais-vd-v1.2.0-darwin-wx315-10.13.6-tarball/versions/1.2.0+140.v1.2.0/ais-vd-v1.2.0_darwin-wx315-10.13.6-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 007a31ad739d3a6dcac7209df37163f0c1c2402978cca1d3f7379be5113f1be0 </tarball-checksum>
+</plugin>

--- a/metadata/ais-vd-v1.2.0-debian-10.xml
+++ b/metadata/ais-vd-v1.2.0-debian-10.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://circleci.com/gh/Hakansv/ais-vd_pi/144 -->
+<plugin version="1">
+  <name> ais-vd </name>
+  <version> 1.2.0+144.v1.2.0 </version>
+  <release>  </release>
+  <summary> Update AIS class A voyage data </summary>
+
+  <api-version> 1.16 </api-version>
+  <open-source> yes </open-source>
+  <author> Dirk R and Hakan S </author>
+  <source> https://github.com/Hakansv/ais-vd_pi </source>
+  <info-url> https://github.com/Hakansv/ais-vd_pi </info-url>
+
+  <description> Update AIS class A voyage static data as:
+Navigational status
+Destination, Time/Date of arrival,
+effective draught and persons on board
+using NMEA0183 ECVSD sentence.
+ </description>
+
+  <target>debian-x86_64</target>
+  <target-version>10</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/ais-vd-prod/raw/names/ais-vd-v1.2.0-debian-10-tarball/versions/1.2.0+144.v1.2.0/ais-vd-v1.2.0_debian-10-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 55bd7080a9d6655dc167703a74a4d70ed81cab623ac4727687e713298c961aaf </tarball-checksum>
+</plugin>

--- a/metadata/ais-vd-v1.2.0-flatpak-18.08.xml
+++ b/metadata/ais-vd-v1.2.0-flatpak-18.08.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://circleci.com/gh/Hakansv/ais-vd_pi/139 -->
+<plugin version="1">
+  <name> ais-vd </name>
+  <version> 1.2.0+139.v1.2.0 </version>
+  <release>  </release>
+  <summary> Update AIS class A voyage data </summary>
+
+  <api-version> 1.16 </api-version>
+  <open-source> yes </open-source>
+  <author> Dirk R and Hakan S </author>
+  <source> https://github.com/Hakansv/ais-vd_pi </source>
+  <info-url> https://github.com/Hakansv/ais-vd_pi </info-url>
+
+  <description> Update AIS class A voyage static data as:
+Navigational status
+Destination, Time/Date of arrival,
+effective draught and persons on board
+using NMEA0183 ECVSD sentence.
+ </description>
+
+  <target>flatpak-x86_64</target>
+  <target-version>18.08</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/ais-vd-prod/raw/names/ais-vd-v1.2.0-flatpak-18.08-tarball/versions/1.2.0+139.v1.2.0/ais-vd-v1.2.0_flatpak-18.08-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 7e156c24ed39c20d35f1329300792ed55743b69482c793e682e3c1ead75d1f81 </tarball-checksum>
+</plugin>

--- a/metadata/ais-vd-v1.2.0-flatpak-20.08.xml
+++ b/metadata/ais-vd-v1.2.0-flatpak-20.08.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://circleci.com/gh/Hakansv/ais-vd_pi/136 -->
+<plugin version="1">
+  <name> ais-vd </name>
+  <version> 1.2.0+136.v1.2.0 </version>
+  <release>  </release>
+  <summary> Update AIS class A voyage data </summary>
+
+  <api-version> 1.16 </api-version>
+  <open-source> yes </open-source>
+  <author> Dirk R and Hakan S </author>
+  <source> https://github.com/Hakansv/ais-vd_pi </source>
+  <info-url> https://github.com/Hakansv/ais-vd_pi </info-url>
+
+  <description> Update AIS class A voyage static data as:
+Navigational status
+Destination, Time/Date of arrival,
+effective draught and persons on board
+using NMEA0183 ECVSD sentence.
+ </description>
+
+  <target>flatpak-x86_64</target>
+  <target-version>20.08</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/ais-vd-prod/raw/names/ais-vd-v1.2.0-flatpak-20.08-tarball/versions/1.2.0+136.v1.2.0/ais-vd-v1.2.0_flatpak-20.08-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 8d60ee35fb2dc14908dfe458be0acd3869383b291bcc4c6e42c35a747d374c83 </tarball-checksum>
+</plugin>

--- a/metadata/ais-vd-v1.2.0-flatpak-A64-20.08.xml
+++ b/metadata/ais-vd-v1.2.0-flatpak-A64-20.08.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://circleci.com/gh/Hakansv/ais-vd_pi/137 -->
+<plugin version="1">
+  <name> ais-vd </name>
+  <version> 1.2.0+137.v1.2.0 </version>
+  <release>  </release>
+  <summary> Update AIS class A voyage data </summary>
+
+  <api-version> 1.16 </api-version>
+  <open-source> yes </open-source>
+  <author> Dirk R and Hakan S </author>
+  <source> https://github.com/Hakansv/ais-vd_pi </source>
+  <info-url> https://github.com/Hakansv/ais-vd_pi </info-url>
+
+  <description> Update AIS class A voyage static data as:
+Navigational status
+Destination, Time/Date of arrival,
+effective draught and persons on board
+using NMEA0183 ECVSD sentence.
+ </description>
+
+  <target>flatpak-aarch64</target>
+  <target-version>20.08</target-version>
+  <target-arch>aarch64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/ais-vd-prod/raw/names/ais-vd-v1.2.0-flatpak-A64-20.08-tarball/versions/1.2.0+137.v1.2.0/ais-vd-v1.2.0_flatpak-20.08-aarch64.tar.gz </tarball-url>
+  <tarball-checksum> f86205c0cd8a232d1bb027809d50dd869efd01f972a0ee67ae91dac024ee5ae9 </tarball-checksum>
+</plugin>

--- a/metadata/ais-vd-v1.2.0-msvc-10.0.14393.xml
+++ b/metadata/ais-vd-v1.2.0-msvc-10.0.14393.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://ci.appveyor.com/project/Hakansv/ais-vd-pi/builds/41846873 -->
+<plugin version="1">
+  <name> ais-vd </name>
+  <version> 1.2.0+11.v1.2.0 </version>
+  <release>  </release>
+  <summary> Update AIS class A voyage data </summary>
+
+  <api-version> 1.16 </api-version>
+  <open-source> yes </open-source>
+  <author> Dirk R and Hakan S </author>
+  <source> https://github.com/Hakansv/ais-vd_pi </source>
+  <info-url> https://github.com/Hakansv/ais-vd_pi </info-url>
+
+  <description> Update AIS class A voyage static data as:
+Navigational status
+Destination, Time/Date of arrival,
+effective draught and persons on board
+using NMEA0183 ECVSD sentence.
+ </description>
+
+  <target>msvc</target>
+  <target-version>10.0.14393</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/ais-vd-prod/raw/names/ais-vd-v1.2.0-msvc-10.0.14393-tarball/versions/1.2.0+11.v1.2.0/ais-vd-v1.2.0_msvc-10.0.14393-win32.tar.gz </tarball-url>
+  <tarball-checksum> 6438d1e8647df5102a7475c9c1f41f95c551105ce3ac04d8739a25eaa36bb342 </tarball-checksum>
+</plugin>

--- a/metadata/ais-vd-v1.2.0-raspbian-11.xml
+++ b/metadata/ais-vd-v1.2.0-raspbian-11.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--  -->
+<plugin version="1">
+  <name> ais-vd </name>
+  <version> 1.2.0+143.v1.2.0 </version>
+  <release>  </release>
+  <summary> Update AIS class A voyage data </summary>
+
+  <api-version> 1.16 </api-version>
+  <open-source> yes </open-source>
+  <author> Dirk R and Hakan S </author>
+  <source> https://github.com/Hakansv/ais-vd_pi </source>
+  <info-url> https://github.com/Hakansv/ais-vd_pi </info-url>
+
+  <description> Update AIS class A voyage static data as:
+Navigational status
+Destination, Time/Date of arrival,
+effective draught and persons on board
+using NMEA0183 ECVSD sentence.
+ </description>
+
+  <target>raspbian-armhf</target>
+  <target-version>11</target-version>
+  <target-arch>armhf</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/ais-vd-prod/raw/names/ais-vd-v1.2.0-raspbian-11-tarball/versions/1.2.0+143.v1.2.0/ais-vd-v1.2.0_raspbian-11-armhf.tar.gz </tarball-url>
+  <tarball-checksum> be9ec50dcbc74b67182639ebf4aaa6b30585c7348bc2860fd0837e24dcea6b1e </tarball-checksum>
+</plugin>

--- a/metadata/ais-vd-v1.2.0-ubuntu-16.04.xml
+++ b/metadata/ais-vd-v1.2.0-ubuntu-16.04.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://circleci.com/gh/Hakansv/ais-vd_pi/141 -->
+<plugin version="1">
+  <name> ais-vd </name>
+  <version> 1.2.0+141.v1.2.0 </version>
+  <release>  </release>
+  <summary> Update AIS class A voyage data </summary>
+
+  <api-version> 1.16 </api-version>
+  <open-source> yes </open-source>
+  <author> Dirk R and Hakan S </author>
+  <source> https://github.com/Hakansv/ais-vd_pi </source>
+  <info-url> https://github.com/Hakansv/ais-vd_pi </info-url>
+
+  <description> Update AIS class A voyage static data as:
+Navigational status
+Destination, Time/Date of arrival,
+effective draught and persons on board
+using NMEA0183 ECVSD sentence.
+ </description>
+
+  <target>ubuntu-x86_64</target>
+  <target-version>16.04</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/ais-vd-prod/raw/names/ais-vd-v1.2.0-ubuntu-16.04-tarball/versions/1.2.0+141.v1.2.0/ais-vd-v1.2.0_ubuntu-16.04-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 7ce580712e20c262a0f37c472770d62a11be96d944e727157cb1f18dd6a4daaf </tarball-checksum>
+</plugin>

--- a/metadata/ais-vd-v1.2.0-ubuntu-18.04.xml
+++ b/metadata/ais-vd-v1.2.0-ubuntu-18.04.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://circleci.com/gh/Hakansv/ais-vd_pi/145 -->
+<plugin version="1">
+  <name> ais-vd </name>
+  <version> 1.2.0+145.v1.2.0 </version>
+  <release>  </release>
+  <summary> Update AIS class A voyage data </summary>
+
+  <api-version> 1.16 </api-version>
+  <open-source> yes </open-source>
+  <author> Dirk R and Hakan S </author>
+  <source> https://github.com/Hakansv/ais-vd_pi </source>
+  <info-url> https://github.com/Hakansv/ais-vd_pi </info-url>
+
+  <description> Update AIS class A voyage static data as:
+Navigational status
+Destination, Time/Date of arrival,
+effective draught and persons on board
+using NMEA0183 ECVSD sentence.
+ </description>
+
+  <target>ubuntu-x86_64</target>
+  <target-version>18.04</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/ais-vd-prod/raw/names/ais-vd-v1.2.0-ubuntu-18.04-tarball/versions/1.2.0+145.v1.2.0/ais-vd-v1.2.0_ubuntu-18.04-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 33b22db53fb725c590ee68707e16223acaa8e8b5067421fa6c90d6eb903e6996 </tarball-checksum>
+</plugin>

--- a/metadata/ais-vd-v1.2.0-ubuntu-gtk3-18.04.xml
+++ b/metadata/ais-vd-v1.2.0-ubuntu-gtk3-18.04.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://circleci.com/gh/Hakansv/ais-vd_pi/142 -->
+<plugin version="1">
+  <name> ais-vd </name>
+  <version> 1.2.0+142.v1.2.0 </version>
+  <release>  </release>
+  <summary> Update AIS class A voyage data </summary>
+
+  <api-version> 1.16 </api-version>
+  <open-source> yes </open-source>
+  <author> Dirk R and Hakan S </author>
+  <source> https://github.com/Hakansv/ais-vd_pi </source>
+  <info-url> https://github.com/Hakansv/ais-vd_pi </info-url>
+
+  <description> Update AIS class A voyage static data as:
+Navigational status
+Destination, Time/Date of arrival,
+effective draught and persons on board
+using NMEA0183 ECVSD sentence.
+ </description>
+
+  <target>ubuntu-gtk3-x86_64</target>
+  <target-version>18.04</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/ais-vd-prod/raw/names/ais-vd-v1.2.0-ubuntu-gtk3-18.04-tarball/versions/1.2.0+142.v1.2.0/ais-vd-v1.2.0_ubuntu-gtk3-18.04-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> ba2fdd7cae12477f0f83814c8e732cf0a572e2c19c8676d54cfe4f61f42aba38 </tarball-checksum>
+</plugin>

--- a/metadata/ais-vd-v1.2.0-ubuntu-gtk3-20.04.xml
+++ b/metadata/ais-vd-v1.2.0-ubuntu-gtk3-20.04.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://circleci.com/gh/Hakansv/ais-vd_pi/138 -->
+<plugin version="1">
+  <name> ais-vd </name>
+  <version> 1.2.0+138.v1.2.0 </version>
+  <release>  </release>
+  <summary> Update AIS class A voyage data </summary>
+
+  <api-version> 1.16 </api-version>
+  <open-source> yes </open-source>
+  <author> Dirk R and Hakan S </author>
+  <source> https://github.com/Hakansv/ais-vd_pi </source>
+  <info-url> https://github.com/Hakansv/ais-vd_pi </info-url>
+
+  <description> Update AIS class A voyage static data as:
+Navigational status
+Destination, Time/Date of arrival,
+effective draught and persons on board
+using NMEA0183 ECVSD sentence.
+ </description>
+
+  <target>ubuntu-gtk3-x86_64</target>
+  <target-version>20.04</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/ais-vd-prod/raw/names/ais-vd-v1.2.0-ubuntu-gtk3-20.04-tarball/versions/1.2.0+138.v1.2.0/ais-vd-v1.2.0_ubuntu-gtk3-20.04-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 861ef55df3b913ebb7366809cd23f8f67427f575cc83773a17130f8f24053b9e </tarball-checksum>
+</plugin>


### PR DESCRIPTION
A new plugin for ships using a AIS class A transponder to help update what's called "static voyage data". That's destination and if they intend to sail or go by motor etc.  
Not for so many average OCPN users but still handy for the few. To enter these data into a AIS device can be hard. Not less if there are many characters for the destination.