### PR TITLE
climatology 1.4.41

### DIFF
--- a/metadata/climatology_pi-1.4.41.0-darwin-wx315-x86_64-11.4-macos.xml
+++ b/metadata/climatology_pi-1.4.41.0-darwin-wx315-x86_64-11.4-macos.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Climatology </name>
-<version> 1.4.40.0 </version>
+<version> 1.4.41.0 </version>
 <release> 0 </release>
 <summary> Climatology PlugIn: 32 years of monthly NOAA Data </summary>
 
 <api-version> 1.16 </api-version>
 <open-source> yes </open-source>
 <author> Sean D'Epagnier </author>
-<source> https://github.com/rgleason/climatology_pi.git </source>
+<source> https://github.com/rgleason/climatology_pi </source>
 
 <description>
 Climatology provides overlay capabilities for historic weather data. Supported Climatology types include: - Average wind directions and speed- Percentage of gale and calm conditions - Sea Surface Currents - Average swell and sea state (not yet implemented) - Precipitation, Humidity, Cloud Cover, and Lightning Strikes - Monthly average Sea Level pressure and Sea Temperature, Air Temperature - Tropical Cyclone tracks
 </description>
 
-<target>debian-armhf</target>
-<build-target>debian</build-target>
+<target>darwin-wx315</target>
+<build-target>darwin</build-target>
 <build-gtk></build-gtk>
-<target-version>10</target-version>
-<target-arch>armhf</target-arch>
+<target-version>11.4</target-version>
+<target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/climatology-beta/raw/names/climatology_pi-1.4.40.0-debian-armhf-10-buster-armhf-tarball/versions/1.4.40.0+2101.9030d7a/climatology_pi-1.4.40.0-debian-armhf-10.tar.gz
+https://dl.cloudsmith.io/public/opencpn/climatology-prod/raw/names/climatology_pi-1.4.41.0-darwin-wx315-x86_64-11.4-macos-tarball/versions/v1.4.41/climatology_pi-1.4.41.0-darwin-wx315-x86_64-11.4-macos.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/climatology.html </info-url>
 </plugin>

--- a/metadata/climatology_pi-1.4.41.0-darwin-x86_64-11.4-macos.xml
+++ b/metadata/climatology_pi-1.4.41.0-darwin-x86_64-11.4-macos.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Climatology </name>
-<version> 1.4.40.0 </version>
+<version> 1.4.41.0 </version>
 <release> 0 </release>
 <summary> Climatology PlugIn: 32 years of monthly NOAA Data </summary>
 
@@ -14,13 +14,13 @@
 Climatology provides overlay capabilities for historic weather data. Supported Climatology types include: - Average wind directions and speed- Percentage of gale and calm conditions - Sea Surface Currents - Average swell and sea state (not yet implemented) - Precipitation, Humidity, Cloud Cover, and Lightning Strikes - Monthly average Sea Level pressure and Sea Temperature, Air Temperature - Tropical Cyclone tracks
 </description>
 
-<target>ubuntu-x86_64</target>
-<build-target>ubuntu</build-target>
+<target>darwin</target>
+<build-target>darwin</build-target>
 <build-gtk></build-gtk>
-<target-version>18.04</target-version>
+<target-version>11.4</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/climatology-beta/raw/names/climatology_pi-1.4.40.0-ubuntu-x86_64-18.04-bionic-tarball/versions/1.4.40.0+2097.9030d7a/climatology_pi-1.4.40.0-ubuntu-x86_64-18.04-bionic.tar.gz
+https://dl.cloudsmith.io/public/opencpn/climatology-prod/raw/names/climatology_pi-1.4.41.0-darwin-x86_64-11.4-macos-tarball/versions/v1.4.41/climatology_pi-1.4.41.0-darwin-x86_64-11.4-macos.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/climatology.html </info-url>
 </plugin>

--- a/metadata/climatology_pi-1.4.41.0-debian-armhf-10.xml
+++ b/metadata/climatology_pi-1.4.41.0-debian-armhf-10.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Climatology </name>
-<version> 1.4.40.0 </version>
+<version> 1.4.41.0 </version>
 <release> 0 </release>
 <summary> Climatology PlugIn: 32 years of monthly NOAA Data </summary>
 
 <api-version> 1.16 </api-version>
 <open-source> yes </open-source>
 <author> Sean D'Epagnier </author>
