### PR TITLE
Correct new, buggy ABI types in #747 (OpenCPN#2797).

### DIFF
--- a/ocpn-plugin.xsd
+++ b/ocpn-plugin.xsd
@@ -63,12 +63,12 @@
       <xs:enumeration value = "darwin"/>
       <xs:enumeration value = "darwin-arm64"/>
       <xs:enumeration value = "debian-armhf"/>
-      <xs:enumeration value = "debian-armhf-wx32"/>
+      <xs:enumeration value = "debian-wx32-armhf"/>
       <xs:enumeration value = "debian-gtk3-armhf"/>
       <xs:enumeration value = "debian-x86_64"/>
-      <xs:enumeration value = "debian-x86_64-wx32"/>
+      <xs:enumeration value = "debian-wx32-x86_64"/>
       <xs:enumeration value = "debian-arm64"/>
-      <xs:enumeration value = "debian-arm64-wx32"/>
+      <xs:enumeration value = "debian-wx32-arm64"/>
       <xs:enumeration value = "flatpak-aarch64"/>
       <xs:enumeration value = "flatpak-x86_64"/>
       <xs:enumeration value = "mingw"/> <!-- transitional, see OpenCPN#2061 -->


### PR DESCRIPTION
For both technical reasons and just to be consistent types like _debian-armhf_wx32_ should be _debian_wx32_armhf_ etc.