### PR TITLE
update for -gtk3 added to all ubuntu builds for gtk3

### DIFF
--- a/metadata/testplugin_pi-1.0.193.1-android-arm64-16-android-arm64.xml
+++ b/metadata/testplugin_pi-1.0.193.1-android-arm64-16-android-arm64.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Testplugin </name>
-<version> 1.0.192.0 </version>
-<release> 0 </release>
+<version> 1.0.193.1 </version>
+<release> 1 </release>
 <summary> Plugin to test examples of the ODAPI and JSON interface for ODRAW </summary>
 
 <api-version> 1.16 </api-version>
@@ -14,13 +14,13 @@
 testplugin Plugin is used to test out the ODraw API and demonstrate how to use it successfully from another plugin
 </description>
 
-<target>debian-x86_64</target>
-<build-target>debian</build-target>
+<target>android-arm64</target>
+<build-target>android</build-target>
 <build-gtk></build-gtk>
-<target-version>10</target-version>
-<target-arch>x86_64</target-arch>
+<target-version>16</target-version>
+<target-arch>arm64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.192.0-debian-x86_64-10-buster-tarball/versions/1.0.192.0+8591.a719317/testplugin_pi-1.0.192.0-debian-x86_64-10-buster.tar.gz
+https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.193.1-android-arm64-16-android-arm64-tarball/versions/1.0.193.1+8677.3004ab1/testplugin_pi-1.0.193.1-android-arm64-16-android-arm64.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:safety:odraw1.6_pi </info-url>
 </plugin>

--- a/metadata/testplugin_pi-1.0.193.1-android-armhf-16-android-armhf.xml
+++ b/metadata/testplugin_pi-1.0.193.1-android-armhf-16-android-armhf.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Testplugin </name>
-<version> 1.0.192.0 </version>
-<release> 0 </release>
+<version> 1.0.193.1 </version>
+<release> 1 </release>
 <summary> Plugin to test examples of the ODAPI and JSON interface for ODRAW </summary>
 
 <api-version> 1.16 </api-version>
 <open-source> yes </open-source>
 <author> Jon Gough </author>
-<source> https://github.com/ </source>
+<source> https://github.com/jongough/testplugin_pi </source>
 
 <description>
 testplugin Plugin is used to test out the ODraw API and demonstrate how to use it successfully from another plugin
 </description>
 
-<target>ubuntu-gtk3-armhf</target>
-<build-target>ubuntu</build-target>
-<build-gtk>gtk3</build-gtk>
-<target-version>20.04</target-version>
+<target>android-armhf</target>
+<build-target>android</build-target>
+<build-gtk></build-gtk>
+<target-version>16</target-version>
 <target-arch>armhf</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.192.0-ubuntu-armhf-20.04-focal-armhf-tarball/versions/1.0.192.0+8601.a719317/testplugin_pi-1.0.192.0-ubuntu-armhf-20.04.tar.gz
+https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.193.1-android-armhf-16-android-armhf-tarball/versions/1.0.193.1+8678.3004ab1/testplugin_pi-1.0.193.1-android-armhf-16-android-armhf.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:safety:odraw1.6_pi </info-url>
 </plugin>

--- a/metadata/testplugin_pi-1.0.193.1-darwin-wx315-x86_64-11.4-macos.xml
+++ b/metadata/testplugin_pi-1.0.193.1-darwin-wx315-x86_64-11.4-macos.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Testplugin </name>
-<version> 1.0.192.0 </version>
-<release> 0 </release>
+<version> 1.0.193.1 </version>
+<release> 1 </release>
 <summary> Plugin to test examples of the ODAPI and JSON interface for ODRAW </summary>
 
 <api-version> 1.16 </api-version>
 <open-source> yes </open-source>
 <author> Jon Gough </author>
-<source> https://github.com/ </source>
+<source> https://github.com/jongough/testplugin_pi </source>
 
 <description>
 testplugin Plugin is used to test out the ODraw API and demonstrate how to use it successfully from another plugin
 </description>
 