-<source> https://github.com/rgleason/climatology_pi </source>
+<source> https://github.com/ </source>
 
 <description>
 Climatology provides overlay capabilities for historic weather data. Supported Climatology types include: - Average wind directions and speed- Percentage of gale and calm conditions - Sea Surface Currents - Average swell and sea state (not yet implemented) - Precipitation, Humidity, Cloud Cover, and Lightning Strikes - Monthly average Sea Level pressure and Sea Temperature, Air Temperature - Tropical Cyclone tracks
 </description>
 
-<target>flatpak-x86_64-wx315</target>
-<build-target>flatpak</build-target>
+<target>debian-armhf</target>
+<build-target>debian</build-target>
 <build-gtk></build-gtk>
-<target-version>20.08</target-version>
-<target-arch>x86_64</target-arch>
+<target-version>10</target-version>
+<target-arch>armhf</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/climatology-beta/raw/names/climatology_pi-1.4.40.0-flatpak-x86_64-wx315-20.08-flatpak-tarball/versions/1.4.40.0+2094.9030d7a/climatology_pi-1.4.40.0-x86_64-wx315_flatpak-20.08.tar.gz
+https://dl.cloudsmith.io/public/opencpn/climatology-prod/raw/names/climatology_pi-1.4.41.0-debian-armhf-10-buster-armhf-tarball/versions/v1.4.41/climatology_pi-1.4.41.0-debian-armhf-10.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/climatology.html </info-url>
 </plugin>

--- a/metadata/climatology_pi-1.4.41.0-debian-armhf-11.xml
+++ b/metadata/climatology_pi-1.4.41.0-debian-armhf-11.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Climatology </name>
-<version> 1.4.40.0 </version>
+<version> 1.4.41.0 </version>
 <release> 0 </release>
 <summary> Climatology PlugIn: 32 years of monthly NOAA Data </summary>
 
 <api-version> 1.16 </api-version>
 <open-source> yes </open-source>
 <author> Sean D'Epagnier </author>
-<source> https://github.com/rgleason/climatology_pi </source>
+<source> https://github.com/ </source>
 
 <description>
 Climatology provides overlay capabilities for historic weather data. Supported Climatology types include: - Average wind directions and speed- Percentage of gale and calm conditions - Sea Surface Currents - Average swell and sea state (not yet implemented) - Precipitation, Humidity, Cloud Cover, and Lightning Strikes - Monthly average Sea Level pressure and Sea Temperature, Air Temperature - Tropical Cyclone tracks
 </description>
 
-<target>debian-x86_64</target>
+<target>debian-armhf</target>
 <build-target>debian</build-target>
 <build-gtk></build-gtk>
-<target-version>10</target-version>
-<target-arch>x86_64</target-arch>
+<target-version>11</target-version>
+<target-arch>armhf</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/climatology-beta/raw/names/climatology_pi-1.4.40.0-debian-x86_64-10-buster-tarball/versions/1.4.40.0+2098.9030d7a/climatology_pi-1.4.40.0-debian-x86_64-10-buster.tar.gz
+https://dl.cloudsmith.io/public/opencpn/climatology-prod/raw/names/climatology_pi-1.4.41.0-debian-armhf-11-bullseye-armhf-tarball/versions/v1.4.41/climatology_pi-1.4.41.0-debian-armhf-11.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/climatology.html </info-url>
 </plugin>

--- a/metadata/climatology_pi-1.4.41.0-debian-x86_64-10-buster.xml
+++ b/metadata/climatology_pi-1.4.41.0-debian-x86_64-10-buster.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Climatology </name>
-<version> 1.4.40.0 </version>
+<version> 1.4.41.0 </version>
 <release> 0 </release>
 <summary> Climatology PlugIn: 32 years of monthly NOAA Data </summary>
 
