### PR TITLE
polar 1.2.3 + TP1.0.237

### DIFF
--- a/metadata/polar_pi-1.2.3.0-darwin-wx32-x86_64-11.4-macos.xml
+++ b/metadata/polar_pi-1.2.3.0-darwin-wx32-x86_64-11.4-macos.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Polar </name>
-<version> 1.2.2.0 </version>
+<version> 1.2.3.0 </version>
 <release> 0 </release>
 <summary> Polar Plugin makes polar diagrams for Weather Routing Predictions </summary>
 
@@ -14,13 +14,13 @@
 Polar Plugin reads VDR data files directly, reads from Opencpn input Nmea channel (Record Start/Stop at bottom) and direct from LogBoookKonni records, to creates a polar diagram which can then be edited manually, saved or loaded as a Boat Polar file. The LogbookKonni selection has several options.
 </description>
 
-<target>raspbian-armhf</target>
-<build-target>raspbian</build-target>
-<build-gtk>gtk2</build-gtk>
-<target-version>9.13</target-version>
-<target-arch>armhf</target-arch>
+<target>darwin-wx32</target>
+<build-target>darwin</build-target>
+<build-gtk></build-gtk>
+<target-version>11.4</target-version>
+<target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.2.0-raspbian-armhf-9.13-stretch-armhf-tarball/versions/v1.2.2.0/polar_pi-1.2.2.0-raspbian-armhf-9.13-stretch-armhf.tar.gz
+https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.3.0-darwin-wx32-x86_64-11.4-macos-tarball/versions/v1.2.3/polar_pi-1.2.3.0-darwin-wx32-x86_64-11.4-macos.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/polar.html </info-url>
 </plugin>

--- a/metadata/polar_pi-1.2.3.0-darwin-x86_64-11.4-macos.xml
+++ b/metadata/polar_pi-1.2.3.0-darwin-x86_64-11.4-macos.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Polar </name>
-<version> 1.2.2.0 </version>
+<version> 1.2.3.0 </version>
 <release> 0 </release>
 <summary> Polar Plugin makes polar diagrams for Weather Routing Predictions </summary>
 
@@ -14,13 +14,13 @@
 Polar Plugin reads VDR data files directly, reads from Opencpn input Nmea channel (Record Start/Stop at bottom) and direct from LogBoookKonni records, to creates a polar diagram which can then be edited manually, saved or loaded as a Boat Polar file. The LogbookKonni selection has several options.
 </description>
 
-<target>debian-arm64</target>
-<build-target>debian</build-target>
-<build-gtk>gtk2</build-gtk>
-<target-version>10</target-version>
-<target-arch>arm64</target-arch>
+<target>darwin</target>
+<build-target>darwin</build-target>
+<build-gtk></build-gtk>
+<target-version>11.4</target-version>
+<target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.2.0-debian-arm64-10-buster-arm64-tarball/versions/v1.2.2.0/polar_pi-1.2.2.0-debian-arm64-10-buster-arm64.tar.gz
+https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.3.0-darwin-x86_64-11.4-macos-tarball/versions/v1.2.3/polar_pi-1.2.3.0-darwin-x86_64-11.4-macos.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/polar.html </info-url>
 </plugin>

--- a/metadata/polar_pi-1.2.3.0-debian-arm64-10-buster-arm64.xml
+++ b/metadata/polar_pi-1.2.3.0-debian-arm64-10-buster-arm64.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Polar </name>
-<version> 1.2.2.0 </version>
+<version> 1.2.3.0 </version>
 <release> 0 </release>
 <summary> Polar Plugin makes polar diagrams for Weather Routing Predictions </summary>
 
@@ -14,13 +14,13 @@
 Polar Plugin reads VDR data files directly, reads from Opencpn input Nmea channel (Record Start/Stop at bottom) and direct from LogBoookKonni records, to creates a polar diagram which can then be edited manually, saved or loaded as a Boat Polar file. The LogbookKonni selection has several options.
 </description>
 
-<target>debian-armhf</target>
+<target>debian-arm64</target>
 <build-target>debian</build-target>
-<build-gtk></build-gtk>
-<target-version>11</target-version>
-<target-arch>armhf</target-arch>
+<build-gtk>gtk2</build-gtk>
+<target-version>10</target-version>
+<target-arch>arm64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.2.0-debian-armhf-11-bullseye-armhf-tarball/versions/v1.2.2.0/polar_pi-1.2.2.0-debian-armhf-11-bullseye-armhf.tar.gz
+https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.3.0-debian-arm64-10-buster-arm64-tarball/versions/v1.2.3/polar_pi-1.2.3.0-debian-arm64-10-buster-arm64.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/polar.html </info-url>
 </plugin>

