### PR TITLE
ocpn-plugin.xsd: Drop ubuntu-arm64, add ubuntu-armhf targets (OCPN#2502)

### DIFF
--- a/ocpn-plugin.xsd
+++ b/ocpn-plugin.xsd
@@ -68,8 +68,8 @@
       <xs:enumeration value = "mingw-x86_64"/>
       <xs:enumeration value = "msvc"/>
       <xs:enumeration value = "raspbian-armhf"/>
-      <xs:enumeration value = "ubuntu-arm64"/>
-      <xs:enumeration value = "ubuntu-gtk3-arm64"/>
+      <xs:enumeration value = "ubuntu-armhf"/>
+      <xs:enumeration value = "ubuntu-gtk3-armhf"/>
       <xs:enumeration value = "ubuntu-gtk3-x86_64"/>
       <xs:enumeration value = "ubuntu-x86_64"/>
       <xs:enumeration value = "android-armhf"/>
@@ -78,6 +78,7 @@
   </xs:simpleType>
 </xs:element>
 
+<!-- Deprecated, not used. -->
 <xs:element name="build-target">
     <xs:simpleType>
         <xs:restriction base = "xs:string">


### PR DESCRIPTION
Since we don't plan to support ubuntu on arm64/aarch64 the corresponding
target are removed. OTOH, we need ubuntu-armhf targets due to
https://github.com/OpenCPN/OpenCPN/discussions/2502.