### PR TITLE
xsd: Add new debian-gtk3-armhf ABI spec

### DIFF
--- a/ocpn-plugin.xsd
+++ b/ocpn-plugin.xsd
@@ -64,6 +64,7 @@
       <xs:enumeration value = "darwin-arm64"/>
       <xs:enumeration value = "darwin-wx315"/>
       <xs:enumeration value = "debian-armhf"/>
+      <xs:enumeration value = "debian-gtk3-armhf"/>
       <xs:enumeration value = "debian-x86_64"/>
       <xs:enumeration value = "flatpak-aarch64"/>
       <xs:enumeration value = "flatpak-x86_64"/>


### PR DESCRIPTION
In Debian 10 there are both gtk3-based official builds and gtk2
based PPA builds. We need to formalize this fact using a separate
ABI for Debian 10, similar to ubuntu-gtk3. This applies whether
we we actually build plugins for debian-gtk3-armhf or not.

See: https://github.com/OpenCPN/OpenCPN/issues/2612