--- a/metadata/polar_pi-1.2.3.0-debian-arm64-11-bullseye-arm64.xml
+++ b/metadata/polar_pi-1.2.3.0-debian-arm64-11-bullseye-arm64.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Polar </name>
-<version> 1.2.2.0 </version>
+<version> 1.2.3.0 </version>
 <release> 0 </release>
 <summary> Polar Plugin makes polar diagrams for Weather Routing Predictions </summary>
 
@@ -14,13 +14,13 @@
 Polar Plugin reads VDR data files directly, reads from Opencpn input Nmea channel (Record Start/Stop at bottom) and direct from LogBoookKonni records, to creates a polar diagram which can then be edited manually, saved or loaded as a Boat Polar file. The LogbookKonni selection has several options.
 </description>
 
-<target>darwin</target>
-<build-target>darwin</build-target>
+<target>debian-arm64</target>
+<build-target>debian</build-target>
 <build-gtk></build-gtk>
-<target-version>11.4</target-version>
-<target-arch>x86_64</target-arch>
+<target-version>11</target-version>
+<target-arch>arm64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.2.0-darwin-x86_64-11.4-macos-tarball/versions/v1.2.2.0/polar_pi-1.2.2.0-darwin-x86_64-11.4-macos.tar.gz
+https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.3.0-debian-arm64-11-bullseye-arm64-tarball/versions/v1.2.3/polar_pi-1.2.3.0-debian-arm64-11-bullseye-arm64.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/polar.html </info-url>
 </plugin>

--- a/metadata/polar_pi-1.2.3.0-debian-arm64-wx32-12-bookworm-arm64.xml
+++ b/metadata/polar_pi-1.2.3.0-debian-arm64-wx32-12-bookworm-arm64.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Polar </name>
-<version> 1.2.2.0 </version>
+<version> 1.2.3.0 </version>
 <release> 0 </release>
 <summary> Polar Plugin makes polar diagrams for Weather Routing Predictions </summary>
 
@@ -14,13 +14,13 @@
 Polar Plugin reads VDR data files directly, reads from Opencpn input Nmea channel (Record Start/Stop at bottom) and direct from LogBoookKonni records, to creates a polar diagram which can then be edited manually, saved or loaded as a Boat Polar file. The LogbookKonni selection has several options.
 </description>
 
-<target>msvc</target>
-<build-target>msvc</build-target>
+<target>debian-wx32-arm64</target>
+<build-target>debian</build-target>
 <build-gtk></build-gtk>
-<target-version>10.0.14393</target-version>
-<target-arch>x86_64</target-arch>
+<target-version>12</target-version>
+<target-arch>arm64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.2.0-msvc-x86_64-10.0.14393-MSVC-tarball/versions/v1.2.2.0/polar_pi-1.2.2.0-msvc-x86_64-10.0.14393-MSVC.tar.gz
+https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.3.0-debian-arm64-wx32-12-bookworm-arm64-tarball/versions/v1.2.3/polar_pi-1.2.3.0-debian-arm64-wx32-12-bookworm-arm64.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/polar.html </info-url>
 </plugin>

--- a/metadata/polar_pi-1.2.3.0-debian-armhf-10-buster-armhf.xml
+++ b/metadata/polar_pi-1.2.3.0-debian-armhf-10-buster-armhf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Polar </name>
-<version> 1.2.2.0 </version>
+<version> 1.2.3.0 </version>
 <release> 0 </release>
 <summary> Polar Plugin makes polar diagrams for Weather Routing Predictions </summary>
 
@@ -14,13 +14,13 @@
 Polar Plugin reads VDR data files directly, reads from Opencpn input Nmea channel (Record Start/Stop at bottom) and direct from LogBoookKonni records, to creates a polar diagram which can then be edited manually, saved or loaded as a Boat Polar file. The LogbookKonni selection has several options.
 </description>
 
-<target>flatpak-x86_64</target>
-<build-target>flatpak</build-target>
-<build-gtk></build-gtk>
-<target-version>20.08</target-version>
-<target-arch>x86_64</target-arch>
+<target>debian-armhf</target>
+<build-target>debian</build-target>
+<build-gtk>gtk2</build-gtk>
+<target-version>10</target-version>
+<target-arch>armhf</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.2.0-flatpak-x86_64-20.08-flatpak-tarball/versions/v1.2.2.0/polar_pi-1.2.2.0-x86_64_flatpak-20.08.tar.gz
+https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.3.0-debian-armhf-10-buster-armhf-tarball/versions/v1.2.3/polar_pi-1.2.3.0-debian-armhf-10-buster-armhf.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/polar.html </info-url>
 </plugin>