@@ -14,13 +14,13 @@
 Climatology provides overlay capabilities for historic weather data. Supported Climatology types include: - Average wind directions and speed- Percentage of gale and calm conditions - Sea Surface Currents - Average swell and sea state (not yet implemented) - Precipitation, Humidity, Cloud Cover, and Lightning Strikes - Monthly average Sea Level pressure and Sea Temperature, Air Temperature - Tropical Cyclone tracks
 </description>
 
-<target>ubuntu-x86_64</target>
-<build-target>ubuntu</build-target>
+<target>debian-x86_64</target>
+<build-target>debian</build-target>
 <build-gtk></build-gtk>
-<target-version>18.04</target-version>
+<target-version>10</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/climatology-beta/raw/names/climatology_pi-1.4.40.0-ubuntu-x86_64-18.04-bionic-gtk3-tarball/versions/1.4.40.0+2096.9030d7a/climatology_pi-1.4.40.0-ubuntu-x86_64-18.04-bionic-gtk3.tar.gz
+https://dl.cloudsmith.io/public/opencpn/climatology-prod/raw/names/climatology_pi-1.4.41.0-debian-x86_64-10-buster-tarball/versions/v1.4.41/climatology_pi-1.4.41.0-debian-x86_64-10-buster.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/climatology.html </info-url>
 </plugin>

--- a/metadata/climatology_pi-1.4.41.0-flatpak-aarch64-20.08-flatpak-arm64.xml
+++ b/metadata/climatology_pi-1.4.41.0-flatpak-aarch64-20.08-flatpak-arm64.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Climatology </name>
-<version> 1.4.40.0 </version>
+<version> 1.4.41.0 </version>
 <release> 0 </release>
 <summary> Climatology PlugIn: 32 years of monthly NOAA Data </summary>
 
@@ -14,13 +14,13 @@
 Climatology provides overlay capabilities for historic weather data. Supported Climatology types include: - Average wind directions and speed- Percentage of gale and calm conditions - Sea Surface Currents - Average swell and sea state (not yet implemented) - Precipitation, Humidity, Cloud Cover, and Lightning Strikes - Monthly average Sea Level pressure and Sea Temperature, Air Temperature - Tropical Cyclone tracks
 </description>
 
-<target>msvc</target>
-<build-target>msvc</build-target>
+<target>flatpak-aarch64</target>
+<build-target>flatpak</build-target>
 <build-gtk></build-gtk>
-<target-version>10.0.14393</target-version>
-<target-arch>x86_64</target-arch>
+<target-version>20.08</target-version>
+<target-arch>aarch64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/climatology-beta/raw/names/climatology_pi-1.4.40.0-msvc-x86_64-10.0.14393-MSVC-tarball/versions/1.4.40.0+237.9030d7a/climatology_pi-1.4.40.0-msvc-x86_64-10.0.14393-MSVC.tar.gz
+https://dl.cloudsmith.io/public/opencpn/climatology-prod/raw/names/climatology_pi-1.4.41.0-flatpak-aarch64-20.08-flatpak-arm64-tarball/versions/v1.4.41/climatology_pi-1.4.41.0-aarch64_flatpak-20.08.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/climatology.html </info-url>
 </plugin>

--- a/metadata/climatology_pi-1.4.41.0-flatpak-x86_64-18.08-flatpak.xml
+++ b/metadata/climatology_pi-1.4.41.0-flatpak-x86_64-18.08-flatpak.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Climatology </name>
-<version> 1.4.40.0 </version>
+<version> 1.4.41.0 </version>
 <release> 0 </release>
 <summary> Climatology PlugIn: 32 years of monthly NOAA Data </summary>
 
@@ -20,7 +20,7 @@ Climatology provides overlay capabilities for historic weather data. Supported C
 <target-version>18.08</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/climatology-beta/raw/names/climatology_pi-1.4.40.0-flatpak-x86_64-18.08-flatpak-tarball/versions/1.4.40.0+2108.9030d7a/climatology_pi-1.4.40.0-x86_64_flatpak-18.08.tar.gz
+https://dl.cloudsmith.io/public/opencpn/climatology-prod/raw/names/climatology_pi-1.4.41.0-flatpak-x86_64-18.08-flatpak-tarball/versions/v1.4.41/climatology_pi-1.4.41.0-x86_64_flatpak-18.08.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/climatology.html </info-url>
 </plugin>