-<target>raspbian-armhf</target>
-<build-target>raspbian</build-target>
+<target>darwin-wx315</target>
+<build-target>darwin</build-target>
 <build-gtk></build-gtk>
-<target-version>9.13</target-version>
-<target-arch>armhf</target-arch>
+<target-version>11.4</target-version>
+<target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.192.0-raspbian-armhf-9.13-stretch-armhf-tarball/versions/1.0.192.0+8588.a719317/testplugin_pi-1.0.192.0-raspbian-armhf-9.13.tar.gz
+https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.193.1-darwin-wx315-x86_64-11.4-macos-tarball/versions/1.0.193.1+8680.3004ab1/testplugin_pi-1.0.193.1-darwin-wx315-x86_64-11.4-macos.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:safety:odraw1.6_pi </info-url>
 </plugin>

--- a/metadata/testplugin_pi-1.0.193.1-darwin-x86_64-11.4-macos.xml
+++ b/metadata/testplugin_pi-1.0.193.1-darwin-x86_64-11.4-macos.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Testplugin </name>
-<version> 1.0.192.0 </version>
-<release> 0 </release>
+<version> 1.0.193.1 </version>
+<release> 1 </release>
 <summary> Plugin to test examples of the ODAPI and JSON interface for ODRAW </summary>
 
 <api-version> 1.16 </api-version>
@@ -14,13 +14,13 @@
 testplugin Plugin is used to test out the ODraw API and demonstrate how to use it successfully from another plugin
 </description>
 
-<target>ubuntu-x86_64</target>
-<build-target>ubuntu</build-target>
+<target>darwin</target>
+<build-target>darwin</build-target>
 <build-gtk></build-gtk>
-<target-version>18.04</target-version>
+<target-version>11.4</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.192.0-ubuntu-x86_64-18.04-bionic-tarball/versions/1.0.192.0+8597.a719317/testplugin_pi-1.0.192.0-ubuntu-x86_64-18.04-bionic.tar.gz
+https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.193.1-darwin-x86_64-11.4-macos-tarball/versions/1.0.193.1+8674.3004ab1/testplugin_pi-1.0.193.1-darwin-x86_64-11.4-macos.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:safety:odraw1.6_pi </info-url>
 </plugin>

--- a/metadata/testplugin_pi-1.0.193.1-debian-armhf-10.xml
+++ b/metadata/testplugin_pi-1.0.193.1-debian-armhf-10.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Testplugin </name>
-<version> 1.0.192.0 </version>
-<release> 0 </release>
+<version> 1.0.193.1 </version>
+<release> 1 </release>
 <summary> Plugin to test examples of the ODAPI and JSON interface for ODRAW </summary>
 
 <api-version> 1.16 </api-version>
 <open-source> yes </open-source>
 <author> Jon Gough </author>
-<source> https://github.com/jongough/testplugin_pi </source>
+<source> https://github.com/ </source>
 
 <description>
 testplugin Plugin is used to test out the ODraw API and demonstrate how to use it successfully from another plugin
 </description>
 
-<target>flatpak-aarch64</target>
-<build-target>flatpak</build-target>
+<target>debian-armhf</target>
+<build-target>debian</build-target>
 <build-gtk></build-gtk>
-<target-version>20.08</target-version>
-<target-arch>aarch64</target-arch>
+<target-version>10</target-version>
+<target-arch>armhf</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.192.0-flatpak-aarch64-20.08-flatpak-arm64-tarball/versions/1.0.192.0+8595.a719317/testplugin_pi-1.0.192.0-aarch64_flatpak-20.08.tar.gz
+https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.193.1-debian-armhf-10-buster-armhf-tarball/versions/1.0.193.1+8676.3004ab1/testplugin_pi-1.0.193.1-debian-armhf-10.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:safety:odraw1.6_pi </info-url>
 </plugin>