--- a/metadata/polar_pi-1.2.3.0-debian-armhf-10-gtk3-buster-armhf.xml
+++ b/metadata/polar_pi-1.2.3.0-debian-armhf-10-gtk3-buster-armhf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Polar </name>
-<version> 1.2.2.0 </version>
+<version> 1.2.3.0 </version>
 <release> 0 </release>
 <summary> Polar Plugin makes polar diagrams for Weather Routing Predictions </summary>
 
@@ -14,13 +14,13 @@
 Polar Plugin reads VDR data files directly, reads from Opencpn input Nmea channel (Record Start/Stop at bottom) and direct from LogBoookKonni records, to creates a polar diagram which can then be edited manually, saved or loaded as a Boat Polar file. The LogbookKonni selection has several options.
 </description>
 
-<target>ubuntu-x86_64</target>
-<build-target>ubuntu</build-target>
-<build-gtk>gtk3</build-gtk>
-<target-version>22.04</target-version>
-<target-arch>x86_64</target-arch>
+<target>debian-gtk3-armhf</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>10</target-version>
+<target-arch>armhf</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.2.0-ubuntu-x86_64-22.04-jammy-tarball/versions/v1.2.2.0/polar_pi-1.2.2.0-ubuntu-x86_64-22.04-jammy.tar.gz
+https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.3.0-debian-armhf-gtk3-10-buster-armhf-tarball/versions/v1.2.3/polar_pi-1.2.3.0-debian-armhf-10-gtk3-buster-armhf.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/polar.html </info-url>
 </plugin>

--- a/metadata/polar_pi-1.2.3.0-debian-armhf-11-bullseye-armhf.xml
+++ b/metadata/polar_pi-1.2.3.0-debian-armhf-11-bullseye-armhf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Polar </name>
-<version> 1.2.2.0 </version>
+<version> 1.2.3.0 </version>
 <release> 0 </release>
 <summary> Polar Plugin makes polar diagrams for Weather Routing Predictions </summary>
 
@@ -14,13 +14,13 @@
 Polar Plugin reads VDR data files directly, reads from Opencpn input Nmea channel (Record Start/Stop at bottom) and direct from LogBoookKonni records, to creates a polar diagram which can then be edited manually, saved or loaded as a Boat Polar file. The LogbookKonni selection has several options.
 </description>
 
-<target>ubuntu-armhf</target>
-<build-target>ubuntu</build-target>
-<build-gtk>gtk2</build-gtk>
-<target-version>18.04</target-version>
+<target>debian-armhf</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>11</target-version>
 <target-arch>armhf</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.2.0-ubuntu-armhf-18.04-buster-armhf-tarball/versions/v1.2.2.0/polar_pi-1.2.2.0-ubuntu-armhf-18.04-buster-armhf.tar.gz
+https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.3.0-debian-armhf-11-bullseye-armhf-tarball/versions/v1.2.3/polar_pi-1.2.3.0-debian-armhf-11-bullseye-armhf.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/polar.html </info-url>
 </plugin>

--- a/metadata/polar_pi-1.2.3.0-debian-armhf-wx32-12-bookworm-armhf.xml
+++ b/metadata/polar_pi-1.2.3.0-debian-armhf-wx32-12-bookworm-armhf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Polar </name>
-<version> 1.2.2.0 </version>
+<version> 1.2.3.0 </version>
 <release> 0 </release>
 <summary> Polar Plugin makes polar diagrams for Weather Routing Predictions </summary>
 
@@ -14,13 +14,13 @@
 Polar Plugin reads VDR data files directly, reads from Opencpn input Nmea channel (Record Start/Stop at bottom) and direct from LogBoookKonni records, to creates a polar diagram which can then be edited manually, saved or loaded as a Boat Polar file. The LogbookKonni selection has several options.
 </description>
 
-<target>flatpak-x86_64</target>
-<build-target>flatpak</build-target>
+<target>debian-wx32-armhf</target>
+<build-target>debian</build-target>
 <build-gtk></build-gtk>
