### PR TITLE
Missing Engine Dashboard 1.4.1.0 MSVC build

### DIFF
--- a/metadata/engine_dashboard_pi-1.4.1.0-msvc-x86_64-10.0.14393-MSVC.xml
+++ b/metadata/engine_dashboard_pi-1.4.1.0-msvc-x86_64-10.0.14393-MSVC.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Engine Dashboard </name>
+<version> 1.4.1.0 </version>
+<release> 0 </release>
+<summary> Engine Dashboard, Displays Engine parameters. </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+
+<description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+
+<target>msvc</target>
+<build-target>msvc</build-target>
+<build-gtk></build-gtk>
+<target-version>10.0.14393</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.4.1.0-msvc-x86_64-10.0.14393-MSVC-tarball/versions/v1.4.1/engine_dashboard_pi-1.4.1.0-msvc-x86_64-10.0.14393-MSVC.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+</plugin>

--- a/ocpn-plugins.xml
+++ b/ocpn-plugins.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <plugins>
   <version>0.0.0</version>
-  <date>2021-12-21 15:47</date>
+  <date>2021-12-26 22:37</date>
   <plugin version="1">
     <name> AutoTrackRaymarine </name>
     <version> 0.3.4.13 </version>
@@ -3439,6 +3439,28 @@ Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternat
     <target-arch>x86_64</target-arch>
     <tarball-url>
 https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.4.1.0-mingw-x86_64-10-mingw-tarball/versions/v1.4.1/engine_dashboard_pi-1.4.1.0-mingw-x86_64-10-mingw.tar.gz
+</tarball-url>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+  </plugin>
+  <plugin version="1">
+    <name> Engine Dashboard </name>
+    <version> 1.4.1.0 </version>
+    <release> 0 </release>
+    <summary> Engine Dashboard, Displays Engine parameters. </summary>
+    <api-version> 1.16 </api-version>
+    <open-source> yes </open-source>
+    <author> twocanplugin@hotmail.com </author>
+    <source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+    <description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+    <target>msvc</target>
+    <build-target>msvc</build-target>
+    <build-gtk/>
+    <target-version>10.0.14393</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.4.1.0-msvc-x86_64-10.0.14393-MSVC-tarball/versions/v1.4.1/engine_dashboard_pi-1.4.1.0-msvc-x86_64-10.0.14393-MSVC.tar.gz
 </tarball-url>
     <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
   </plugin>


### PR DESCRIPTION
For some reason appveyor missed the git hub commit and failed to build the msvc release,.

Passes XSD and url checks,