--- a/metadata/climatology_pi-1.4.41.0-flatpak-x86_64-20.08-flatpak.xml
+++ b/metadata/climatology_pi-1.4.41.0-flatpak-x86_64-20.08-flatpak.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Climatology </name>
-<version> 1.4.40.0 </version>
+<version> 1.4.41.0 </version>
 <release> 0 </release>
 <summary> Climatology PlugIn: 32 years of monthly NOAA Data </summary>
 
 <api-version> 1.16 </api-version>
 <open-source> yes </open-source>
 <author> Sean D'Epagnier </author>
-<source> https://github.com/rgleason/climatology_pi.git </source>
+<source> https://github.com/rgleason/climatology_pi </source>
 
 <description>
 Climatology provides overlay capabilities for historic weather data. Supported Climatology types include: - Average wind directions and speed- Percentage of gale and calm conditions - Sea Surface Currents - Average swell and sea state (not yet implemented) - Precipitation, Humidity, Cloud Cover, and Lightning Strikes - Monthly average Sea Level pressure and Sea Temperature, Air Temperature - Tropical Cyclone tracks
 </description>
 
-<target>ubuntu-gtk3-armhf</target>
-<build-target>ubuntu</build-target>
-<build-gtk>gtk3</build-gtk>
-<target-version>20.04</target-version>
-<target-arch>armhf</target-arch>
+<target>flatpak-x86_64</target>
+<build-target>flatpak</build-target>
+<build-gtk></build-gtk>
+<target-version>20.08</target-version>
+<target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/climatology-beta/raw/names/climatology_pi-1.4.40.0-ubuntu-armhf-20.04-focal-armhf-tarball/versions/1.4.40.0+2095.9030d7a/climatology_pi-1.4.40.0-ubuntu-armhf-20.04.tar.gz
+https://dl.cloudsmith.io/public/opencpn/climatology-prod/raw/names/climatology_pi-1.4.41.0-flatpak-x86_64-20.08-flatpak-tarball/versions/v1.4.41/climatology_pi-1.4.41.0-x86_64_flatpak-20.08.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/climatology.html </info-url>
 </plugin>

--- a/metadata/climatology_pi-1.4.41.0-flatpak-x86_64-wx315-20.08-flatpak.xml
+++ b/metadata/climatology_pi-1.4.41.0-flatpak-x86_64-wx315-20.08-flatpak.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Climatology </name>
-<version> 1.4.40.0 </version>
+<version> 1.4.41.0 </version>
 <release> 0 </release>
 <summary> Climatology PlugIn: 32 years of monthly NOAA Data </summary>
 
@@ -14,13 +14,13 @@
 Climatology provides overlay capabilities for historic weather data. Supported Climatology types include: - Average wind directions and speed- Percentage of gale and calm conditions - Sea Surface Currents - Average swell and sea state (not yet implemented) - Precipitation, Humidity, Cloud Cover, and Lightning Strikes - Monthly average Sea Level pressure and Sea Temperature, Air Temperature - Tropical Cyclone tracks
 </description>
 
-<target>darwin-wx315</target>
-<build-target>darwin</build-target>
+<target>flatpak-x86_64-wx315</target>
+<build-target>flatpak</build-target>
 <build-gtk></build-gtk>
-<target-version>11.4</target-version>
+<target-version>20.08</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/climatology-beta/raw/names/climatology_pi-1.4.40.0-darwin-wx315-x86_64-11.4-macos-tarball/versions/1.4.40.0+2102.9030d7a/climatology_pi-1.4.40.0-darwin-wx315-x86_64-11.4-macos.tar.gz
+https://dl.cloudsmith.io/public/opencpn/climatology-prod/raw/names/climatology_pi-1.4.41.0-flatpak-x86_64-wx315-20.08-flatpak-tarball/versions/v1.4.41/climatology_pi-1.4.41.0-x86_64-wx315_flatpak-20.08.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/climatology.html </info-url>
 </plugin>