-<target-version>22.08</target-version>
-<target-arch>x86_64</target-arch>
+<target-version>12</target-version>
+<target-arch>armhf</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.2.0-flatpak-x86_64-22.08-flatpak-tarball/versions/v1.2.2.0/polar_pi-1.2.2.0-x86_64_flatpak-22.08.tar.gz
+https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.3.0-debian-armhf-wx32-12-bookworm-armhf-tarball/versions/v1.2.3/polar_pi-1.2.3.0-debian-armhf-wx32-12-bookworm-armhf.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/polar.html </info-url>
 </plugin>

--- a/metadata/polar_pi-1.2.3.0-debian-x86_64-10-buster.xml
+++ b/metadata/polar_pi-1.2.3.0-debian-x86_64-10-buster.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Polar </name>
-<version> 1.2.2.0 </version>
+<version> 1.2.3.0 </version>
 <release> 0 </release>
 <summary> Polar Plugin makes polar diagrams for Weather Routing Predictions </summary>
 
@@ -14,13 +14,13 @@
 Polar Plugin reads VDR data files directly, reads from Opencpn input Nmea channel (Record Start/Stop at bottom) and direct from LogBoookKonni records, to creates a polar diagram which can then be edited manually, saved or loaded as a Boat Polar file. The LogbookKonni selection has several options.
 </description>
 
-<target>darwin-wx32</target>
-<build-target>darwin</build-target>
-<build-gtk></build-gtk>
-<target-version>11.4</target-version>
+<target>debian-x86_64</target>
+<build-target>debian</build-target>
+<build-gtk>gtk2</build-gtk>
+<target-version>10</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.2.0-darwin-wx32-x86_64-11.4-macos-tarball/versions/v1.2.2.0/polar_pi-1.2.2.0-darwin-wx32-x86_64-11.4-macos.tar.gz
+https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.3.0-debian-x86_64-10-buster-tarball/versions/v1.2.3/polar_pi-1.2.3.0-debian-x86_64-10-buster.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/polar.html </info-url>
 </plugin>

--- a/metadata/polar_pi-1.2.3.0-debian-x86_64-11-bullseye.xml
+++ b/metadata/polar_pi-1.2.3.0-debian-x86_64-11-bullseye.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Polar </name>
-<version> 1.2.2.0 </version>
+<version> 1.2.3.0 </version>
 <release> 0 </release>
 <summary> Polar Plugin makes polar diagrams for Weather Routing Predictions </summary>
 
@@ -14,13 +14,13 @@
 Polar Plugin reads VDR data files directly, reads from Opencpn input Nmea channel (Record Start/Stop at bottom) and direct from LogBoookKonni records, to creates a polar diagram which can then be edited manually, saved or loaded as a Boat Polar file. The LogbookKonni selection has several options.
 </description>
 
-<target>ubuntu-gtk3-x86_64</target>
-<build-target>ubuntu</build-target>
+<target>debian-x86_64</target>
+<build-target>debian</build-target>
 <build-gtk>gtk3</build-gtk>
-<target-version>18.04</target-version>
+<target-version>11</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.2.0-ubuntu-x86_64-gtk3-18.04-bionic-gtk3-tarball/versions/v1.2.2.0/polar_pi-1.2.2.0-ubuntu-x86_64-18.04-gtk3-bionic-gtk3.tar.gz
+https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.3.0-debian-x86_64-11-bullseye-tarball/versions/v1.2.3/polar_pi-1.2.3.0-debian-x86_64-11-bullseye.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/polar.html </info-url>
 </plugin>

--- a/metadata/polar_pi-1.2.3.0-debian-x86_64-12-bookworm.xml
+++ b/metadata/polar_pi-1.2.3.0-debian-x86_64-12-bookworm.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Polar </name>
+<version> 1.2.3.0 </version>
+<release> 0 </release>
+<summary> Polar Plugin makes polar diagrams for Weather Routing Predictions </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> Peter Tulp </author>
+<source> https://github.com/rgleason/polar_pi </source>
+
+<description>
+Polar Plugin reads VDR data files directly, reads from Opencpn input Nmea channel (Record Start/Stop at bottom) and direct from LogBoookKonni records, to creates a polar diagram which can then be edited manually, saved or loaded as a Boat Polar file. The LogbookKonni selection has several options.
+</description>
+
+<target>debian-wx32-x86_64</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>12</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.3.0-debian-x86_64-wx32-12-bookworm-tarball/versions/v1.2.3/polar_pi-1.2.3.0-debian-x86_64-12-bookworm.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/polar.html </info-url>
+</plugin>