--- a/metadata/testplugin_pi-1.0.193.1-debian-armhf-11.xml
+++ b/metadata/testplugin_pi-1.0.193.1-debian-armhf-11.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Testplugin </name>
-<version> 1.0.192.0 </version>
-<release> 0 </release>
+<version> 1.0.193.1 </version>
+<release> 1 </release>
 <summary> Plugin to test examples of the ODAPI and JSON interface for ODRAW </summary>
 
 <api-version> 1.16 </api-version>
 <open-source> yes </open-source>
 <author> Jon Gough </author>
-<source> https://github.com/jongough/testplugin_pi </source>
+<source> https://github.com/ </source>
 
 <description>
 testplugin Plugin is used to test out the ODraw API and demonstrate how to use it successfully from another plugin
 </description>
 
-<target>darwin</target>
-<build-target>darwin</build-target>
+<target>debian-armhf</target>
+<build-target>debian</build-target>
 <build-gtk></build-gtk>
-<target-version>11.4</target-version>
-<target-arch>x86_64</target-arch>
+<target-version>11</target-version>
+<target-arch>armhf</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.192.0-darwin-x86_64-11.4-macos-tarball/versions/1.0.192.0+8598.a719317/testplugin_pi-1.0.192.0-darwin-x86_64-11.4-macos.tar.gz
+https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.193.1-debian-armhf-11-bullseye-armhf-tarball/versions/1.0.193.1+8685.3004ab1/testplugin_pi-1.0.193.1-debian-armhf-11.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:safety:odraw1.6_pi </info-url>
 </plugin>

--- a/metadata/testplugin_pi-1.0.193.1-debian-x86_64-10-buster.xml
+++ b/metadata/testplugin_pi-1.0.193.1-debian-x86_64-10-buster.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Testplugin </name>
-<version> 1.0.192.0 </version>
-<release> 0 </release>
+<version> 1.0.193.1 </version>
+<release> 1 </release>
 <summary> Plugin to test examples of the ODAPI and JSON interface for ODRAW </summary>
 
 <api-version> 1.16 </api-version>
@@ -14,13 +14,13 @@
 testplugin Plugin is used to test out the ODraw API and demonstrate how to use it successfully from another plugin
 </description>
 
-<target>flatpak-x86_64-wx315</target>
-<build-target>flatpak</build-target>
+<target>debian-x86_64</target>
+<build-target>debian</build-target>
 <build-gtk></build-gtk>
-<target-version>20.08</target-version>
+<target-version>10</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.192.0-flatpak-x86_64-wx315-20.08-flatpak-tarball/versions/1.0.192.0+8603.a719317/testplugin_pi-1.0.192.0-x86_64-wx315_flatpak-20.08.tar.gz
+https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.193.1-debian-x86_64-10-buster-tarball/versions/1.0.193.1+8683.3004ab1/testplugin_pi-1.0.193.1-debian-x86_64-10-buster.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:safety:odraw1.6_pi </info-url>
 </plugin>

--- a/metadata/testplugin_pi-1.0.193.1-flatpak-aarch64-20.08-flatpak-arm64.xml
+++ b/metadata/testplugin_pi-1.0.193.1-flatpak-aarch64-20.08-flatpak-arm64.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Testplugin </name>
-<version> 1.0.192.0 </version>
-<release> 0 </release>
+<version> 1.0.193.1 </version>
+<release> 1 </release>
 <summary> Plugin to test examples of the ODAPI and JSON interface for ODRAW </summary>
 
 <api-version> 1.16 </api-version>
@@ -14,13 +14,13 @@
 testplugin Plugin is used to test out the ODraw API and demonstrate how to use it successfully from another plugin
 </description>
 
-<target>ubuntu-x86_64</target>
-<build-target>ubuntu</build-target>
+<target>flatpak-aarch64</target>
+<build-target>flatpak</build-target>
 <build-gtk></build-gtk>
