### PR TITLE
Fix pre-commit

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -5,9 +5,11 @@
 #   - Copy to .git/hooks to activate.
 #   - Use --no-verify to override.
 
+set -euo pipefail
+
 function files_to_update()
 {
-    git diff --cached --name-status | grep -v ^D | awk '$1 $2 { print $2}'
+    git diff --cached --name-status | grep -v ^D | awk '{print $NF}'
 }
 topdir=$( git rev-parse --show-toplevel )
 here=$(dirname $0)
@@ -15,8 +17,11 @@ here=$(dirname $0)
 XML_SOURCES=( $( files_to_update | grep -E '\.xml$'))
 
 if [ -n "$XML_SOURCES" ]; then
-  xmllint --schema $topdir/ocpn-plugin.xsd  $XML_SOURCES --noout || exit 1
-  python $here/../../tools/check-metadata-urls $XML_SOURCES  || exit 1
+  for f in "${XML_SOURCES[@]}"
+  do
+    xmllint --schema "${topdir}/ocpn-plugin.xsd" "${f}" --noout || exit 1
+    python "${here}/../../tools/check-metadata-urls" "${f}" || exit 1
+  done
 fi
 
 # If there are whitespace errors, print the offending file names and fail.


### PR DESCRIPTION
* When files are renamed, use the renamed-to file as the file to verify.
* Iterate over all files in $XML_SOURCES; previously only the first file was checked.
* Shellcheck safe.