--- a/metadata/polar_pi-1.2.3.0-flatpak-aarch64-20.08-flatpak-arm64.xml
+++ b/metadata/polar_pi-1.2.3.0-flatpak-aarch64-20.08-flatpak-arm64.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Polar </name>
-<version> 1.2.2.0 </version>
+<version> 1.2.3.0 </version>
 <release> 0 </release>
 <summary> Polar Plugin makes polar diagrams for Weather Routing Predictions </summary>
 
@@ -14,13 +14,13 @@
 Polar Plugin reads VDR data files directly, reads from Opencpn input Nmea channel (Record Start/Stop at bottom) and direct from LogBoookKonni records, to creates a polar diagram which can then be edited manually, saved or loaded as a Boat Polar file. The LogbookKonni selection has several options.
 </description>
 
-<target>debian-gtk3-armhf</target>
-<build-target>debian</build-target>
+<target>flatpak-aarch64</target>
+<build-target>flatpak</build-target>
 <build-gtk></build-gtk>
-<target-version>10</target-version>
-<target-arch>armhf</target-arch>
+<target-version>20.08</target-version>
+<target-arch>aarch64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.2.0-debian-armhf-gtk3-10-buster-armhf-tarball/versions/v1.2.2.0/polar_pi-1.2.2.0-debian-armhf-10-gtk3-buster-armhf.tar.gz
+https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.3.0-flatpak-aarch64-20.08-flatpak-arm64-tarball/versions/v1.2.3/polar_pi-1.2.3.0-aarch64_flatpak-20.08.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/polar.html </info-url>
 </plugin>

--- a/metadata/polar_pi-1.2.3.0-flatpak-x86_64-20.08-flatpak.xml
+++ b/metadata/polar_pi-1.2.3.0-flatpak-x86_64-20.08-flatpak.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Polar </name>
-<version> 1.2.2.0 </version>
+<version> 1.2.3.0 </version>
 <release> 0 </release>
 <summary> Polar Plugin makes polar diagrams for Weather Routing Predictions </summary>
 
@@ -14,13 +14,13 @@
 Polar Plugin reads VDR data files directly, reads from Opencpn input Nmea channel (Record Start/Stop at bottom) and direct from LogBoookKonni records, to creates a polar diagram which can then be edited manually, saved or loaded as a Boat Polar file. The LogbookKonni selection has several options.
 </description>
 
-<target>debian-arm64</target>
-<build-target>debian</build-target>
+<target>flatpak-x86_64</target>
+<build-target>flatpak</build-target>
 <build-gtk></build-gtk>
-<target-version>11</target-version>
-<target-arch>arm64</target-arch>
+<target-version>20.08</target-version>
+<target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.2.0-debian-arm64-11-bullseye-arm64-tarball/versions/v1.2.2.0/polar_pi-1.2.2.0-debian-arm64-11-bullseye-arm64.tar.gz
+https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.3.0-flatpak-x86_64-20.08-flatpak-tarball/versions/v1.2.3/polar_pi-1.2.3.0-x86_64_flatpak-20.08.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/polar.html </info-url>
 </plugin>

--- a/metadata/polar_pi-1.2.3.0-flatpak-x86_64-22.08-flatpak.xml
+++ b/metadata/polar_pi-1.2.3.0-flatpak-x86_64-22.08-flatpak.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Polar </name>
-<version> 1.2.2.0 </version>
+<version> 1.2.3.0 </version>
 <release> 0 </release>
 <summary> Polar Plugin makes polar diagrams for Weather Routing Predictions </summary>
 
@@ -14,13 +14,13 @@
 Polar Plugin reads VDR data files directly, reads from Opencpn input Nmea channel (Record Start/Stop at bottom) and direct from LogBoookKonni records, to creates a polar diagram which can then be edited manually, saved or loaded as a Boat Polar file. The LogbookKonni selection has several options.
 </description>
 
-<target>debian-x86_64</target>
-<build-target>debian</build-target>
-<build-gtk>gtk2</build-gtk>
-<target-version>10</target-version>
+<target>flatpak-x86_64</target>
+<build-target>flatpak</build-target>
+<build-gtk></build-gtk>
+<target-version>22.08</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.2.0-debian-x86_64-10-buster-tarball/versions/v1.2.2.0/polar_pi-1.2.2.0-debian-x86_64-10-buster.tar.gz
+https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.3.0-flatpak-x86_64-22.08-flatpak-tarball/versions/v1.2.3/polar_pi-1.2.3.0-x86_64_flatpak-22.08.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/polar.html </info-url>
 </plugin>