-<target-version>18.04</target-version>
-<target-arch>x86_64</target-arch>
+<target-version>20.08</target-version>
+<target-arch>aarch64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.192.0-ubuntu-x86_64-18.04-bionic-gtk3-tarball/versions/1.0.192.0+8594.a719317/testplugin_pi-1.0.192.0-ubuntu-x86_64-18.04-bionic-gtk3.tar.gz
+https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.193.1-flatpak-aarch64-20.08-flatpak-arm64-tarball/versions/1.0.193.1+8688.3004ab1/testplugin_pi-1.0.193.1-aarch64_flatpak-20.08.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:safety:odraw1.6_pi </info-url>
 </plugin>

--- a/metadata/testplugin_pi-1.0.193.1-flatpak-x86_64-18.08-flatpak.xml
+++ b/metadata/testplugin_pi-1.0.193.1-flatpak-x86_64-18.08-flatpak.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Testplugin </name>
-<version> 1.0.192.0 </version>
-<release> 0 </release>
+<version> 1.0.193.1 </version>
+<release> 1 </release>
 <summary> Plugin to test examples of the ODAPI and JSON interface for ODRAW </summary>
 
 <api-version> 1.16 </api-version>
@@ -20,7 +20,7 @@ testplugin Plugin is used to test out the ODraw API and demonstrate how to use i
 <target-version>18.08</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.192.0-flatpak-x86_64-18.08-flatpak-tarball/versions/1.0.192.0+8596.a719317/testplugin_pi-1.0.192.0-x86_64_flatpak-18.08.tar.gz
+https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.193.1-flatpak-x86_64-18.08-flatpak-tarball/versions/1.0.193.1+8681.3004ab1/testplugin_pi-1.0.193.1-x86_64_flatpak-18.08.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:safety:odraw1.6_pi </info-url>
 </plugin>

--- a/metadata/testplugin_pi-1.0.193.1-flatpak-x86_64-20.08-flatpak.xml
+++ b/metadata/testplugin_pi-1.0.193.1-flatpak-x86_64-20.08-flatpak.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Testplugin </name>
-<version> 1.0.192.0 </version>
-<release> 0 </release>
+<version> 1.0.193.1 </version>
+<release> 1 </release>
 <summary> Plugin to test examples of the ODAPI and JSON interface for ODRAW </summary>
 
 <api-version> 1.16 </api-version>
@@ -14,13 +14,13 @@
 testplugin Plugin is used to test out the ODraw API and demonstrate how to use it successfully from another plugin
 </description>
 
-<target>android-arm64</target>
-<build-target>android</build-target>
+<target>flatpak-x86_64</target>
+<build-target>flatpak</build-target>
 <build-gtk></build-gtk>
-<target-version>16</target-version>
-<target-arch>arm64</target-arch>
+<target-version>20.08</target-version>
+<target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.192.0-android-arm64-16-android-arm64-tarball/versions/1.0.192.0+8589.a719317/testplugin_pi-1.0.192.0-android-arm64-16-android-arm64.tar.gz
+https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.193.1-flatpak-x86_64-20.08-flatpak-tarball/versions/1.0.193.1+8686.3004ab1/testplugin_pi-1.0.193.1-x86_64_flatpak-20.08.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:safety:odraw1.6_pi </info-url>
 </plugin>

--- a/metadata/testplugin_pi-1.0.193.1-flatpak-x86_64-wx315-20.08-flatpak.xml
+++ b/metadata/testplugin_pi-1.0.193.1-flatpak-x86_64-wx315-20.08-flatpak.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Testplugin </name>
-<version> 1.0.192.0 </version>
-<release> 0 </release>
+<version> 1.0.193.1 </version>
+<release> 1 </release>
 <summary> Plugin to test examples of the ODAPI and JSON interface for ODRAW </summary>
 
 <api-version> 1.16 </api-version>
@@ -14,13 +14,13 @@
 testplugin Plugin is used to test out the ODraw API and demonstrate how to use it successfully from another plugin
 </description>
 
