### PR TITLE
Engine Dashboard 1.5.0.0

### DIFF
--- a/metadata/engine_dashboard_pi-1.5.0.0-darwin-wx32-x86_64-11.4-macos.xml
+++ b/metadata/engine_dashboard_pi-1.5.0.0-darwin-wx32-x86_64-11.4-macos.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Engine Dashboard </name>
+<version> 1.5.0.0 </version>
+<release> 0 </release>
+<summary> Engine Dashboard, Displays Engine parameters. </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+
+<description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+
+<target>darwin-wx32</target>
+<build-target>darwin</build-target>
+<build-gtk></build-gtk>
+<target-version>11.4</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-darwin-wx32-x86_64-11.4-macos-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-darwin-wx32-x86_64-11.4-macos.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+</plugin>

--- a/metadata/engine_dashboard_pi-1.5.0.0-darwin-x86_64-11.4-macos.xml
+++ b/metadata/engine_dashboard_pi-1.5.0.0-darwin-x86_64-11.4-macos.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Engine Dashboard </name>
+<version> 1.5.0.0 </version>
+<release> 0 </release>
+<summary> Engine Dashboard, Displays Engine parameters. </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+
+<description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+
+<target>darwin</target>
+<build-target>darwin</build-target>
+<build-gtk></build-gtk>
+<target-version>11.4</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-darwin-x86_64-11.4-macos-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-darwin-x86_64-11.4-macos.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+</plugin>

--- a/metadata/engine_dashboard_pi-1.5.0.0-debian-arm64-11-bullseye-arm64.xml
+++ b/metadata/engine_dashboard_pi-1.5.0.0-debian-arm64-11-bullseye-arm64.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Engine Dashboard </name>
+<version> 1.5.0.0 </version>
+<release> 0 </release>
+<summary> Engine Dashboard, Displays Engine parameters. </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+
+<description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+
+<target>debian-arm64</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>11</target-version>
+<target-arch>arm64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-debian-arm64-11-bullseye-arm64-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-debian-arm64-11-bullseye-arm64.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+</plugin>

--- a/metadata/engine_dashboard_pi-1.5.0.0-debian-armhf-10-buster-armhf.xml
+++ b/metadata/engine_dashboard_pi-1.5.0.0-debian-armhf-10-buster-armhf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Engine Dashboard </name>
+<version> 1.5.0.0 </version>
+<release> 0 </release>
+<summary> Engine Dashboard, Displays Engine parameters. </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+
+<description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+
+<target>debian-armhf</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>10</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-debian-armhf-10-buster-armhf-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-debian-armhf-10-buster-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+</plugin>

--- a/metadata/engine_dashboard_pi-1.5.0.0-debian-armhf-11-bullseye-armhf.xml
+++ b/metadata/engine_dashboard_pi-1.5.0.0-debian-armhf-11-bullseye-armhf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Engine Dashboard </name>
+<version> 1.5.0.0 </version>
+<release> 0 </release>
+<summary> Engine Dashboard, Displays Engine parameters. </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+
+<description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+
+<target>debian-armhf</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>11</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-debian-armhf-11-bullseye-armhf-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-debian-armhf-11-bullseye-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+</plugin>

--- a/metadata/engine_dashboard_pi-1.5.0.0-debian-x86_64-10-buster.xml
+++ b/metadata/engine_dashboard_pi-1.5.0.0-debian-x86_64-10-buster.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Engine Dashboard </name>
+<version> 1.5.0.0 </version>
+<release> 0 </release>
+<summary> Engine Dashboard, Displays Engine parameters. </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+
+<description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+
+<target>debian-x86_64</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>10</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-debian-x86_64-10-buster-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-debian-x86_64-10-buster.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+</plugin>