--- a/metadata/polar_pi-1.2.3.0-msvc-x86_64-10.0.14393-MSVC.xml
+++ b/metadata/polar_pi-1.2.3.0-msvc-x86_64-10.0.14393-MSVC.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Polar </name>
+<version> 1.2.3.0 </version>
+<release> 0 </release>
+<summary> Polar Plugin makes polar diagrams for Weather Routing Predictions </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> Peter Tulp </author>
+<source> https://github.com/rgleason/polar_pi </source>
+
+<description>
+Polar Plugin reads VDR data files directly, reads from Opencpn input Nmea channel (Record Start/Stop at bottom) and direct from LogBoookKonni records, to creates a polar diagram which can then be edited manually, saved or loaded as a Boat Polar file. The LogbookKonni selection has several options.
+</description>
+
+<target>msvc</target>
+<build-target>msvc</build-target>
+<build-gtk></build-gtk>
+<target-version>10.0.14393</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.3.0-msvc-x86_64-10.0.14393-MSVC-tarball/versions/v1.2.3/polar_pi-1.2.3.0-msvc-x86_64-10.0.14393-MSVC.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/polar.html </info-url>
+</plugin>

--- a/metadata/polar_pi-1.2.3.0-msvc-x86_64-wx32-10.0.17763-MSVC.xml
+++ b/metadata/polar_pi-1.2.3.0-msvc-x86_64-wx32-10.0.17763-MSVC.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Polar </name>
-<version> 1.2.2.0 </version>
+<version> 1.2.3.0 </version>
 <release> 0 </release>
 <summary> Polar Plugin makes polar diagrams for Weather Routing Predictions </summary>
 
@@ -14,13 +14,13 @@
 Polar Plugin reads VDR data files directly, reads from Opencpn input Nmea channel (Record Start/Stop at bottom) and direct from LogBoookKonni records, to creates a polar diagram which can then be edited manually, saved or loaded as a Boat Polar file. The LogbookKonni selection has several options.
 </description>
 
-<target>debian-x86_64</target>
-<build-target>debian</build-target>
-<build-gtk>gtk3</build-gtk>
-<target-version>11</target-version>
+<target>msvc-wx32</target>
+<build-target>msvc</build-target>
+<build-gtk></build-gtk>
+<target-version>10.0.17763</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.2.0-debian-x86_64-11-bullseye-tarball/versions/v1.2.2.0/polar_pi-1.2.2.0-debian-x86_64-11-bullseye.tar.gz
+https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.3.0-msvc-x86_64-wx32-10.0.17763-MSVC-tarball/versions/v1.2.3/polar_pi-1.2.3.0-msvc-x86_64-wx32-10.0.17763-MSVC.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/polar.html </info-url>
 </plugin>

--- a/metadata/polar_pi-1.2.3.0-raspbian-armhf-9.13-stretch-armhf.xml
+++ b/metadata/polar_pi-1.2.3.0-raspbian-armhf-9.13-stretch-armhf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Polar </name>
-<version> 1.2.2.0 </version>
+<version> 1.2.3.0 </version>
 <release> 0 </release>
 <summary> Polar Plugin makes polar diagrams for Weather Routing Predictions </summary>
 
@@ -14,13 +14,13 @@
 Polar Plugin reads VDR data files directly, reads from Opencpn input Nmea channel (Record Start/Stop at bottom) and direct from LogBoookKonni records, to creates a polar diagram which can then be edited manually, saved or loaded as a Boat Polar file. The LogbookKonni selection has several options.
 </description>
 
-<target>ubuntu-x86_64</target>
-<build-target>ubuntu</build-target>
+<target>raspbian-armhf</target>
+<build-target>raspbian</build-target>
 <build-gtk>gtk2</build-gtk>
-<target-version>18.04</target-version>
-<target-arch>x86_64</target-arch>
+<target-version>9.13</target-version>
+<target-arch>armhf</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.2.0-ubuntu-x86_64-18.04-bionic-tarball/versions/v1.2.2.0/polar_pi-1.2.2.0-ubuntu-x86_64-18.04-bionic.tar.gz
+https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.3.0-raspbian-armhf-9.13-stretch-armhf-tarball/versions/v1.2.3/polar_pi-1.2.3.0-raspbian-armhf-9.13-stretch-armhf.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/polar.html </info-url>
 </plugin>