-<target>ubuntu-x86_64</target>
-<build-target>ubuntu</build-target>
+<target>flatpak-x86_64-wx315</target>
+<build-target>flatpak</build-target>
 <build-gtk></build-gtk>
-<target-version>20.04</target-version>
+<target-version>20.08</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.192.0-ubuntu-x86_64-20.04-focal-gtk3-tarball/versions/1.0.192.0+8587.a719317/testplugin_pi-1.0.192.0-ubuntu-x86_64-20.04-focal-gtk3.tar.gz
+https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.193.1-flatpak-x86_64-wx315-20.08-flatpak-tarball/versions/1.0.193.1+8682.3004ab1/testplugin_pi-1.0.193.1-x86_64-wx315_flatpak-20.08.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:safety:odraw1.6_pi </info-url>
 </plugin>

--- a/metadata/testplugin_pi-1.0.193.1-msvc-x86_64-10.0.14393-MSVC.xml
+++ b/metadata/testplugin_pi-1.0.193.1-msvc-x86_64-10.0.14393-MSVC.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Testplugin </name>
-<version> 1.0.192.0 </version>
-<release> 0 </release>
+<version> 1.0.193.1 </version>
+<release> 1 </release>
 <summary> Plugin to test examples of the ODAPI and JSON interface for ODRAW </summary>
 
 <api-version> 1.16 </api-version>
@@ -20,7 +20,7 @@ testplugin Plugin is used to test out the ODraw API and demonstrate how to use i
 <target-version>10.0.14393</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.192.0-msvc-x86_64-10.0.14393-MSVC-tarball/versions/1.0.192.0+1356.a719317/testplugin_pi-1.0.192.0-msvc-x86_64-10.0.14393-MSVC.tar.gz
+https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.193.1-msvc-x86_64-10.0.14393-MSVC-tarball/versions/1.0.193.1+1363.3004ab1/testplugin_pi-1.0.193.1-msvc-x86_64-10.0.14393-MSVC.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:safety:odraw1.6_pi </info-url>
 </plugin>

--- a/metadata/testplugin_pi-1.0.193.1-raspbian-armhf-9.13.xml
+++ b/metadata/testplugin_pi-1.0.193.1-raspbian-armhf-9.13.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Testplugin </name>
-<version> 1.0.192.0 </version>
-<release> 0 </release>
+<version> 1.0.193.1 </version>
+<release> 1 </release>
 <summary> Plugin to test examples of the ODAPI and JSON interface for ODRAW </summary>
 
 <api-version> 1.16 </api-version>
 <open-source> yes </open-source>
 <author> Jon Gough </author>
-<source> https://github.com/jongough/testplugin_pi </source>
+<source> https://github.com/ </source>
 
 <description>
 testplugin Plugin is used to test out the ODraw API and demonstrate how to use it successfully from another plugin
 </description>
 
-<target>darwin-wx315</target>
-<build-target>darwin</build-target>
+<target>raspbian-armhf</target>
+<build-target>raspbian</build-target>
 <build-gtk></build-gtk>
-<target-version>11.4</target-version>
-<target-arch>x86_64</target-arch>
+<target-version>9.13</target-version>
+<target-arch>armhf</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.192.0-darwin-wx315-x86_64-11.4-macos-tarball/versions/1.0.192.0+8593.a719317/testplugin_pi-1.0.192.0-darwin-wx315-x86_64-11.4-macos.tar.gz
+https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.193.1-raspbian-armhf-9.13-stretch-armhf-tarball/versions/1.0.193.1+8687.3004ab1/testplugin_pi-1.0.193.1-raspbian-armhf-9.13.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:safety:odraw1.6_pi </info-url>
 </plugin>

--- a/metadata/testplugin_pi-1.0.193.1-ubuntu-armhf-18.04.xml
+++ b/metadata/testplugin_pi-1.0.193.1-ubuntu-armhf-18.04.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Testplugin </name>
-<version> 1.0.192.0 </version>
-<release> 0 </release>
+<version> 1.0.193.1 </version>
+<release> 1 </release>
 <summary> Plugin to test examples of the ODAPI and JSON interface for ODRAW </summary>
 
 <api-version> 1.16 </api-version>