--- a/metadata/engine_dashboard_pi-1.5.0.0-flatpak-aarch64-20.08-flatpak-arm64.xml
+++ b/metadata/engine_dashboard_pi-1.5.0.0-flatpak-aarch64-20.08-flatpak-arm64.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Engine Dashboard </name>
+<version> 1.5.0.0 </version>
+<release> 0 </release>
+<summary> Engine Dashboard, Displays Engine parameters. </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+
+<description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+
+<target>flatpak-aarch64</target>
+<build-target>flatpak</build-target>
+<build-gtk></build-gtk>
+<target-version>20.08</target-version>
+<target-arch>aarch64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-flatpak-aarch64-20.08-flatpak-arm64-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-aarch64_flatpak-20.08.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+</plugin>

--- a/metadata/engine_dashboard_pi-1.5.0.0-flatpak-x86_64-20.08-flatpak.xml
+++ b/metadata/engine_dashboard_pi-1.5.0.0-flatpak-x86_64-20.08-flatpak.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Engine Dashboard </name>
+<version> 1.5.0.0 </version>
+<release> 0 </release>
+<summary> Engine Dashboard, Displays Engine parameters. </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+
+<description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+
+<target>flatpak-x86_64</target>
+<build-target>flatpak</build-target>
+<build-gtk></build-gtk>
+<target-version>20.08</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-flatpak-x86_64-20.08-flatpak-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-x86_64_flatpak-20.08.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+</plugin>

--- a/metadata/engine_dashboard_pi-1.5.0.0-flatpak-x86_64-22.08-flatpak.xml
+++ b/metadata/engine_dashboard_pi-1.5.0.0-flatpak-x86_64-22.08-flatpak.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Engine Dashboard </name>
+<version> 1.5.0.0 </version>
+<release> 0 </release>
+<summary> Engine Dashboard, Displays Engine parameters. </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+
+<description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+
+<target>flatpak-x86_64</target>
+<build-target>flatpak</build-target>
+<build-gtk></build-gtk>
+<target-version>22.08</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-flatpak-x86_64-22.08-flatpak-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-x86_64_flatpak-22.08.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+</plugin>

--- a/metadata/engine_dashboard_pi-1.5.0.0-msvc-x86_64-10.0.14393-MSVC.xml
+++ b/metadata/engine_dashboard_pi-1.5.0.0-msvc-x86_64-10.0.14393-MSVC.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Engine Dashboard </name>
+<version> 1.5.0.0 </version>
+<release> 0 </release>
+<summary> Engine Dashboard, Displays Engine parameters. </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+
+<description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+
+<target>msvc</target>
+<build-target>msvc</build-target>
+<build-gtk></build-gtk>
+<target-version>10.0.14393</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-msvc-x86_64-10.0.14393-MSVC-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-msvc-x86_64-10.0.14393-MSVC.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+</plugin>

--- a/metadata/engine_dashboard_pi-1.5.0.0-msvc-x86_64-wx32-10.0.17763-MSVC.xml
+++ b/metadata/engine_dashboard_pi-1.5.0.0-msvc-x86_64-wx32-10.0.17763-MSVC.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Engine Dashboard </name>
+<version> 1.5.0.0 </version>
+<release> 0 </release>
+<summary> Engine Dashboard, Displays Engine parameters. </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+
+<description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+
+<target>msvc-wx32</target>
+<build-target>msvc</build-target>
+<build-gtk></build-gtk>
+<target-version>10.0.17763</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-msvc-x86_64-10.0.17763-MSVC-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-msvc-x86_64-wx32-10.0.17763-MSVC.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+</plugin>

--- a/metadata/engine_dashboard_pi-1.5.0.0-raspbian-armhf-9.13-stretch-armhf.xml
+++ b/metadata/engine_dashboard_pi-1.5.0.0-raspbian-armhf-9.13-stretch-armhf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Engine Dashboard </name>
+<version> 1.5.0.0 </version>
+<release> 0 </release>
+<summary> Engine Dashboard, Displays Engine parameters. </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+
+<description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+
+<target>raspbian-armhf</target>
+<build-target>raspbian</build-target>
+<build-gtk></build-gtk>
+<target-version>9.13</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-raspbian-armhf-9.13-stretch-armhf-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-raspbian-armhf-9.13-stretch-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+</plugin>