--- a/metadata/climatology_pi-1.4.41.0-msvc-x86_64-10.0.14393-MSVC.xml
+++ b/metadata/climatology_pi-1.4.41.0-msvc-x86_64-10.0.14393-MSVC.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Climatology </name>
-<version> 1.4.40.0 </version>
+<version> 1.4.41.0 </version>
 <release> 0 </release>
 <summary> Climatology PlugIn: 32 years of monthly NOAA Data </summary>
 
@@ -14,13 +14,13 @@
 Climatology provides overlay capabilities for historic weather data. Supported Climatology types include: - Average wind directions and speed- Percentage of gale and calm conditions - Sea Surface Currents - Average swell and sea state (not yet implemented) - Precipitation, Humidity, Cloud Cover, and Lightning Strikes - Monthly average Sea Level pressure and Sea Temperature, Air Temperature - Tropical Cyclone tracks
 </description>
 
-<target>flatpak-x86_64</target>
-<build-target>flatpak</build-target>
+<target>msvc</target>
+<build-target>msvc</build-target>
 <build-gtk></build-gtk>
-<target-version>20.08</target-version>
+<target-version>10.0.14393</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/climatology-beta/raw/names/climatology_pi-1.4.40.0-flatpak-x86_64-20.08-flatpak-tarball/versions/1.4.40.0+2104.9030d7a/climatology_pi-1.4.40.0-x86_64_flatpak-20.08.tar.gz
+https://dl.cloudsmith.io/public/opencpn/climatology-prod/raw/names/climatology_pi-1.4.41.0-msvc-x86_64-10.0.14393-MSVC-tarball/versions/v1.4.41/climatology_pi-1.4.41.0-msvc-x86_64-10.0.14393-MSVC.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/climatology.html </info-url>
 </plugin>

--- a/metadata/climatology_pi-1.4.41.0-raspbian-armhf-9.13.xml
+++ b/metadata/climatology_pi-1.4.41.0-raspbian-armhf-9.13.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Climatology </name>
-<version> 1.4.40.0 </version>
+<version> 1.4.41.0 </version>
 <release> 0 </release>
 <summary> Climatology PlugIn: 32 years of monthly NOAA Data </summary>
 
 <api-version> 1.16 </api-version>
 <open-source> yes </open-source>
 <author> Sean D'Epagnier </author>
-<source> https://github.com/rgleason/climatology_pi.git </source>
+<source> https://github.com/ </source>
 
 <description>
 Climatology provides overlay capabilities for historic weather data. Supported Climatology types include: - Average wind directions and speed- Percentage of gale and calm conditions - Sea Surface Currents - Average swell and sea state (not yet implemented) - Precipitation, Humidity, Cloud Cover, and Lightning Strikes - Monthly average Sea Level pressure and Sea Temperature, Air Temperature - Tropical Cyclone tracks
@@ -20,7 +20,7 @@ Climatology provides overlay capabilities for historic weather data. Supported C
 <target-version>9.13</target-version>
 <target-arch>armhf</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/climatology-beta/raw/names/climatology_pi-1.4.40.0-raspbian-armhf-9.13-stretch-armhf-tarball/versions/1.4.40.0+2093.9030d7a/climatology_pi-1.4.40.0-raspbian-armhf-9.13.tar.gz
+https://dl.cloudsmith.io/public/opencpn/climatology-prod/raw/names/climatology_pi-1.4.41.0-raspbian-armhf-9.13-stretch-armhf-tarball/versions/v1.4.41/climatology_pi-1.4.41.0-raspbian-armhf-9.13.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/climatology.html </info-url>
 </plugin>

--- a/metadata/climatology_pi-1.4.41.0-ubuntu-armhf-18.04.xml
+++ b/metadata/climatology_pi-1.4.41.0-ubuntu-armhf-18.04.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Climatology </name>
-<version> 1.4.40.0 </version>
+<version> 1.4.41.0 </version>
 <release> 0 </release>
 <summary> Climatology PlugIn: 32 years of monthly NOAA Data </summary>
 
 <api-version> 1.16 </api-version>
 <open-source> yes </open-source>
 <author> Sean D'Epagnier </author>
