### PR TITLE
Radar v5.5.0-beta2

### DIFF
--- a/metadata/Radar-v5.5.0-beta2-darwin-wx32-10.xml
+++ b/metadata/Radar-v5.5.0-beta2-darwin-wx32-10.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/2480 -->
+<plugin version="1">
+  <name> Radar </name>
+  <version> v5.5.0-beta2 </version>
+  <release>  </release>
+  <summary> Overlays the radar picture on OpenCPN </summary>
+
+  <api-version> 1.16 </api-version>
+  <open-source> yes </open-source>
+  <author> Hakan Svensson / Douwe Fokkema / Kees Verruijt / David S Register </author>
+  <source> https://github.com/opencpn-radar-pi/radar_pi </source>
+  <info-url> https://opencpn.org/OpenCPN/plugins/radarPI.html </info-url>
+
+  <description> Garmin, Navico and Raymarine radar support
+
+WARNING: OPENGL MODE IS REQUIRED!
+
+Works with Garmin HD, xHD, Navico BR24, 3G, 4G, HALOxx and several Raymarine radars.
+
+When a compass heading is provided it will allow radar overlay on the chart(s).
+It also allows separate display of a traditional radar picture (PPI).
+
+Supports MARPA (even on radars that do not support this themselves),
+Guard zones, AIS overlay on PPI, and various radar dependent features
+such as dual radar range and Doppler.
+ </description>
+
+  <target>darwin-wx32</target>
+  <target-version>10</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta2-darwin-wx32-10-tarball/versions/v5.5.0-beta2/Radar-v5.5.0-beta2_darwin-wx32-10-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 2a5fba7d238ff73f2524e8bae0a4ff677b825f45dba4c538abf03a236706e985 </tarball-checksum>
+</plugin>

--- a/metadata/Radar-v5.5.0-beta2-debian-11.xml
+++ b/metadata/Radar-v5.5.0-beta2-debian-11.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--  -->
+<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/2481 -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.5.0-beta </version>
+  <version> v5.5.0-beta2 </version>
   <release>  </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>debian-armhf</target>
-  <target-version>12</target-version>
-  <target-arch>armhf</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta-debian-A32-12-tarball/versions/v5.5.0-beta/Radar-v5.5.0-beta_debian-12-armhf.tar.gz </tarball-url>
-  <tarball-checksum> 34436e2d4d270031dc2bee5a4e98936389aaa6cbdab834edeee9a9a740f5db8e </tarball-checksum>
+  <target>debian-x86_64</target>
+  <target-version>11</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta2-debian-11-tarball/versions/v5.5.0-beta2/Radar-v5.5.0-beta2_debian-11-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 2dc7dda48398e61d94d7a90134b8cd30eac5da9d2dbe114b69ca541b24131809 </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.0-beta2-debian-12.xml
+++ b/metadata/Radar-v5.5.0-beta2-debian-12.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/2299 -->
+<!--  -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.5.0-beta </version>
+  <version> v5.5.0-beta2 </version>
   <release>  </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>flatpak-aarch64</target>
-  <target-version>22.08</target-version>
-  <target-arch>aarch64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta-flatpak-A64-22.08-tarball/versions/v5.5.0-beta/Radar-v5.5.0-beta_flatpak-22.08-aarch64.tar.gz </tarball-url>
-  <tarball-checksum> 0ea2e793ee521b18f15eaaeb07814226b458423ae1cea7bbaaea07a48cafa1cf </tarball-checksum>
+  <target>debian-x86_64</target>
+  <target-version>12</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta2-debian-12-tarball/versions/v5.5.0-beta2/Radar-v5.5.0-beta2_debian-12-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 5313355298756b342463def10b4f84240b3e077d5b46ea8e8141a386b0c426cc </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.0-beta2-debian-A32-11.xml
+++ b/metadata/Radar-v5.5.0-beta2-debian-A32-11.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/2284 -->
+<!--  -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.5.0-beta </version>
+  <version> v5.5.0-beta2 </version>
   <release>  </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>debian-wx32-x86_64</target>
+  <target>debian-armhf</target>
   <target-version>11</target-version>
-  <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta-debian-wx32.wx32-11-tarball/versions/v5.5.0-beta/Radar-v5.5.0-beta_debian-wx32.wx32-11-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 5ce233e71607ffbc5d2e9c737adac8e4563403dabc236adbaa8efd4d5b1e69fb </tarball-checksum>
+  <target-arch>armhf</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta2-debian-A32-11-tarball/versions/v5.5.0-beta2/Radar-v5.5.0-beta2_debian-11-armhf.tar.gz </tarball-url>
+  <tarball-checksum> 4dd925c01b51dc24646cb9bce16003ebadb259435676a6f4ba3cf6d046fead4f </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.0-beta2-debian-A32-12.xml
+++ b/metadata/Radar-v5.5.0-beta2-debian-A32-12.xml
@@ -2,7 +2,7 @@
 <!--  -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.5.0-beta </version>