--- a/metadata/engine_dashboard_pi-1.5.0.0-ubuntu-armhf-18.04-buster-armhf.xml
+++ b/metadata/engine_dashboard_pi-1.5.0.0-ubuntu-armhf-18.04-buster-armhf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Engine Dashboard </name>
+<version> 1.5.0.0 </version>
+<release> 0 </release>
+<summary> Engine Dashboard, Displays Engine parameters. </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+
+<description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+
+<target>ubuntu-armhf</target>
+<build-target>ubuntu</build-target>
+<build-gtk></build-gtk>
+<target-version>18.04</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-ubuntu-armhf-18.04-buster-armhf-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-ubuntu-armhf-18.04-buster-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+</plugin>

--- a/metadata/engine_dashboard_pi-1.5.0.0-ubuntu-armhf-20.04-gtk3-focal-armhf.xml
+++ b/metadata/engine_dashboard_pi-1.5.0.0-ubuntu-armhf-20.04-gtk3-focal-armhf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Engine Dashboard </name>
+<version> 1.5.0.0 </version>
+<release> 0 </release>
+<summary> Engine Dashboard, Displays Engine parameters. </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+
+<description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+
+<target>ubuntu-gtk3-armhf</target>
+<build-target>ubuntu</build-target>
+<build-gtk>-gtk3</build-gtk>
+<target-version>20.04</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-ubuntu-armhf-20.04-focal-armhf-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-ubuntu-armhf-20.04-gtk3-focal-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+</plugin>

--- a/metadata/engine_dashboard_pi-1.5.0.0-ubuntu-x86_64-18.04-bionic.xml
+++ b/metadata/engine_dashboard_pi-1.5.0.0-ubuntu-x86_64-18.04-bionic.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Engine Dashboard </name>
+<version> 1.5.0.0 </version>
+<release> 0 </release>
+<summary> Engine Dashboard, Displays Engine parameters. </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+
+<description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+
+<target>ubuntu-x86_64</target>
+<build-target>ubuntu</build-target>
+<build-gtk></build-gtk>
+<target-version>18.04</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-ubuntu-x86_64-18.04-bionic-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-ubuntu-x86_64-18.04-bionic.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+</plugin>

--- a/metadata/engine_dashboard_pi-1.5.0.0-ubuntu-x86_64-18.04-gtk3-bionic-gtk3.xml
+++ b/metadata/engine_dashboard_pi-1.5.0.0-ubuntu-x86_64-18.04-gtk3-bionic-gtk3.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Engine Dashboard </name>
+<version> 1.5.0.0 </version>
+<release> 0 </release>
+<summary> Engine Dashboard, Displays Engine parameters. </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+
+<description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+
+<target>ubuntu-gtk3-x86_64</target>
+<build-target>ubuntu</build-target>
+<build-gtk>-gtk3</build-gtk>
+<target-version>18.04</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-ubuntu-x86_64-18.04-bionic-gtk3-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-ubuntu-x86_64-18.04-gtk3-bionic-gtk3.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+</plugin>

--- a/metadata/engine_dashboard_pi-1.5.0.0-ubuntu-x86_64-20.04-gtk3-focal-gtk3.xml
+++ b/metadata/engine_dashboard_pi-1.5.0.0-ubuntu-x86_64-20.04-gtk3-focal-gtk3.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Engine Dashboard </name>
+<version> 1.5.0.0 </version>
+<release> 0 </release>
+<summary> Engine Dashboard, Displays Engine parameters. </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+
+<description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+
+<target>ubuntu-gtk3-x86_64</target>
+<build-target>ubuntu</build-target>
+<build-gtk>-gtk3</build-gtk>
+<target-version>20.04</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-ubuntu-x86_64-20.04-focal-gtk3-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-ubuntu-x86_64-20.04-gtk3-focal-gtk3.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+</plugin>

