### PR TITLE
GPS Odometer 0.7.0.5

### DIFF
--- a/metadata/gpsodometer_pi-0.7.0.4-darwin-wx32-x86_64-11.4-macos.xml
+++ b/metadata/gpsodometer_pi-0.7.0.4-darwin-wx32-x86_64-11.4-macos.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.4 </version>
+<release> 4 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>darwin-wx32</target>
+<build-target>darwin</build-target>
+<build-gtk></build-gtk>
+<target-version>11.4</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.4-darwin-wx32-x86_64-11.4-macos-tarball/versions/v0.7.0.4/gpsodometer_pi-0.7.0.4-darwin-wx32-x86_64-11.4-macos.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/plugins/gps-odometer/0.1/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.4-darwin-x86_64-11.4-macos.xml
+++ b/metadata/gpsodometer_pi-0.7.0.4-darwin-x86_64-11.4-macos.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.4 </version>
+<release> 4 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>darwin</target>
+<build-target>darwin</build-target>
+<build-gtk></build-gtk>
+<target-version>11.4</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.4-darwin-x86_64-11.4-macos-tarball/versions/v0.7.0.4/gpsodometer_pi-0.7.0.4-darwin-x86_64-11.4-macos.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/plugins/gps-odometer/0.1/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.4-debian-arm64-10-buster-arm64.xml
+++ b/metadata/gpsodometer_pi-0.7.0.4-debian-arm64-10-buster-arm64.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.4 </version>
+<release> 4 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>debian-arm64</target>
+<build-target>debian</build-target>
+<build-gtk>gtk2</build-gtk>
+<target-version>10</target-version>
+<target-arch>arm64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.4-debian-arm64-10-buster-arm64-tarball/versions/v0.7.0.4/gpsodometer_pi-0.7.0.4-debian-arm64-10-buster-arm64.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/plugins/gps-odometer/0.1/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.4-debian-arm64-11-bullseye-arm64.xml
+++ b/metadata/gpsodometer_pi-0.7.0.4-debian-arm64-11-bullseye-arm64.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.4 </version>
+<release> 4 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>debian-arm64</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>11</target-version>
+<target-arch>arm64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.4-debian-arm64-11-bullseye-arm64-tarball/versions/v0.7.0.4/gpsodometer_pi-0.7.0.4-debian-arm64-11-bullseye-arm64.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/plugins/gps-odometer/0.1/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.4-debian-arm64-wx32-12-bookworm-arm64.xml
+++ b/metadata/gpsodometer_pi-0.7.0.4-debian-arm64-wx32-12-bookworm-arm64.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.4 </version>
+<release> 4 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>debian-wx32-arm64</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>12</target-version>
+<target-arch>arm64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.4-debian-arm64-wx32-12-bookworm-arm64-tarball/versions/v0.7.0.4/gpsodometer_pi-0.7.0.4-debian-arm64-wx32-12-bookworm-arm64.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/plugins/gps-odometer/0.1/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.4-debian-armhf-10-buster-armhf.xml
+++ b/metadata/gpsodometer_pi-0.7.0.4-debian-armhf-10-buster-armhf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.4 </version>
+<release> 4 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>debian-armhf</target>
+<build-target>debian</build-target>
+<build-gtk>gtk2</build-gtk>
+<target-version>10</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.4-debian-armhf-10-buster-armhf-tarball/versions/v0.7.0.4/gpsodometer_pi-0.7.0.4-debian-armhf-10-buster-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/plugins/gps-odometer/0.1/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.4-debian-armhf-10-gtk3-buster-armhf.xml
+++ b/metadata/gpsodometer_pi-0.7.0.4-debian-armhf-10-gtk3-buster-armhf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.4 </version>
+<release> 4 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>debian-gtk3-armhf</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>10</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.4-debian-armhf-gtk3-10-buster-armhf-tarball/versions/v0.7.0.4/gpsodometer_pi-0.7.0.4-debian-armhf-10-gtk3-buster-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/plugins/gps-odometer/0.1/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.4-debian-armhf-11-bullseye-armhf.xml
+++ b/metadata/gpsodometer_pi-0.7.0.4-debian-armhf-11-bullseye-armhf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.4 </version>
+<release> 4 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>debian-armhf</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>11</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.4-debian-armhf-11-bullseye-armhf-tarball/versions/v0.7.0.4/gpsodometer_pi-0.7.0.4-debian-armhf-11-bullseye-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/plugins/gps-odometer/0.1/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.4-debian-armhf-wx32-12-bookworm-armhf.xml
+++ b/metadata/gpsodometer_pi-0.7.0.4-debian-armhf-wx32-12-bookworm-armhf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.4 </version>
+<release> 4 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>debian-wx32-armhf</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>12</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.4-debian-armhf-wx32-12-bookworm-armhf-tarball/versions/v0.7.0.4/gpsodometer_pi-0.7.0.4-debian-armhf-wx32-12-bookworm-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/plugins/gps-odometer/0.1/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.4-debian-x86_64-10-buster.xml
+++ b/metadata/gpsodometer_pi-0.7.0.4-debian-x86_64-10-buster.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.4 </version>
+<release> 4 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>debian-x86_64</target>
+<build-target>debian</build-target>
+<build-gtk>gtk2</build-gtk>
+<target-version>10</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.4-debian-x86_64-10-buster-tarball/versions/v0.7.0.4/gpsodometer_pi-0.7.0.4-debian-x86_64-10-buster.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/plugins/gps-odometer/0.1/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.4-debian-x86_64-11-bullseye.xml
+++ b/metadata/gpsodometer_pi-0.7.0.4-debian-x86_64-11-bullseye.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.4 </version>
+<release> 4 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>debian-x86_64</target>
+<build-target>debian</build-target>
+<build-gtk>gtk3</build-gtk>
+<target-version>11</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.4-debian-x86_64-11-bullseye-tarball/versions/v0.7.0.4/gpsodometer_pi-0.7.0.4-debian-x86_64-11-bullseye.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/plugins/gps-odometer/0.1/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.4-debian-x86_64-12-bookworm.xml
+++ b/metadata/gpsodometer_pi-0.7.0.4-debian-x86_64-12-bookworm.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.4 </version>
+<release> 4 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>debian-wx32-x86_64</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>12</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.4-debian-x86_64-wx32-12-bookworm-tarball/versions/v0.7.0.4/gpsodometer_pi-0.7.0.4-debian-x86_64-12-bookworm.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/plugins/gps-odometer/0.1/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.4-flatpak-aarch64-20.08-flatpak-arm64.xml
+++ b/metadata/gpsodometer_pi-0.7.0.4-flatpak-aarch64-20.08-flatpak-arm64.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.4 </version>
+<release> 4 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>flatpak-aarch64</target>
+<build-target>flatpak</build-target>
+<build-gtk></build-gtk>
+<target-version>20.08</target-version>
+<target-arch>aarch64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.4-flatpak-aarch64-20.08-flatpak-arm64-tarball/versions/v0.7.0.4/gpsodometer_pi-0.7.0.4-aarch64_flatpak-20.08.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/plugins/gps-odometer/0.1/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.4-flatpak-x86_64-20.08-flatpak.xml
+++ b/metadata/gpsodometer_pi-0.7.0.4-flatpak-x86_64-20.08-flatpak.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.4 </version>
+<release> 4 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>flatpak-x86_64</target>
+<build-target>flatpak</build-target>
+<build-gtk></build-gtk>
+<target-version>20.08</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.4-flatpak-x86_64-20.08-flatpak-tarball/versions/v0.7.0.4/gpsodometer_pi-0.7.0.4-x86_64_flatpak-20.08.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/plugins/gps-odometer/0.1/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.4-flatpak-x86_64-22.08-flatpak.xml
+++ b/metadata/gpsodometer_pi-0.7.0.4-flatpak-x86_64-22.08-flatpak.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.4 </version>
+<release> 4 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>flatpak-x86_64</target>
+<build-target>flatpak</build-target>
+<build-gtk></build-gtk>
+<target-version>22.08</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.4-flatpak-x86_64-22.08-flatpak-tarball/versions/v0.7.0.4/gpsodometer_pi-0.7.0.4-x86_64_flatpak-22.08.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/plugins/gps-odometer/0.1/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.4-msvc-x86_64-10.0.14393-MSVC.xml
+++ b/metadata/gpsodometer_pi-0.7.0.4-msvc-x86_64-10.0.14393-MSVC.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.4 </version>
+<release> 4 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>msvc</target>
+<build-target>msvc</build-target>
+<build-gtk></build-gtk>
+<target-version>10.0.14393</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.4-msvc-x86_64-10.0.14393-MSVC-tarball/versions/v0.7.0.4/gpsodometer_pi-0.7.0.4-msvc-x86_64-10.0.14393-MSVC.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/plugins/gps-odometer/0.1/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.4-msvc-x86_64-wx32-10.0.17763-MSVC.xml
+++ b/metadata/gpsodometer_pi-0.7.0.4-msvc-x86_64-wx32-10.0.17763-MSVC.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.4 </version>
+<release> 4 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>msvc-wx32</target>
+<build-target>msvc</build-target>
+<build-gtk></build-gtk>
+<target-version>10.0.17763</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.4-msvc-x86_64-wx32-10.0.17763-MSVC-tarball/versions/v0.7.0.4/gpsodometer_pi-0.7.0.4-msvc-x86_64-wx32-10.0.17763-MSVC.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/plugins/gps-odometer/0.1/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.4-raspbian-armhf-9.13-stretch-armhf.xml
+++ b/metadata/gpsodometer_pi-0.7.0.4-raspbian-armhf-9.13-stretch-armhf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.4 </version>
+<release> 4 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>raspbian-armhf</target>
+<build-target>raspbian</build-target>
+<build-gtk>gtk2</build-gtk>
+<target-version>9.13</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.4-raspbian-armhf-9.13-stretch-armhf-tarball/versions/v0.7.0.4/gpsodometer_pi-0.7.0.4-raspbian-armhf-9.13-stretch-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/plugins/gps-odometer/0.1/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.4-ubuntu-armhf-18.04-buster-armhf.xml
+++ b/metadata/gpsodometer_pi-0.7.0.4-ubuntu-armhf-18.04-buster-armhf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.4 </version>
+<release> 4 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>ubuntu-armhf</target>
+<build-target>ubuntu</build-target>
+<build-gtk>gtk2</build-gtk>
+<target-version>18.04</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.4-ubuntu-armhf-18.04-buster-armhf-tarball/versions/v0.7.0.4/gpsodometer_pi-0.7.0.4-ubuntu-armhf-18.04-buster-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/plugins/gps-odometer/0.1/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.4-ubuntu-armhf-20.04-gtk3-focal-armhf.xml
+++ b/metadata/gpsodometer_pi-0.7.0.4-ubuntu-armhf-20.04-gtk3-focal-armhf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.4 </version>
+<release> 4 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>ubuntu-gtk3-armhf</target>
+<build-target>ubuntu</build-target>
+<build-gtk></build-gtk>
+<target-version>20.04</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.4-ubuntu-armhf-gtk3-20.04-focal-armhf-tarball/versions/v0.7.0.4/gpsodometer_pi-0.7.0.4-ubuntu-armhf-20.04-gtk3-focal-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/plugins/gps-odometer/0.1/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.4-ubuntu-x86_64-18.04-bionic.xml
+++ b/metadata/gpsodometer_pi-0.7.0.4-ubuntu-x86_64-18.04-bionic.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.4 </version>
+<release> 4 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>ubuntu-x86_64</target>
+<build-target>ubuntu</build-target>
+<build-gtk>gtk2</build-gtk>
+<target-version>18.04</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.4-ubuntu-x86_64-18.04-bionic-tarball/versions/v0.7.0.4/gpsodometer_pi-0.7.0.4-ubuntu-x86_64-18.04-bionic.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/plugins/gps-odometer/0.1/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.4-ubuntu-x86_64-18.04-gtk3-bionic-gtk3.xml
+++ b/metadata/gpsodometer_pi-0.7.0.4-ubuntu-x86_64-18.04-gtk3-bionic-gtk3.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.4 </version>
+<release> 4 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>ubuntu-gtk3-x86_64</target>
+<build-target>ubuntu</build-target>
+<build-gtk>gtk3</build-gtk>
+<target-version>18.04</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.4-ubuntu-x86_64-gtk3-18.04-bionic-gtk3-tarball/versions/v0.7.0.4/gpsodometer_pi-0.7.0.4-ubuntu-x86_64-18.04-gtk3-bionic-gtk3.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/plugins/gps-odometer/0.1/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.4-ubuntu-x86_64-20.04-gtk3-focal-gtk3.xml
+++ b/metadata/gpsodometer_pi-0.7.0.4-ubuntu-x86_64-20.04-gtk3-focal-gtk3.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.4 </version>
+<release> 4 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>ubuntu-gtk3-x86_64</target>
+<build-target>ubuntu</build-target>
+<build-gtk>gtk3</build-gtk>
+<target-version>20.04</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.4-ubuntu-x86_64-gtk3-20.04-focal-gtk3-tarball/versions/v0.7.0.4/gpsodometer_pi-0.7.0.4-ubuntu-x86_64-20.04-gtk3-focal-gtk3.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/plugins/gps-odometer/0.1/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.4-ubuntu-x86_64-22.04-jammy.xml
+++ b/metadata/gpsodometer_pi-0.7.0.4-ubuntu-x86_64-22.04-jammy.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.4 </version>
+<release> 4 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>ubuntu-x86_64</target>
+<build-target>ubuntu</build-target>
+<build-gtk>gtk3</build-gtk>
+<target-version>22.04</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.4-ubuntu-x86_64-22.04-jammy-tarball/versions/v0.7.0.4/gpsodometer_pi-0.7.0.4-ubuntu-x86_64-22.04-jammy.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/plugins/gps-odometer/0.1/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.5-darwin-wx32-x86_64-11.4-macos.xml
+++ b/metadata/gpsodometer_pi-0.7.0.5-darwin-wx32-x86_64-11.4-macos.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.5 </version>
+<release> 5 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>darwin-wx32</target>
+<build-target>darwin</build-target>
+<build-gtk></build-gtk>
+<target-version>11.4</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.5-darwin-wx32-x86_64-11.4-macos-tarball/versions/v0.7.0.5/gpsodometer_pi-0.7.0.5-darwin-wx32-x86_64-11.4-macos.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.5-darwin-x86_64-11.4-macos.xml
+++ b/metadata/gpsodometer_pi-0.7.0.5-darwin-x86_64-11.4-macos.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.5 </version>
+<release> 5 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>darwin</target>
+<build-target>darwin</build-target>
+<build-gtk></build-gtk>
+<target-version>11.4</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.5-darwin-x86_64-11.4-macos-tarball/versions/v0.7.0.5/gpsodometer_pi-0.7.0.5-darwin-x86_64-11.4-macos.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.5-debian-arm64-10-buster-arm64.xml
+++ b/metadata/gpsodometer_pi-0.7.0.5-debian-arm64-10-buster-arm64.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.5 </version>
+<release> 5 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>debian-arm64</target>
+<build-target>debian</build-target>
+<build-gtk>gtk2</build-gtk>
+<target-version>10</target-version>
+<target-arch>arm64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.5-debian-arm64-10-buster-arm64-tarball/versions/v0.7.0.5/gpsodometer_pi-0.7.0.5-debian-arm64-10-buster-arm64.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.5-debian-arm64-11-bullseye-arm64.xml
+++ b/metadata/gpsodometer_pi-0.7.0.5-debian-arm64-11-bullseye-arm64.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.5 </version>
+<release> 5 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>debian-arm64</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>11</target-version>
+<target-arch>arm64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.5-debian-arm64-11-bullseye-arm64-tarball/versions/v0.7.0.5/gpsodometer_pi-0.7.0.5-debian-arm64-11-bullseye-arm64.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.5-debian-arm64-wx32-12-bookworm-arm64.xml
+++ b/metadata/gpsodometer_pi-0.7.0.5-debian-arm64-wx32-12-bookworm-arm64.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.5 </version>
+<release> 5 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>debian-wx32-arm64</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>12</target-version>
+<target-arch>arm64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.5-debian-arm64-wx32-12-bookworm-arm64-tarball/versions/v0.7.0.5/gpsodometer_pi-0.7.0.5-debian-arm64-wx32-12-bookworm-arm64.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.5-debian-armhf-10-buster-armhf.xml
+++ b/metadata/gpsodometer_pi-0.7.0.5-debian-armhf-10-buster-armhf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.5 </version>
+<release> 5 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>debian-armhf</target>
+<build-target>debian</build-target>
+<build-gtk>gtk2</build-gtk>
+<target-version>10</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.5-debian-armhf-10-buster-armhf-tarball/versions/v0.7.0.5/gpsodometer_pi-0.7.0.5-debian-armhf-10-buster-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.5-debian-armhf-10-gtk3-buster-armhf.xml
+++ b/metadata/gpsodometer_pi-0.7.0.5-debian-armhf-10-gtk3-buster-armhf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.5 </version>
+<release> 5 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>debian-gtk3-armhf</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>10</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.5-debian-armhf-gtk3-10-buster-armhf-tarball/versions/v0.7.0.5/gpsodometer_pi-0.7.0.5-debian-armhf-10-gtk3-buster-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.5-debian-armhf-11-bullseye-armhf.xml
+++ b/metadata/gpsodometer_pi-0.7.0.5-debian-armhf-11-bullseye-armhf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.5 </version>
+<release> 5 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>debian-armhf</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>11</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.5-debian-armhf-11-bullseye-armhf-tarball/versions/v0.7.0.5/gpsodometer_pi-0.7.0.5-debian-armhf-11-bullseye-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.5-debian-armhf-wx32-12-bookworm-armhf.xml
+++ b/metadata/gpsodometer_pi-0.7.0.5-debian-armhf-wx32-12-bookworm-armhf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.5 </version>
+<release> 5 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>debian-wx32-armhf</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>12</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.5-debian-armhf-wx32-12-bookworm-armhf-tarball/versions/v0.7.0.5/gpsodometer_pi-0.7.0.5-debian-armhf-wx32-12-bookworm-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.5-debian-x86_64-10-buster.xml
+++ b/metadata/gpsodometer_pi-0.7.0.5-debian-x86_64-10-buster.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.5 </version>
+<release> 5 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>debian-x86_64</target>
+<build-target>debian</build-target>
+<build-gtk>gtk2</build-gtk>
+<target-version>10</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.5-debian-x86_64-10-buster-tarball/versions/v0.7.0.5/gpsodometer_pi-0.7.0.5-debian-x86_64-10-buster.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.5-debian-x86_64-11-bullseye.xml
+++ b/metadata/gpsodometer_pi-0.7.0.5-debian-x86_64-11-bullseye.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.5 </version>
+<release> 5 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>debian-x86_64</target>
+<build-target>debian</build-target>
+<build-gtk>gtk3</build-gtk>
+<target-version>11</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.5-debian-x86_64-11-bullseye-tarball/versions/v0.7.0.5/gpsodometer_pi-0.7.0.5-debian-x86_64-11-bullseye.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.5-debian-x86_64-12-bookworm.xml
+++ b/metadata/gpsodometer_pi-0.7.0.5-debian-x86_64-12-bookworm.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.5 </version>
+<release> 5 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>debian-wx32-x86_64</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>12</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.5-debian-x86_64-wx32-12-bookworm-tarball/versions/v0.7.0.5/gpsodometer_pi-0.7.0.5-debian-x86_64-12-bookworm.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.5-flatpak-aarch64-20.08-flatpak-arm64.xml
+++ b/metadata/gpsodometer_pi-0.7.0.5-flatpak-aarch64-20.08-flatpak-arm64.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.5 </version>
+<release> 5 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>flatpak-aarch64</target>
+<build-target>flatpak</build-target>
+<build-gtk></build-gtk>
+<target-version>20.08</target-version>
+<target-arch>aarch64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.5-flatpak-aarch64-20.08-flatpak-arm64-tarball/versions/v0.7.0.5/gpsodometer_pi-0.7.0.5-aarch64_flatpak-20.08.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.5-flatpak-x86_64-20.08-flatpak.xml
+++ b/metadata/gpsodometer_pi-0.7.0.5-flatpak-x86_64-20.08-flatpak.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.5 </version>
+<release> 5 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>flatpak-x86_64</target>
+<build-target>flatpak</build-target>
+<build-gtk></build-gtk>
+<target-version>20.08</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.5-flatpak-x86_64-20.08-flatpak-tarball/versions/v0.7.0.5/gpsodometer_pi-0.7.0.5-x86_64_flatpak-20.08.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.5-flatpak-x86_64-22.08-flatpak.xml
+++ b/metadata/gpsodometer_pi-0.7.0.5-flatpak-x86_64-22.08-flatpak.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.5 </version>
+<release> 5 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>flatpak-x86_64</target>
+<build-target>flatpak</build-target>
+<build-gtk></build-gtk>
+<target-version>22.08</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.5-flatpak-x86_64-22.08-flatpak-tarball/versions/v0.7.0.5/gpsodometer_pi-0.7.0.5-x86_64_flatpak-22.08.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.5-msvc-x86_64-10.0.14393-MSVC.xml
+++ b/metadata/gpsodometer_pi-0.7.0.5-msvc-x86_64-10.0.14393-MSVC.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.5 </version>
+<release> 5 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>msvc</target>
+<build-target>msvc</build-target>
+<build-gtk></build-gtk>
+<target-version>10.0.14393</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.5-msvc-x86_64-10.0.14393-MSVC-tarball/versions/v0.7.0.5/gpsodometer_pi-0.7.0.5-msvc-x86_64-10.0.14393-MSVC.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.5-msvc-x86_64-wx32-10.0.17763-MSVC.xml
+++ b/metadata/gpsodometer_pi-0.7.0.5-msvc-x86_64-wx32-10.0.17763-MSVC.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.5 </version>
+<release> 5 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>msvc-wx32</target>
+<build-target>msvc</build-target>
+<build-gtk></build-gtk>
+<target-version>10.0.17763</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.5-msvc-x86_64-wx32-10.0.17763-MSVC-tarball/versions/v0.7.0.5/gpsodometer_pi-0.7.0.5-msvc-x86_64-wx32-10.0.17763-MSVC.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.5-raspbian-armhf-9.13-stretch-armhf.xml
+++ b/metadata/gpsodometer_pi-0.7.0.5-raspbian-armhf-9.13-stretch-armhf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.5 </version>
+<release> 5 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>raspbian-armhf</target>
+<build-target>raspbian</build-target>
+<build-gtk>gtk2</build-gtk>
+<target-version>9.13</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.5-raspbian-armhf-9.13-stretch-armhf-tarball/versions/v0.7.0.5/gpsodometer_pi-0.7.0.5-raspbian-armhf-9.13-stretch-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.5-ubuntu-armhf-18.04-buster-armhf.xml
+++ b/metadata/gpsodometer_pi-0.7.0.5-ubuntu-armhf-18.04-buster-armhf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.5 </version>
+<release> 5 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>ubuntu-armhf</target>
+<build-target>ubuntu</build-target>
+<build-gtk>gtk2</build-gtk>
+<target-version>18.04</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.5-ubuntu-armhf-18.04-buster-armhf-tarball/versions/v0.7.0.5/gpsodometer_pi-0.7.0.5-ubuntu-armhf-18.04-buster-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.5-ubuntu-armhf-20.04-gtk3-focal-armhf.xml
+++ b/metadata/gpsodometer_pi-0.7.0.5-ubuntu-armhf-20.04-gtk3-focal-armhf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.5 </version>
+<release> 5 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>ubuntu-gtk3-armhf</target>
+<build-target>ubuntu</build-target>
+<build-gtk></build-gtk>
+<target-version>20.04</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.5-ubuntu-armhf-gtk3-20.04-focal-armhf-tarball/versions/v0.7.0.5/gpsodometer_pi-0.7.0.5-ubuntu-armhf-20.04-gtk3-focal-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.5-ubuntu-x86_64-18.04-bionic.xml
+++ b/metadata/gpsodometer_pi-0.7.0.5-ubuntu-x86_64-18.04-bionic.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.5 </version>
+<release> 5 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>ubuntu-x86_64</target>
+<build-target>ubuntu</build-target>
+<build-gtk>gtk2</build-gtk>
+<target-version>18.04</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.5-ubuntu-x86_64-18.04-bionic-tarball/versions/v0.7.0.5/gpsodometer_pi-0.7.0.5-ubuntu-x86_64-18.04-bionic.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.5-ubuntu-x86_64-18.04-gtk3-bionic-gtk3.xml
+++ b/metadata/gpsodometer_pi-0.7.0.5-ubuntu-x86_64-18.04-gtk3-bionic-gtk3.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.5 </version>
+<release> 5 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>ubuntu-gtk3-x86_64</target>
+<build-target>ubuntu</build-target>
+<build-gtk>gtk3</build-gtk>
+<target-version>18.04</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.5-ubuntu-x86_64-gtk3-18.04-bionic-gtk3-tarball/versions/v0.7.0.5/gpsodometer_pi-0.7.0.5-ubuntu-x86_64-18.04-gtk3-bionic-gtk3.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.5-ubuntu-x86_64-20.04-gtk3-focal-gtk3.xml
+++ b/metadata/gpsodometer_pi-0.7.0.5-ubuntu-x86_64-20.04-gtk3-focal-gtk3.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.5 </version>
+<release> 5 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>ubuntu-gtk3-x86_64</target>
+<build-target>ubuntu</build-target>
+<build-gtk>gtk3</build-gtk>
+<target-version>20.04</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.5-ubuntu-x86_64-gtk3-20.04-focal-gtk3-tarball/versions/v0.7.0.5/gpsodometer_pi-0.7.0.5-ubuntu-x86_64-20.04-gtk3-focal-gtk3.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.7.0.5-ubuntu-x86_64-22.04-jammy.xml
+++ b/metadata/gpsodometer_pi-0.7.0.5-ubuntu-x86_64-22.04-jammy.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.7.0.5 </version>
+<release> 5 </release>
+<summary> GPS/GNSS Odometer plugin for OpenCPN release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/LennartG-Sve/GPS-Odometer_pi </source>
+
+<description>
+GPS/GNSS controlled Dashboard based Odometer plugin for OpenCPN release 5.8 and above, displays GPS/GNSS calculated Log and Trip information
+</description>
+
+<target>ubuntu-x86_64</target>
+<build-target>ubuntu</build-target>
+<build-gtk>gtk3</build-gtk>
+<target-version>22.04</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.7.0.5-ubuntu-x86_64-22.04-jammy-tarball/versions/v0.7.0.5/gpsodometer_pi-0.7.0.5-ubuntu-x86_64-22.04-jammy.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
+</plugin>


### PR DESCRIPTION
Added support for socketCAN (OpenCPN 5.8 and up). Also added separate data storage for sumlog total distance.