--- a/metadata/polar_pi-1.2.3.0-ubuntu-armhf-18.04-buster-armhf.xml
+++ b/metadata/polar_pi-1.2.3.0-ubuntu-armhf-18.04-buster-armhf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Polar </name>
+<version> 1.2.3.0 </version>
+<release> 0 </release>
+<summary> Polar Plugin makes polar diagrams for Weather Routing Predictions </summary>
+
+<api-version> 1.16 </api-version>
+<open-source> yes </open-source>
+<author> Peter Tulp </author>
+<source> https://github.com/rgleason/polar_pi </source>
+
+<description>
+Polar Plugin reads VDR data files directly, reads from Opencpn input Nmea channel (Record Start/Stop at bottom) and direct from LogBoookKonni records, to creates a polar diagram which can then be edited manually, saved or loaded as a Boat Polar file. The LogbookKonni selection has several options.
+</description>
+
+<target>ubuntu-armhf</target>
+<build-target>ubuntu</build-target>
+<build-gtk>gtk2</build-gtk>
+<target-version>18.04</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.3.0-ubuntu-armhf-18.04-buster-armhf-tarball/versions/v1.2.3/polar_pi-1.2.3.0-ubuntu-armhf-18.04-buster-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/polar.html </info-url>
+</plugin>

--- a/metadata/polar_pi-1.2.3.0-ubuntu-armhf-20.04-gtk3-focal-armhf.xml
+++ b/metadata/polar_pi-1.2.3.0-ubuntu-armhf-20.04-gtk3-focal-armhf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Polar </name>
-<version> 1.2.2.0 </version>
+<version> 1.2.3.0 </version>
 <release> 0 </release>
 <summary> Polar Plugin makes polar diagrams for Weather Routing Predictions </summary>
 
@@ -20,7 +20,7 @@ Polar Plugin reads VDR data files directly, reads from Opencpn input Nmea channe
 <target-version>20.04</target-version>
 <target-arch>armhf</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.2.0-ubuntu-armhf-gtk3-20.04-focal-armhf-tarball/versions/v1.2.2.0/polar_pi-1.2.2.0-ubuntu-armhf-20.04-gtk3-focal-armhf.tar.gz
+https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.3.0-ubuntu-armhf-gtk3-20.04-focal-armhf-tarball/versions/v1.2.3/polar_pi-1.2.3.0-ubuntu-armhf-20.04-gtk3-focal-armhf.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/polar.html </info-url>
 </plugin>

--- a/metadata/polar_pi-1.2.3.0-ubuntu-x86_64-18.04-bionic.xml
+++ b/metadata/polar_pi-1.2.3.0-ubuntu-x86_64-18.04-bionic.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Polar </name>
-<version> 1.2.2.0 </version>
+<version> 1.2.3.0 </version>
 <release> 0 </release>
 <summary> Polar Plugin makes polar diagrams for Weather Routing Predictions </summary>
 
@@ -14,13 +14,13 @@
 Polar Plugin reads VDR data files directly, reads from Opencpn input Nmea channel (Record Start/Stop at bottom) and direct from LogBoookKonni records, to creates a polar diagram which can then be edited manually, saved or loaded as a Boat Polar file. The LogbookKonni selection has several options.
 </description>
 
-<target>flatpak-aarch64</target>
-<build-target>flatpak</build-target>
-<build-gtk></build-gtk>
-<target-version>20.08</target-version>
-<target-arch>aarch64</target-arch>
+<target>ubuntu-x86_64</target>
+<build-target>ubuntu</build-target>
+<build-gtk>gtk2</build-gtk>
+<target-version>18.04</target-version>
+<target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.2.0-flatpak-aarch64-20.08-flatpak-arm64-tarball/versions/v1.2.2.0/polar_pi-1.2.2.0-aarch64_flatpak-20.08.tar.gz
+https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.3.0-ubuntu-x86_64-18.04-bionic-tarball/versions/v1.2.3/polar_pi-1.2.3.0-ubuntu-x86_64-18.04-bionic.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/polar.html </info-url>
 </plugin>

--- a/metadata/polar_pi-1.2.3.0-ubuntu-x86_64-18.04-gtk3-bionic-gtk3.xml
+++ b/metadata/polar_pi-1.2.3.0-ubuntu-x86_64-18.04-gtk3-bionic-gtk3.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Polar </name>
-<version> 1.2.2.0 </version>
+<version> 1.2.3.0 </version>
 <release> 0 </release>
 <summary> Polar Plugin makes polar diagrams for Weather Routing Predictions </summary>
 
@@ -17,10 +17,10 @@ Polar Plugin reads VDR data files directly, reads from Opencpn input Nmea channe
 <target>ubuntu-gtk3-x86_64</target>
 <build-target>ubuntu</build-target>
 <build-gtk>gtk3</build-gtk>