-<source> https://github.com/rgleason/climatology_pi.git </source>
+<source> https://github.com/ </source>
 
 <description>
 Climatology provides overlay capabilities for historic weather data. Supported Climatology types include: - Average wind directions and speed- Percentage of gale and calm conditions - Sea Surface Currents - Average swell and sea state (not yet implemented) - Precipitation, Humidity, Cloud Cover, and Lightning Strikes - Monthly average Sea Level pressure and Sea Temperature, Air Temperature - Tropical Cyclone tracks
@@ -20,7 +20,7 @@ Climatology provides overlay capabilities for historic weather data. Supported C
 <target-version>18.04</target-version>
 <target-arch>armhf</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/climatology-beta/raw/names/climatology_pi-1.4.40.0-ubuntu-armhf-18.04-buster-armhf-tarball/versions/1.4.40.0+2105.9030d7a/climatology_pi-1.4.40.0-ubuntu-armhf-18.04.tar.gz
+https://dl.cloudsmith.io/public/opencpn/climatology-prod/raw/names/climatology_pi-1.4.41.0-ubuntu-armhf-18.04-buster-armhf-tarball/versions/v1.4.41/climatology_pi-1.4.41.0-ubuntu-armhf-18.04.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/climatology.html </info-url>
 </plugin>

--- a/metadata/climatology_pi-1.4.41.0-ubuntu-armhf-20.04.xml
+++ b/metadata/climatology_pi-1.4.41.0-ubuntu-armhf-20.04.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Climatology </name>
-<version> 1.4.40.0 </version>
+<version> 1.4.41.0 </version>
 <release> 0 </release>
 <summary> Climatology PlugIn: 32 years of monthly NOAA Data </summary>
 
@@ -14,13 +14,13 @@
 Climatology provides overlay capabilities for historic weather data. Supported Climatology types include: - Average wind directions and speed- Percentage of gale and calm conditions - Sea Surface Currents - Average swell and sea state (not yet implemented) - Precipitation, Humidity, Cloud Cover, and Lightning Strikes - Monthly average Sea Level pressure and Sea Temperature, Air Temperature - Tropical Cyclone tracks
 </description>
 
-<target>debian-armhf</target>
-<build-target>debian</build-target>
-<build-gtk></build-gtk>
-<target-version>11</target-version>
+<target>ubuntu-gtk3-armhf</target>
+<build-target>ubuntu</build-target>
+<build-gtk>gtk3</build-gtk>
+<target-version>20.04</target-version>
 <target-arch>armhf</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/climatology-beta/raw/names/climatology_pi-1.4.40.0-debian-armhf-11-bullseye-armhf-tarball/versions/1.4.40.0+2106.9030d7a/climatology_pi-1.4.40.0-debian-armhf-11.tar.gz
+https://dl.cloudsmith.io/public/opencpn/climatology-prod/raw/names/climatology_pi-1.4.41.0-ubuntu-armhf-20.04-focal-armhf-tarball/versions/v1.4.41/climatology_pi-1.4.41.0-ubuntu-armhf-20.04.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/climatology.html </info-url>
 </plugin>

--- a/metadata/climatology_pi-1.4.41.0-ubuntu-x86_64-18.04-bionic-gtk3.xml
+++ b/metadata/climatology_pi-1.4.41.0-ubuntu-x86_64-18.04-bionic-gtk3.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Climatology </name>
-<version> 1.4.40.0 </version>
+<version> 1.4.41.0 </version>
 <release> 0 </release>
 <summary> Climatology PlugIn: 32 years of monthly NOAA Data </summary>
 
@@ -14,13 +14,13 @@
 Climatology provides overlay capabilities for historic weather data. Supported Climatology types include: - Average wind directions and speed- Percentage of gale and calm conditions - Sea Surface Currents - Average swell and sea state (not yet implemented) - Precipitation, Humidity, Cloud Cover, and Lightning Strikes - Monthly average Sea Level pressure and Sea Temperature, Air Temperature - Tropical Cyclone tracks
 </description>
 
