### PR TITLE
Fix checksums for radar v5.5.0-beta

### DIFF
--- a/metadata/Radar-v5.5.0-beta-darwin-wx32-10.xml
+++ b/metadata/Radar-v5.5.0-beta-darwin-wx32-10.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/2279 -->
+<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/2298 -->
 <plugin version="1">
   <name> Radar </name>
   <version> v5.5.0-beta </version>
@@ -30,5 +30,5 @@ such as dual radar range and Doppler.
   <target-version>10</target-version>
   <target-arch>x86_64</target-arch>
   <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta-darwin-wx32-10-tarball/versions/v5.5.0-beta/Radar-v5.5.0-beta_darwin-wx32-10-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 704eba252665f5ab0d5be740cd3dedc130d49e741ba305e5b29f0f575a1fa21e </tarball-checksum>
+  <tarball-checksum> 2d5edf5d4b6b8555eb134cf5b7dddd687c92df73ff087953baab7e9e37f381ab </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.0-beta-debian-11.xml
+++ b/metadata/Radar-v5.5.0-beta-debian-11.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/2272 -->
+<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/2285 -->
 <plugin version="1">
   <name> Radar </name>
   <version> v5.5.0-beta </version>
@@ -30,5 +30,5 @@ such as dual radar range and Doppler.
   <target-version>11</target-version>
   <target-arch>x86_64</target-arch>
   <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta-debian-11-tarball/versions/v5.5.0-beta/Radar-v5.5.0-beta_debian-11-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> f7e8eeaf538066079113c376b5fe597ef86fcb00522b762c4a19e1eb02c1a019 </tarball-checksum>
+  <tarball-checksum> ce025ba4ec529a465ea4a117050ae1de08a7075a5aaa6557788c9a507cc41f92 </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.0-beta-debian-A32-11.xml
+++ b/metadata/Radar-v5.5.0-beta-debian-A32-11.xml
@@ -30,5 +30,5 @@ such as dual radar range and Doppler.
   <target-version>11</target-version>
   <target-arch>armhf</target-arch>
   <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta-debian-A32-11-tarball/versions/v5.5.0-beta/Radar-v5.5.0-beta_debian-11-armhf.tar.gz </tarball-url>
-  <tarball-checksum> e9e43b62de13e4cd2937a109986564a926012bf5aefe5f1a13bd4e7d6c1ed0e6 </tarball-checksum>
+  <tarball-checksum> 22fb60d35e739f61eed54a22b8e79241356b73707a9aeaf7b1974a2a056860a9 </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.0-beta-debian-A64-11.xml
+++ b/metadata/Radar-v5.5.0-beta-debian-A64-11.xml
@@ -30,5 +30,5 @@ such as dual radar range and Doppler.
   <target-version>11</target-version>
   <target-arch>arm64</target-arch>
   <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta-debian-A64-11-tarball/versions/v5.5.0-beta/Radar-v5.5.0-beta_debian-11-arm64.tar.gz </tarball-url>
-  <tarball-checksum> 9031c0163b7722924de08aec3bfdfea1c5d04b9ee3cc6f430ff6394371e4ffd0 </tarball-checksum>
+  <tarball-checksum> 6891d00bbcb0dbfff1924735eac593a40e0fa57f231d7d5d2dd0a718571a4dcc </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.0-beta-debian-wx32-A64-11.xml
+++ b/metadata/Radar-v5.5.0-beta-debian-wx32-A64-11.xml
@@ -30,5 +30,5 @@ such as dual radar range and Doppler.
   <target-version>11</target-version>
   <target-arch>arm64</target-arch>
   <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta-debian-wx32-A64-11-tarball/versions/v5.5.0-beta/Radar-v5.5.0-beta_debian-wx32-11-arm64.tar.gz </tarball-url>
-  <tarball-checksum> 89cf93ba7f53d8eebc2408d0827399d54c6debf7be7999f6470752f66685f1ea </tarball-checksum>
+  <tarball-checksum> d72b5c074544dcd8853bb37a0a47d1d54b7698a78bcf81f8d5b4eea8e31774cf </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.0-beta-flatpak-A64-22.08.xml
+++ b/metadata/Radar-v5.5.0-beta-flatpak-A64-22.08.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/2274 -->
+<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/2299 -->
 <plugin version="1">
   <name> Radar </name>
   <version> v5.5.0-beta </version>
@@ -30,5 +30,5 @@ such as dual radar range and Doppler.
   <target-version>22.08</target-version>
   <target-arch>aarch64</target-arch>
   <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta-flatpak-A64-22.08-tarball/versions/v5.5.0-beta/Radar-v5.5.0-beta_flatpak-22.08-aarch64.tar.gz </tarball-url>
-  <tarball-checksum> 58fab5a05a95f61ab69e71d3a8980254d33afbb39b5c73cc43bb9b8036341fb1 </tarball-checksum>
+  <tarball-checksum> 0ea2e793ee521b18f15eaaeb07814226b458423ae1cea7bbaaea07a48cafa1cf </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.0-beta-msvc-wx32-10.xml
+++ b/metadata/Radar-v5.5.0-beta-msvc-wx32-10.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://ci.appveyor.com/project/keesverruijt/radar-pi/builds/46430097 -->
+<!-- https://ci.appveyor.com/project/keesverruijt/radar-pi/builds/46430566 -->
 <plugin version="1">
   <name> Radar </name>
   <version> v5.5.0-beta </version>
@@ -30,5 +30,5 @@ such as dual radar range and Doppler.
   <target-version>10</target-version>
   <target-arch>x86_64</target-arch>
   <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta-msvc-wx32-10-tarball/versions/v5.5.0-beta/Radar-v5.5.0-beta_msvc-wx32-10-win32.tar.gz </tarball-url>
-  <tarball-checksum> 9e227f08cc1179bc6b79f492b0dd56bba74303cb3067575f0d4d6dabe80cec46 </tarball-checksum>
+  <tarball-checksum> b28d94cca1fdc3a094969ba8f1517840aa8993c349a946d696030e9a5402ae80 </tarball-checksum>
 </plugin>


### PR DESCRIPTION
Due to a botched patchup the download process did not re-download the files created in an earlier attempt and so the wrong checksums were committed.