-<target-version>20.04</target-version>
+<target-version>18.04</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.2.0-ubuntu-x86_64-gtk3-20.04-focal-gtk3-tarball/versions/v1.2.2.0/polar_pi-1.2.2.0-ubuntu-x86_64-20.04-gtk3-focal-gtk3.tar.gz
+https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.3.0-ubuntu-x86_64-gtk3-18.04-bionic-gtk3-tarball/versions/v1.2.3/polar_pi-1.2.3.0-ubuntu-x86_64-18.04-gtk3-bionic-gtk3.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/polar.html </info-url>
 </plugin>

--- a/metadata/polar_pi-1.2.3.0-ubuntu-x86_64-20.04-gtk3-focal-gtk3.xml
+++ b/metadata/polar_pi-1.2.3.0-ubuntu-x86_64-20.04-gtk3-focal-gtk3.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Polar </name>
-<version> 1.2.2.0 </version>
+<version> 1.2.3.0 </version>
 <release> 0 </release>
 <summary> Polar Plugin makes polar diagrams for Weather Routing Predictions </summary>
 
@@ -14,13 +14,13 @@
 Polar Plugin reads VDR data files directly, reads from Opencpn input Nmea channel (Record Start/Stop at bottom) and direct from LogBoookKonni records, to creates a polar diagram which can then be edited manually, saved or loaded as a Boat Polar file. The LogbookKonni selection has several options.
 </description>
 
-<target>msvc-wx32</target>
-<build-target>msvc</build-target>
-<build-gtk></build-gtk>
-<target-version>10.0.17763</target-version>
+<target>ubuntu-gtk3-x86_64</target>
+<build-target>ubuntu</build-target>
+<build-gtk>gtk3</build-gtk>
+<target-version>20.04</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.2.0-msvc-x86_64-wx32-10.0.17763-MSVC-tarball/versions/v1.2.2.0/polar_pi-1.2.2.0-msvc-x86_64-wx32-10.0.17763-MSVC.tar.gz
+https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.3.0-ubuntu-x86_64-gtk3-20.04-focal-gtk3-tarball/versions/v1.2.3/polar_pi-1.2.3.0-ubuntu-x86_64-20.04-gtk3-focal-gtk3.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/polar.html </info-url>
 </plugin>

--- a/metadata/polar_pi-1.2.3.0-ubuntu-x86_64-22.04-jammy.xml
+++ b/metadata/polar_pi-1.2.3.0-ubuntu-x86_64-22.04-jammy.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Polar </name>
-<version> 1.2.2.0 </version>
+<version> 1.2.3.0 </version>
 <release> 0 </release>
 <summary> Polar Plugin makes polar diagrams for Weather Routing Predictions </summary>
 
@@ -14,13 +14,13 @@
 Polar Plugin reads VDR data files directly, reads from Opencpn input Nmea channel (Record Start/Stop at bottom) and direct from LogBoookKonni records, to creates a polar diagram which can then be edited manually, saved or loaded as a Boat Polar file. The LogbookKonni selection has several options.
 </description>
 
-<target>debian-armhf</target>
-<build-target>debian</build-target>
-<build-gtk>gtk2</build-gtk>
-<target-version>10</target-version>
-<target-arch>armhf</target-arch>
+<target>ubuntu-x86_64</target>
+<build-target>ubuntu</build-target>
+<build-gtk>gtk3</build-gtk>
+<target-version>22.04</target-version>
+<target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.2.0-debian-armhf-10-buster-armhf-tarball/versions/v1.2.2.0/polar_pi-1.2.2.0-debian-armhf-10-buster-armhf.tar.gz
+https://dl.cloudsmith.io/public/opencpn/polar-prod/raw/names/polar_pi-1.2.3.0-ubuntu-x86_64-22.04-jammy-tarball/versions/v1.2.3/polar_pi-1.2.3.0-ubuntu-x86_64-22.04-jammy.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/polar.html </info-url>
 </plugin>


### PR DESCRIPTION
This has Pavel's changes for MacOS dark mode etc.
This does not include the builds for as there are missing libs when using the PPA

Debian 11 Bullseye wx32 |   | wx32 version |  
-- | -- | -- | --
debian-wx32-arm64-11-bullseye | Jammy/Focal* | wx32 gtk3 | O58 ADD
debian-wx32-armhf-11-bullseye | Jammy/Focal* | wx32 gtk3 | O58 ADD
debian-wx32-x86_64-11-bullseye | Jammy/Focal* | wx32 gtk3 | O58 ADD

For more information see https://github.com/jongough/testplugin_pi/issues/310