@@ -14,13 +14,13 @@
 testplugin Plugin is used to test out the ODraw API and demonstrate how to use it successfully from another plugin
 </description>
 
-<target>debian-armhf</target>
-<build-target>debian</build-target>
+<target>ubuntu-armhf</target>
+<build-target>ubuntu</build-target>
 <build-gtk></build-gtk>
-<target-version>10</target-version>
+<target-version>18.04</target-version>
 <target-arch>armhf</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.192.0-debian-armhf-10-buster-armhf-tarball/versions/1.0.192.0+8599.a719317/testplugin_pi-1.0.192.0-debian-armhf-10.tar.gz
+https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.193.1-ubuntu-armhf-18.04-buster-armhf-tarball/versions/1.0.193.1+8675.3004ab1/testplugin_pi-1.0.193.1-ubuntu-armhf-18.04.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:safety:odraw1.6_pi </info-url>
 </plugin>

--- a/metadata/testplugin_pi-1.0.193.1-ubuntu-armhf-20.04.xml
+++ b/metadata/testplugin_pi-1.0.193.1-ubuntu-armhf-20.04.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Testplugin </name>
-<version> 1.0.192.0 </version>
-<release> 0 </release>
+<version> 1.0.193.1 </version>
+<release> 1 </release>
 <summary> Plugin to test examples of the ODAPI and JSON interface for ODRAW </summary>
 
 <api-version> 1.16 </api-version>
 <open-source> yes </open-source>
 <author> Jon Gough </author>
-<source> https://github.com/jongough/testplugin_pi </source>
+<source> https://github.com/ </source>
 
 <description>
 testplugin Plugin is used to test out the ODraw API and demonstrate how to use it successfully from another plugin
 </description>
 
-<target>android-armhf</target>
-<build-target>android</build-target>
-<build-gtk></build-gtk>
-<target-version>16</target-version>
+<target>ubuntu-gtk3-armhf</target>
+<build-target>ubuntu</build-target>
+<build-gtk>gtk3</build-gtk>
+<target-version>20.04</target-version>
 <target-arch>armhf</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.192.0-android-armhf-16-android-armhf-tarball/versions/1.0.192.0+8590.a719317/testplugin_pi-1.0.192.0-android-armhf-16-android-armhf.tar.gz
+https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.193.1-ubuntu-armhf-20.04-focal-armhf-tarball/versions/1.0.193.1+8672.3004ab1/testplugin_pi-1.0.193.1-ubuntu-armhf-20.04.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:safety:odraw1.6_pi </info-url>
 </plugin>

--- a/metadata/testplugin_pi-1.0.193.1-ubuntu-x86_64-18.04-bionic-gtk3.xml
+++ b/metadata/testplugin_pi-1.0.193.1-ubuntu-x86_64-18.04-bionic-gtk3.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Testplugin </name>
-<version> 1.0.192.0 </version>
-<release> 0 </release>
+<version> 1.0.193.1 </version>
+<release> 1 </release>
 <summary> Plugin to test examples of the ODAPI and JSON interface for ODRAW </summary>
 
 <api-version> 1.16 </api-version>
 <open-source> yes </open-source>
 <author> Jon Gough </author>
-<source> https://github.com/ </source>
+<source> https://github.com/jongough/testplugin_pi </source>
 
 <description>
 testplugin Plugin is used to test out the ODraw API and demonstrate how to use it successfully from another plugin
 </description>
 