--- a/metadata/engine_dashboard_pi-1.5.0.0-ubuntu-x86_64-22.04-jammy.xml
+++ b/metadata/engine_dashboard_pi-1.5.0.0-ubuntu-x86_64-22.04-jammy.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Engine Dashboard </name>
+<version> 1.5.0.0 </version>
+<release> 0 </release>
+<summary> Engine Dashboard, Displays Engine parameters. </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> twocanplugin@hotmail.com </author>
+<source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+
+<description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+
+<target>ubuntu-x86_64</target>
+<build-target>ubuntu</build-target>
+<build-gtk></build-gtk>
+<target-version>22.04</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-ubuntu-x86_64-22.04-jammy-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-ubuntu-x86_64-22.04-jammy.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+</plugin>

--- a/ocpn-plugins.xml
+++ b/ocpn-plugins.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <plugins>
   <version>0.0.0</version>
-  <date>2023-05-21 19:24</date>
+  <date>2023-05-21 22:13</date>
   <plugin version="1">
     <name> AutoTrackRaymarine </name>
     <version> 1.1.3.1 </version>
@@ -9124,6 +9124,402 @@ Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternat
     <target-arch>x86_64</target-arch>
     <tarball-url>
 https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.4.2.0-ubuntu-x86_64-20.04-focal-gtk3-tarball/versions/v1.4.2/engine_dashboard_pi-1.4.2.0-ubuntu-x86_64-20.04-focal-gtk3.tar.gz