+  <version> v5.5.0-beta2 </version>
   <release>  </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>debian-arm64</target>
-  <target-version>11</target-version>
-  <target-arch>arm64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta-debian-A64-11-tarball/versions/v5.5.0-beta/Radar-v5.5.0-beta_debian-11-arm64.tar.gz </tarball-url>
-  <tarball-checksum> 6891d00bbcb0dbfff1924735eac593a40e0fa57f231d7d5d2dd0a718571a4dcc </tarball-checksum>
+  <target>debian-armhf</target>
+  <target-version>12</target-version>
+  <target-arch>armhf</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta2-debian-A32-12-tarball/versions/v5.5.0-beta2/Radar-v5.5.0-beta2_debian-12-armhf.tar.gz </tarball-url>
+  <tarball-checksum> f70cdf90c456c88a1e88da25fc904cee8c66ac837294f27571676cdebee3f9e4 </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.0-beta2-debian-A64-11.xml
+++ b/metadata/Radar-v5.5.0-beta2-debian-A64-11.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/2298 -->
+<!--  -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.5.0-beta </version>
+  <version> v5.5.0-beta2 </version>
   <release>  </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>darwin-wx32</target>
-  <target-version>10</target-version>
-  <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta-darwin-wx32-10-tarball/versions/v5.5.0-beta/Radar-v5.5.0-beta_darwin-wx32-10-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 2d5edf5d4b6b8555eb134cf5b7dddd687c92df73ff087953baab7e9e37f381ab </tarball-checksum>
+  <target>debian-arm64</target>
+  <target-version>11</target-version>
+  <target-arch>arm64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta2-debian-A64-11-tarball/versions/v5.5.0-beta2/Radar-v5.5.0-beta2_debian-11-arm64.tar.gz </tarball-url>
+  <tarball-checksum> b275c578e4c6a9d31cd7b8cff40082f0cc929376a0486eca81eb432292720712 </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.0-beta2-debian-A64-12.xml
+++ b/metadata/Radar-v5.5.0-beta2-debian-A64-12.xml
@@ -2,7 +2,7 @@
 <!--  -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.5.0-beta </version>
+  <version> v5.5.0-beta2 </version>
   <release>  </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -29,6 +29,6 @@ such as dual radar range and Doppler.
   <target>debian-arm64</target>
   <target-version>12</target-version>
   <target-arch>arm64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta-debian-A64-12-tarball/versions/v5.5.0-beta/Radar-v5.5.0-beta_debian-12-arm64.tar.gz </tarball-url>
-  <tarball-checksum> 2d0fcc9cd14ff7a89579fd96796db57e7aa8a5f4ee9e8b65e450c218687a02f9 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta2-debian-A64-12-tarball/versions/v5.5.0-beta2/Radar-v5.5.0-beta2_debian-12-arm64.tar.gz </tarball-url>
+  <tarball-checksum> 103d0098d22672c74864816994f15d808fc9e6f85e4129705f9fed4455f85dd4 </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.0-beta2-debian-wx32-A64-11.xml
+++ b/metadata/Radar-v5.5.0-beta2-debian-wx32-A64-11.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/2286 -->
+<!--  -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.5.0-beta </version>
+  <version> v5.5.0-beta2 </version>
   <release>  </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>flatpak-x86_64</target>
-  <target-version>22.08</target-version>
-  <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta-flatpak-22.08-tarball/versions/v5.5.0-beta/Radar-v5.5.0-beta_flatpak-22.08-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 7c9c0b42331a02dc5151fe03c36c84b3cf1b21161c0b90e2d837859ba3c915bc </tarball-checksum>
+  <target>debian-wx32-arm64</target>
+  <target-version>11</target-version>
+  <target-arch>arm64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta2-debian-wx32-A64-11-tarball/versions/v5.5.0-beta2/Radar-v5.5.0-beta2_debian-wx32-11-arm64.tar.gz </tarball-url>
+  <tarball-checksum> 4df36b7769dc6b880867f4180f0b7b1a9a5dcb137e61664f5c181a29b6a4b1c6 </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.0-beta2-debian-wx32.wx32-11.xml
+++ b/metadata/Radar-v5.5.0-beta2-debian-wx32.wx32-11.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--  -->
+<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/2489 -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.5.0-beta </version>
+  <version> v5.5.0-beta2 </version>
   <release>  </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>debian-armhf</target>
+  <target>debian-wx32-x86_64</target>
   <target-version>11</target-version>