-<target>debian-armhf</target>
-<build-target>debian</build-target>
-<build-gtk></build-gtk>
-<target-version>11</target-version>
-<target-arch>armhf</target-arch>
+<target>ubuntu-gtk3-x86_64</target>
+<build-target>ubuntu</build-target>
+<build-gtk>gtk3</build-gtk>
+<target-version>18.04</target-version>
+<target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.192.0-debian-armhf-11-bullseye-armhf-tarball/versions/1.0.192.0+8592.a719317/testplugin_pi-1.0.192.0-debian-armhf-11.tar.gz
+https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.193.1-ubuntu-x86_64-18.04-bionic-gtk3-tarball/versions/1.0.193.1+8679.3004ab1/testplugin_pi-1.0.193.1-ubuntu-x86_64-18.04-bionic-gtk3.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:safety:odraw1.6_pi </info-url>
 </plugin>

--- a/metadata/testplugin_pi-1.0.193.1-ubuntu-x86_64-18.04-bionic.xml
+++ b/metadata/testplugin_pi-1.0.193.1-ubuntu-x86_64-18.04-bionic.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Testplugin </name>
-<version> 1.0.192.0 </version>
-<release> 0 </release>
+<version> 1.0.193.1 </version>
+<release> 1 </release>
 <summary> Plugin to test examples of the ODAPI and JSON interface for ODRAW </summary>
 
 <api-version> 1.16 </api-version>
 <open-source> yes </open-source>
 <author> Jon Gough </author>
-<source> https://github.com/ </source>
+<source> https://github.com/jongough/testplugin_pi </source>
 
 <description>
 testplugin Plugin is used to test out the ODraw API and demonstrate how to use it successfully from another plugin
 </description>
 
-<target>ubuntu-armhf</target>
+<target>ubuntu-x86_64</target>
 <build-target>ubuntu</build-target>
 <build-gtk></build-gtk>
 <target-version>18.04</target-version>
-<target-arch>armhf</target-arch>
+<target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.192.0-ubuntu-armhf-18.04-buster-armhf-tarball/versions/1.0.192.0+8600.a719317/testplugin_pi-1.0.192.0-ubuntu-armhf-18.04.tar.gz
+https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.193.1-ubuntu-x86_64-18.04-bionic-tarball/versions/1.0.193.1+8673.3004ab1/testplugin_pi-1.0.193.1-ubuntu-x86_64-18.04-bionic.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:safety:odraw1.6_pi </info-url>
 </plugin>

--- a/metadata/testplugin_pi-1.0.193.1-ubuntu-x86_64-20.04-focal-gtk3.xml
+++ b/metadata/testplugin_pi-1.0.193.1-ubuntu-x86_64-20.04-focal-gtk3.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Testplugin </name>
-<version> 1.0.192.0 </version>
-<release> 0 </release>
+<version> 1.0.193.1 </version>
+<release> 1 </release>
 <summary> Plugin to test examples of the ODAPI and JSON interface for ODRAW </summary>
 
 <api-version> 1.16 </api-version>
@@ -14,13 +14,13 @@
 testplugin Plugin is used to test out the ODraw API and demonstrate how to use it successfully from another plugin
 </description>
 
-<target>flatpak-x86_64</target>
-<build-target>flatpak</build-target>
-<build-gtk></build-gtk>
-<target-version>20.08</target-version>
+<target>ubuntu-gtk3-x86_64</target>
+<build-target>ubuntu</build-target>
+<build-gtk>gtk3</build-gtk>
+<target-version>20.04</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.192.0-flatpak-x86_64-20.08-flatpak-tarball/versions/1.0.192.0+8602.a719317/testplugin_pi-1.0.192.0-x86_64_flatpak-20.08.tar.gz
+https://dl.cloudsmith.io/public/opencpn/testplugin-alpha/raw/names/testplugin_pi-1.0.193.1-ubuntu-x86_64-20.04-focal-gtk3-tarball/versions/1.0.193.1+8684.3004ab1/testplugin_pi-1.0.193.1-ubuntu-x86_64-20.04-focal-gtk3.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:safety:odraw1.6_pi </info-url>
 </plugin>


### PR DESCRIPTION
Add -gtk3 to target for ubuntu versions 18.04 & 20.04 that are built with gtk3