+</tarball-url>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+  </plugin>
+  <plugin version="1">
+    <name> Engine Dashboard </name>
+    <version> 1.5.0.0 </version>
+    <release> 0 </release>
+    <summary> Engine Dashboard, Displays Engine parameters. </summary>
+    <api-version> 1.18 </api-version>
+    <open-source> yes </open-source>
+    <author> twocanplugin@hotmail.com </author>
+    <source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+    <description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+    <target>darwin-wx32</target>
+    <build-target>darwin</build-target>
+    <build-gtk/>
+    <target-version>11.4</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-darwin-wx32-x86_64-11.4-macos-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-darwin-wx32-x86_64-11.4-macos.tar.gz
+</tarball-url>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+  </plugin>
+  <plugin version="1">
+    <name> Engine Dashboard </name>
+    <version> 1.5.0.0 </version>
+    <release> 0 </release>
+    <summary> Engine Dashboard, Displays Engine parameters. </summary>
+    <api-version> 1.18 </api-version>
+    <open-source> yes </open-source>
+    <author> twocanplugin@hotmail.com </author>
+    <source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+    <description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+    <target>darwin</target>
+    <build-target>darwin</build-target>
+    <build-gtk/>
+    <target-version>11.4</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-darwin-x86_64-11.4-macos-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-darwin-x86_64-11.4-macos.tar.gz
+</tarball-url>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+  </plugin>
+  <plugin version="1">
+    <name> Engine Dashboard </name>
+    <version> 1.5.0.0 </version>
+    <release> 0 </release>
+    <summary> Engine Dashboard, Displays Engine parameters. </summary>
+    <api-version> 1.18 </api-version>
+    <open-source> yes </open-source>
+    <author> twocanplugin@hotmail.com </author>
+    <source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+    <description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+    <target>debian-arm64</target>
+    <build-target>debian</build-target>
+    <build-gtk/>
+    <target-version>11</target-version>
+    <target-arch>arm64</target-arch>
+    <tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-debian-arm64-11-bullseye-arm64-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-debian-arm64-11-bullseye-arm64.tar.gz
+</tarball-url>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+  </plugin>
+  <plugin version="1">
+    <name> Engine Dashboard </name>
+    <version> 1.5.0.0 </version>
+    <release> 0 </release>
+    <summary> Engine Dashboard, Displays Engine parameters. </summary>
+    <api-version> 1.18 </api-version>
+    <open-source> yes </open-source>
+    <author> twocanplugin@hotmail.com </author>
+    <source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+    <description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+    <target>debian-armhf</target>
+    <build-target>debian</build-target>
+    <build-gtk/>
+    <target-version>10</target-version>
+    <target-arch>armhf</target-arch>
+    <tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-debian-armhf-10-buster-armhf-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-debian-armhf-10-buster-armhf.tar.gz
+</tarball-url>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+  </plugin>
+  <plugin version="1">
+    <name> Engine Dashboard </name>
+    <version> 1.5.0.0 </version>
+    <release> 0 </release>
+    <summary> Engine Dashboard, Displays Engine parameters. </summary>
+    <api-version> 1.18 </api-version>
+    <open-source> yes </open-source>
+    <author> twocanplugin@hotmail.com </author>
+    <source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+    <description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+    <target>debian-armhf</target>
+    <build-target>debian</build-target>
+    <build-gtk/>
+    <target-version>11</target-version>
+    <target-arch>armhf</target-arch>
+    <tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-debian-armhf-11-bullseye-armhf-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-debian-armhf-11-bullseye-armhf.tar.gz
+</tarball-url>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+  </plugin>
+  <plugin version="1">
+    <name> Engine Dashboard </name>
+    <version> 1.5.0.0 </version>
+    <release> 0 </release>
+    <summary> Engine Dashboard, Displays Engine parameters. </summary>
+    <api-version> 1.18 </api-version>
+    <open-source> yes </open-source>
+    <author> twocanplugin@hotmail.com </author>
+    <source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+    <description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+    <target>debian-x86_64</target>
+    <build-target>debian</build-target>
+    <build-gtk/>
+    <target-version>10</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-debian-x86_64-10-buster-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-debian-x86_64-10-buster.tar.gz
+</tarball-url>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+  </plugin>
+  <plugin version="1">
+    <name> Engine Dashboard </name>
+    <version> 1.5.0.0 </version>
+    <release> 0 </release>
+    <summary> Engine Dashboard, Displays Engine parameters. </summary>
+    <api-version> 1.18 </api-version>
+    <open-source> yes </open-source>
+    <author> twocanplugin@hotmail.com </author>
+    <source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+    <description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+    <target>flatpak-aarch64</target>
+    <build-target>flatpak</build-target>
+    <build-gtk/>
+    <target-version>20.08</target-version>
+    <target-arch>aarch64</target-arch>
+    <tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-flatpak-aarch64-20.08-flatpak-arm64-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-aarch64_flatpak-20.08.tar.gz
+</tarball-url>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+  </plugin>
+  <plugin version="1">
+    <name> Engine Dashboard </name>
+    <version> 1.5.0.0 </version>
+    <release> 0 </release>
+    <summary> Engine Dashboard, Displays Engine parameters. </summary>
+    <api-version> 1.18 </api-version>
+    <open-source> yes </open-source>
+    <author> twocanplugin@hotmail.com </author>
+    <source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+    <description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+    <target>flatpak-x86_64</target>
+    <build-target>flatpak</build-target>
+    <build-gtk/>
+    <target-version>20.08</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-flatpak-x86_64-20.08-flatpak-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-x86_64_flatpak-20.08.tar.gz
+</tarball-url>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+  </plugin>
+  <plugin version="1">
+    <name> Engine Dashboard </name>
+    <version> 1.5.0.0 </version>
+    <release> 0 </release>
+    <summary> Engine Dashboard, Displays Engine parameters. </summary>
+    <api-version> 1.18 </api-version>
+    <open-source> yes </open-source>
+    <author> twocanplugin@hotmail.com </author>
+    <source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+    <description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+    <target>flatpak-x86_64</target>
+    <build-target>flatpak</build-target>
+    <build-gtk/>
+    <target-version>22.08</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-flatpak-x86_64-22.08-flatpak-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-x86_64_flatpak-22.08.tar.gz
+</tarball-url>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+  </plugin>
+  <plugin version="1">
+    <name> Engine Dashboard </name>
+    <version> 1.5.0.0 </version>
+    <release> 0 </release>
+    <summary> Engine Dashboard, Displays Engine parameters. </summary>
+    <api-version> 1.18 </api-version>
+    <open-source> yes </open-source>
+    <author> twocanplugin@hotmail.com </author>
+    <source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+    <description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+    <target>msvc</target>
+    <build-target>msvc</build-target>
+    <build-gtk/>
+    <target-version>10.0.14393</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-msvc-x86_64-10.0.14393-MSVC-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-msvc-x86_64-10.0.14393-MSVC.tar.gz
+</tarball-url>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+  </plugin>
+  <plugin version="1">
+    <name> Engine Dashboard </name>
+    <version> 1.5.0.0 </version>
+    <release> 0 </release>
+    <summary> Engine Dashboard, Displays Engine parameters. </summary>
+    <api-version> 1.18 </api-version>
+    <open-source> yes </open-source>
+    <author> twocanplugin@hotmail.com </author>
+    <source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+    <description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+    <target>msvc-wx32</target>
+    <build-target>msvc</build-target>
+    <build-gtk/>
+    <target-version>10.0.17763</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-msvc-x86_64-10.0.17763-MSVC-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-msvc-x86_64-wx32-10.0.17763-MSVC.tar.gz
+</tarball-url>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+  </plugin>
+  <plugin version="1">
+    <name> Engine Dashboard </name>
+    <version> 1.5.0.0 </version>
+    <release> 0 </release>
+    <summary> Engine Dashboard, Displays Engine parameters. </summary>
+    <api-version> 1.18 </api-version>
+    <open-source> yes </open-source>
+    <author> twocanplugin@hotmail.com </author>
+    <source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+    <description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+    <target>raspbian-armhf</target>
+    <build-target>raspbian</build-target>
+    <build-gtk/>
+    <target-version>9.13</target-version>
+    <target-arch>armhf</target-arch>
+    <tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-raspbian-armhf-9.13-stretch-armhf-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-raspbian-armhf-9.13-stretch-armhf.tar.gz
+</tarball-url>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+  </plugin>
+  <plugin version="1">
+    <name> Engine Dashboard </name>
+    <version> 1.5.0.0 </version>
+    <release> 0 </release>
+    <summary> Engine Dashboard, Displays Engine parameters. </summary>
+    <api-version> 1.18 </api-version>
+    <open-source> yes </open-source>
+    <author> twocanplugin@hotmail.com </author>
+    <source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+    <description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+    <target>ubuntu-armhf</target>
+    <build-target>ubuntu</build-target>
+    <build-gtk/>
+    <target-version>18.04</target-version>
+    <target-arch>armhf</target-arch>
+    <tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-ubuntu-armhf-18.04-buster-armhf-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-ubuntu-armhf-18.04-buster-armhf.tar.gz
+</tarball-url>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+  </plugin>
+  <plugin version="1">
+    <name> Engine Dashboard </name>
+    <version> 1.5.0.0 </version>
+    <release> 0 </release>
+    <summary> Engine Dashboard, Displays Engine parameters. </summary>
+    <api-version> 1.18 </api-version>
+    <open-source> yes </open-source>
+    <author> twocanplugin@hotmail.com </author>
+    <source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+    <description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+    <target>ubuntu-gtk3-armhf</target>
+    <build-target>ubuntu</build-target>
+    <build-gtk>-gtk3</build-gtk>
+    <target-version>20.04</target-version>
+    <target-arch>armhf</target-arch>
+    <tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-ubuntu-armhf-20.04-focal-armhf-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-ubuntu-armhf-20.04-gtk3-focal-armhf.tar.gz
+</tarball-url>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+  </plugin>
+  <plugin version="1">
+    <name> Engine Dashboard </name>
+    <version> 1.5.0.0 </version>
+    <release> 0 </release>
+    <summary> Engine Dashboard, Displays Engine parameters. </summary>
+    <api-version> 1.18 </api-version>
+    <open-source> yes </open-source>
+    <author> twocanplugin@hotmail.com </author>
+    <source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+    <description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+    <target>ubuntu-x86_64</target>
+    <build-target>ubuntu</build-target>
+    <build-gtk/>
+    <target-version>18.04</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-ubuntu-x86_64-18.04-bionic-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-ubuntu-x86_64-18.04-bionic.tar.gz
+</tarball-url>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+  </plugin>
+  <plugin version="1">
+    <name> Engine Dashboard </name>
+    <version> 1.5.0.0 </version>
+    <release> 0 </release>
+    <summary> Engine Dashboard, Displays Engine parameters. </summary>
+    <api-version> 1.18 </api-version>
+    <open-source> yes </open-source>
+    <author> twocanplugin@hotmail.com </author>
+    <source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+    <description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+    <target>ubuntu-gtk3-x86_64</target>
+    <build-target>ubuntu</build-target>
+    <build-gtk>-gtk3</build-gtk>
+    <target-version>18.04</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-ubuntu-x86_64-18.04-bionic-gtk3-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-ubuntu-x86_64-18.04-gtk3-bionic-gtk3.tar.gz
+</tarball-url>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+  </plugin>
+  <plugin version="1">
+    <name> Engine Dashboard </name>
+    <version> 1.5.0.0 </version>
+    <release> 0 </release>
+    <summary> Engine Dashboard, Displays Engine parameters. </summary>
+    <api-version> 1.18 </api-version>
+    <open-source> yes </open-source>
+    <author> twocanplugin@hotmail.com </author>
+    <source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+    <description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+    <target>ubuntu-gtk3-x86_64</target>
+    <build-target>ubuntu</build-target>
+    <build-gtk>-gtk3</build-gtk>
+    <target-version>20.04</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-ubuntu-x86_64-20.04-focal-gtk3-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-ubuntu-x86_64-20.04-gtk3-focal-gtk3.tar.gz
+</tarball-url>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
+  </plugin>
+  <plugin version="1">
+    <name> Engine Dashboard </name>
+    <version> 1.5.0.0 </version>
+    <release> 0 </release>
+    <summary> Engine Dashboard, Displays Engine parameters. </summary>
+    <api-version> 1.18 </api-version>
+    <open-source> yes </open-source>
+    <author> twocanplugin@hotmail.com </author>
+    <source> https://github.com/TwoCanPlugIn/EngineDashboard </source>
+    <description>
+Engine Dashboard, Displays Engine RPM, Oil pressure, Water temperature, Alternator output and Tank levels.
+</description>
+    <target>ubuntu-x86_64</target>
+    <build-target>ubuntu</build-target>
+    <build-gtk/>
+    <target-version>22.04</target-version>
+    <target-arch>x86_64</target-arch>
+    <tarball-url>
+https://dl.cloudsmith.io/public/steven-adler/engineplugin-prod/raw/names/engine_dashboard_pi-1.5.0.0-ubuntu-x86_64-22.04-jammy-tarball/versions/v1.5/engine_dashboard_pi-1.5.0.0-ubuntu-x86_64-22.04-jammy.tar.gz
 </tarball-url>
     <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:developer_manual:plugins:beta_plugins:engine-dash </info-url>
   </plugin>


### PR DESCRIPTION
Updated plugin supports OCPN 5.8.x NMEA 2000.
Passed XML and URL checks