### PR TITLE
SailawayNMEA v0.4-beta2

### DIFF
--- a/metadata/SailawayNMEA-v0.4-beta2-darwin-wx315-10.13.6.xml
+++ b/metadata/SailawayNMEA-v0.4-beta2-darwin-wx315-10.13.6.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://circleci.com/gh/Rasbats/SailawayNMEA_pi/305 -->
+<plugin version="1">
+  <name> SailawayNMEA </name>
+  <version> v0.4-beta2 </version>
+  <release>  </release>
+  <summary> Connect SailAway simgame </summary>
+
+  <api-version> 1.17 </api-version>
+  <open-source> yes </open-source>
+  <author> Mike Rossiter </author>
+  <source> https://github.com/Rasbats/SailawayNMEA_pi </source>
+  <info-url> https://opencpn.org/OpenCPN/plugins/SailawayNMEA.html </info-url>
+
+  <description> Provides NMEA feed from the Sailaway simgame.
+ </description>
+
+  <target>darwin-wx315</target>
+  <target-version>10.13.6</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/mike-rossiter/sailawaynmea-beta/raw/names/SailawayNMEA-v0.4-beta2-darwin-wx315-10.13.6-tarball/versions/v0.4-beta2/SailawayNMEA-v0.4-beta2_darwin-wx315-10.13.6-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 4dc5c81736cd2e04eb918a4c90bca153b62fe060d92c07e58ac5449b5ec3506a </tarball-checksum>
+</plugin>

--- a/metadata/SailawayNMEA-v0.4-beta2-msvc-10.0.14393.xml
+++ b/metadata/SailawayNMEA-v0.4-beta2-msvc-10.0.14393.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://ci.appveyor.com/project/Rasbats/sailawaynmea-pi/builds/42315178 -->
+<plugin version="1">
+  <name> SailawayNMEA </name>
+  <version> v0.4-beta2 </version>
+  <release>  </release>
+  <summary> Connect SailAway simgame </summary>
+
+  <api-version> 1.17 </api-version>
+  <open-source> yes </open-source>
+  <author> Mike Rossiter </author>
+  <source> https://github.com/Rasbats/SailawayNMEA_pi </source>
+  <info-url> https://opencpn.org/OpenCPN/plugins/SailawayNMEA.html </info-url>
+
+  <description> Provides NMEA feed from the Sailaway simgame.
+ </description>
+
+  <target>msvc</target>
+  <target-version>10.0.14393</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/mike-rossiter/sailawaynmea-beta/raw/names/SailawayNMEA-v0.4-beta2-msvc-10.0.14393-tarball/versions/v0.4-beta2/SailawayNMEA-v0.4-beta2_msvc-10.0.14393-win32.tar.gz </tarball-url>
+  <tarball-checksum> f567829932a38467f10be21a9ac6d0835fe9f11a63543afa3c7ea02390f2f859 </tarball-checksum>
+</plugin>


### PR DESCRIPTION
Move to managed version (ShipDriver). Only for MacOS and Win.