### PR TITLE
ocpn-plugin.xsd: New ABI designator msvc-wx32

### DIFF
--- a/ocpn-plugin.xsd
+++ b/ocpn-plugin.xsd
@@ -74,6 +74,7 @@
       <xs:enumeration value = "mingw-x86_64"/>
       <xs:enumeration value = "msvc"/>
       <xs:enumeration value = "msvc-64"/>
+      <xs:enumeration value = "msvc-wx32"/>
       <xs:enumeration value = "raspbian-armhf"/>
       <xs:enumeration value = "ubuntu-armhf"/>
       <xs:enumeration value = "ubuntu-gtk3-armhf"/>


### PR DESCRIPTION
Add a new ABI for windows plugins using  wxwidgets 3.2.x