-<target>flatpak-aarch64</target>
-<build-target>flatpak</build-target>
-<build-gtk></build-gtk>
-<target-version>20.08</target-version>
-<target-arch>aarch64</target-arch>
+<target>ubuntu-gtk3-x86_64</target>
+<build-target>ubuntu</build-target>
+<build-gtk>gtk3</build-gtk>
+<target-version>18.04</target-version>
+<target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/climatology-beta/raw/names/climatology_pi-1.4.40.0-flatpak-aarch64-20.08-flatpak-arm64-tarball/versions/1.4.40.0+2092.9030d7a/climatology_pi-1.4.40.0-aarch64_flatpak-20.08.tar.gz
+https://dl.cloudsmith.io/public/opencpn/climatology-prod/raw/names/climatology_pi-1.4.41.0-ubuntu-x86_64-18.04-bionic-gtk3-tarball/versions/v1.4.41/climatology_pi-1.4.41.0-ubuntu-x86_64-18.04-bionic-gtk3.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/climatology.html </info-url>
 </plugin>

--- a/metadata/climatology_pi-1.4.41.0-ubuntu-x86_64-18.04-bionic.xml
+++ b/metadata/climatology_pi-1.4.41.0-ubuntu-x86_64-18.04-bionic.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Climatology </name>
-<version> 1.4.40.0 </version>
+<version> 1.4.41.0 </version>
 <release> 0 </release>
 <summary> Climatology PlugIn: 32 years of monthly NOAA Data </summary>
 
@@ -17,10 +17,10 @@ Climatology provides overlay capabilities for historic weather data. Supported C
 <target>ubuntu-x86_64</target>
 <build-target>ubuntu</build-target>
 <build-gtk></build-gtk>
-<target-version>20.04</target-version>
+<target-version>18.04</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/climatology-beta/raw/names/climatology_pi-1.4.40.0-ubuntu-x86_64-20.04-focal-gtk3-tarball/versions/1.4.40.0+2107.9030d7a/climatology_pi-1.4.40.0-ubuntu-x86_64-20.04-focal-gtk3.tar.gz
+https://dl.cloudsmith.io/public/opencpn/climatology-prod/raw/names/climatology_pi-1.4.41.0-ubuntu-x86_64-18.04-bionic-tarball/versions/v1.4.41/climatology_pi-1.4.41.0-ubuntu-x86_64-18.04-bionic.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/climatology.html </info-url>
 </plugin>

--- a/metadata/climatology_pi-1.4.41.0-ubuntu-x86_64-20.04-focal-gtk3.xml
+++ b/metadata/climatology_pi-1.4.41.0-ubuntu-x86_64-20.04-focal-gtk3.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Climatology </name>
-<version> 1.4.40.0 </version>
+<version> 1.4.41.0 </version>
 <release> 0 </release>
 <summary> Climatology PlugIn: 32 years of monthly NOAA Data </summary>
 
@@ -14,13 +14,13 @@
 Climatology provides overlay capabilities for historic weather data. Supported Climatology types include: - Average wind directions and speed- Percentage of gale and calm conditions - Sea Surface Currents - Average swell and sea state (not yet implemented) - Precipitation, Humidity, Cloud Cover, and Lightning Strikes - Monthly average Sea Level pressure and Sea Temperature, Air Temperature - Tropical Cyclone tracks
 </description>
 
-<target>darwin</target>
-<build-target>darwin</build-target>
-<build-gtk></build-gtk>
-<target-version>11.4</target-version>
+<target>ubuntu-gtk3-x86_64</target>
+<build-target>ubuntu</build-target>
+<build-gtk>gtk3</build-gtk>
+<target-version>20.04</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/climatology-beta/raw/names/climatology_pi-1.4.40.0-darwin-x86_64-11.4-macos-tarball/versions/1.4.40.0+2099.9030d7a/climatology_pi-1.4.40.0-darwin-x86_64-11.4-macos.tar.gz
+https://dl.cloudsmith.io/public/opencpn/climatology-prod/raw/names/climatology_pi-1.4.41.0-ubuntu-x86_64-20.04-focal-gtk3-tarball/versions/v1.4.41/climatology_pi-1.4.41.0-ubuntu-x86_64-20.04-focal-gtk3.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/climatology.html </info-url>
 </plugin>


### PR DESCRIPTION
For some reason many (most) of the v1.4.40 are no longer found on Cloudsmith. I have been unable to explain this. I have not found a "history" on Cloudsmith so that avenue is not available. This version is to replace that 1.4.40