### PR TITLE
Add new targets for native macOS arm  and windows 64-bit builds

### DIFF
--- a/ocpn-plugin.xsd
+++ b/ocpn-plugin.xsd
@@ -61,6 +61,7 @@
       <xs:enumeration value = "android-armhf"/>
       <xs:enumeration value = "android-arm64"/>
       <xs:enumeration value = "darwin"/>
+      <xs:enumeration value = "darwin-arm64"/>
       <xs:enumeration value = "darwin-wx315"/>
       <xs:enumeration value = "debian-x86_64"/>
       <xs:enumeration value = "debian-armhf"/>
@@ -70,6 +71,7 @@
       <xs:enumeration value = "mingw"/> <!-- transitional, see OpenCPN#2061 -->
       <xs:enumeration value = "mingw-x86_64"/>
       <xs:enumeration value = "msvc"/>
+      <xs:enumeration value = "msvc-64"/>
       <xs:enumeration value = "ubuntu-gtk3-x86_64"/>
       <xs:enumeration value = "ubuntu-x86_64"/>
       <xs:enumeration value = "ubuntu-gtk3-armhf"/>

--- a/ocpn-plugin.xsd
+++ b/ocpn-plugin.xsd
@@ -56,15 +56,15 @@
   <xs:simpleType>
     <xs:restriction base = "xs:string">
       <xs:enumeration value = "all"/>
+      <xs:enumeration value = "android-arm64"/>
       <xs:enumeration value = "android-arm64-v8a"/>
       <xs:enumeration value = "android-armeabi-v7a"/>
       <xs:enumeration value = "android-armhf"/>
-      <xs:enumeration value = "android-arm64"/>
       <xs:enumeration value = "darwin"/>
       <xs:enumeration value = "darwin-arm64"/>
       <xs:enumeration value = "darwin-wx315"/>
-      <xs:enumeration value = "debian-x86_64"/>
       <xs:enumeration value = "debian-armhf"/>
+      <xs:enumeration value = "debian-x86_64"/>
       <xs:enumeration value = "flatpak-aarch64"/>
       <xs:enumeration value = "flatpak-x86_64"/>
       <xs:enumeration value = "flatpak-x86_64-wx315"/>
@@ -72,11 +72,11 @@
       <xs:enumeration value = "mingw-x86_64"/>
       <xs:enumeration value = "msvc"/>
       <xs:enumeration value = "msvc-64"/>
+      <xs:enumeration value = "raspbian-armhf"/>
+      <xs:enumeration value = "ubuntu-armhf"/>
+      <xs:enumeration value = "ubuntu-gtk3-armhf"/>
       <xs:enumeration value = "ubuntu-gtk3-x86_64"/>
       <xs:enumeration value = "ubuntu-x86_64"/>
-      <xs:enumeration value = "ubuntu-gtk3-armhf"/>
-      <xs:enumeration value = "ubuntu-armhf"/>
-      <xs:enumeration value = "raspbian-armhf"/>
     </xs:restriction>
   </xs:simpleType>
 </xs:element>


### PR DESCRIPTION
As heading says. This is just preparations for the 5.8.0 cycle, to define things and at least let them pass basic xsd validation.