### PR TITLE
ocpn-plugin: Add new abi darwin-wx32 (OpenCPN#2797)

### DIFF
--- a/ocpn-plugin.xsd
+++ b/ocpn-plugin.xsd
@@ -62,6 +62,7 @@
       <xs:enumeration value = "android-armhf"/>
       <xs:enumeration value = "darwin"/>
       <xs:enumeration value = "darwin-arm64"/>
+      <xs:enumeration value = "darwin-wx32"/>
       <xs:enumeration value = "debian-armhf"/>
       <xs:enumeration value = "debian-wx32-armhf"/>
       <xs:enumeration value = "debian-gtk3-armhf"/>


### PR DESCRIPTION
As discussed in https://github.com/OpenCPN/OpenCPN/discussions/2797: add  a new ABI specification for wx32-based plugins on MacOS.