### PR TITLE
Update wx32-dependent types (opencpn#2502).

### DIFF
--- a/ocpn-plugin.xsd
+++ b/ocpn-plugin.xsd
@@ -62,14 +62,15 @@
       <xs:enumeration value = "android-armhf"/>
       <xs:enumeration value = "darwin"/>
       <xs:enumeration value = "darwin-arm64"/>
-      <xs:enumeration value = "darwin-wx315"/>
       <xs:enumeration value = "debian-armhf"/>
+      <xs:enumeration value = "debian-armhf-wx32"/>
       <xs:enumeration value = "debian-gtk3-armhf"/>
       <xs:enumeration value = "debian-x86_64"/>
+      <xs:enumeration value = "debian-x86_64-wx32"/>
       <xs:enumeration value = "debian-arm64"/>
+      <xs:enumeration value = "debian-arm64-wx32"/>
       <xs:enumeration value = "flatpak-aarch64"/>
       <xs:enumeration value = "flatpak-x86_64"/>
-      <xs:enumeration value = "flatpak-x86_64-wx315"/>
       <xs:enumeration value = "mingw"/> <!-- transitional, see OpenCPN#2061 -->
       <xs:enumeration value = "mingw-x86_64"/>
       <xs:enumeration value = "msvc"/>


### PR DESCRIPTION
Retire obsolete wx315 transitional ABIs.

Add -wx32 ABI for all debian builds, which will be needed for Ubuntu 22.04 which will use both wx3.0 and and wx 3.2.

Flatpak and MacOS will only use either wx3.0 or wx3.2 for all versions, so no -wx32 is required for these. msvc-wx32 is already in place.

See: https://github.com/OpenCPN/OpenCPN/discussions/2502