-  <target-arch>armhf</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta-debian-A32-11-tarball/versions/v5.5.0-beta/Radar-v5.5.0-beta_debian-11-armhf.tar.gz </tarball-url>
-  <tarball-checksum> 22fb60d35e739f61eed54a22b8e79241356b73707a9aeaf7b1974a2a056860a9 </tarball-checksum>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta2-debian-wx32.wx32-11-tarball/versions/v5.5.0-beta2/Radar-v5.5.0-beta2_debian-wx32.wx32-11-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 229ba5d463637bfe56dcb9b4383e1f7cb556dda913a6485c64bd7cfd414b3d0c </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.0-beta2-debian-wx32.wx32-A32-11.xml
+++ b/metadata/Radar-v5.5.0-beta2-debian-wx32.wx32-A32-11.xml
@@ -2,7 +2,7 @@
 <!--  -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.5.0-beta </version>
+  <version> v5.5.0-beta2 </version>
   <release>  </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>debian-x86_64</target>
-  <target-version>12</target-version>
-  <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta-debian-12-tarball/versions/v5.5.0-beta/Radar-v5.5.0-beta_debian-12-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 2bca4ff95e87f32e6183a5d677bbd3c4612ef5139c8ddc673364f7720ea6c934 </tarball-checksum>
+  <target>debian-wx32-armhf</target>
+  <target-version>11</target-version>
+  <target-arch>armhf</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta2-debian-wx32.wx32-A32-11-tarball/versions/v5.5.0-beta2/Radar-v5.5.0-beta2_debian-wx32.wx32-11-armhf.tar.gz </tarball-url>
+  <tarball-checksum> 0409171f9ce28ec641ad599dae20399de8971218bd301d2a5f01bf9c56850b20 </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.0-beta2-flatpak-22.08.xml
+++ b/metadata/Radar-v5.5.0-beta2-flatpak-22.08.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--  -->
+<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/2490 -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.5.0-beta </version>
+  <version> v5.5.0-beta2 </version>
   <release>  </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>debian-wx32-arm64</target>
-  <target-version>11</target-version>
-  <target-arch>arm64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta-debian-wx32-A64-11-tarball/versions/v5.5.0-beta/Radar-v5.5.0-beta_debian-wx32-11-arm64.tar.gz </tarball-url>
-  <tarball-checksum> d72b5c074544dcd8853bb37a0a47d1d54b7698a78bcf81f8d5b4eea8e31774cf </tarball-checksum>
+  <target>flatpak-x86_64</target>
+  <target-version>22.08</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta2-flatpak-22.08-tarball/versions/v5.5.0-beta2/Radar-v5.5.0-beta2_flatpak-22.08-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 7550bb7dce4c66051b9a03d0dcebbb5251590cb343f9b8573091a996b03c9b77 </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.0-beta2-flatpak-A64-22.08.xml
+++ b/metadata/Radar-v5.5.0-beta2-flatpak-A64-22.08.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/2285 -->
+<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/2487 -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.5.0-beta </version>
+  <version> v5.5.0-beta2 </version>
   <release>  </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>debian-x86_64</target>
-  <target-version>11</target-version>
-  <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta-debian-11-tarball/versions/v5.5.0-beta/Radar-v5.5.0-beta_debian-11-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> ce025ba4ec529a465ea4a117050ae1de08a7075a5aaa6557788c9a507cc41f92 </tarball-checksum>
+  <target>flatpak-aarch64</target>
+  <target-version>22.08</target-version>
+  <target-arch>aarch64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta2-flatpak-A64-22.08-tarball/versions/v5.5.0-beta2/Radar-v5.5.0-beta2_flatpak-22.08-aarch64.tar.gz </tarball-url>
+  <tarball-checksum> dfdc9530cac882c9bea79fd6f03ca280eded0c23df313190c8084428911e03a7 </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.0-beta2-msvc-wx32-10.xml
+++ b/metadata/Radar-v5.5.0-beta2-msvc-wx32-10.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://ci.appveyor.com/project/keesverruijt/radar-pi/builds/46430566 -->
+<!-- https://ci.appveyor.com/project/keesverruijt/radar-pi/builds/46750287 -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.5.0-beta </version>
+  <version> v5.5.0-beta2 </version>
   <release>  </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -29,6 +29,6 @@ such as dual radar range and Doppler.
   <target>msvc-wx32</target>
   <target-version>10</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta-msvc-wx32-10-tarball/versions/v5.5.0-beta/Radar-v5.5.0-beta_msvc-wx32-10-win32.tar.gz </tarball-url>
-  <tarball-checksum> b28d94cca1fdc3a094969ba8f1517840aa8993c349a946d696030e9a5402ae80 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.0-beta2-msvc-wx32-10-tarball/versions/v5.5.0-beta2/Radar-v5.5.0-beta2_msvc-wx32-10-win32.tar.gz </tarball-url>
+  <tarball-checksum> 9fa1a84ff2d4352f3e8551df3445cda277f254d4ca8a2ebae5eca4f9c5e58097 </tarball-checksum>
 </plugin>


### PR DESCRIPTION
Build for -wx32 on the proper platforms with wx 3.2.2.1 dependencies.