### PR TITLE
check-metadata-urls: Handle empty urls

### DIFF
--- a/tools/check-metadata-urls
+++ b/tools/check-metadata-urls
@@ -152,6 +152,10 @@ def get_checksum(url):
 
 def is_accessible(url, path, tag, stats):
     """Check that  url is accessible, return boolean """
+    if not url:
+        stats.url_errors.append(path  + ": empty url")
+        stats.print_dot('F')
+        return False;
     status = get_status_code(url.strip())
     dot = '.'
     r = True


### PR DESCRIPTION
Add some handling for empty urls. This reports grib as problematic since it's url is empty. It should be pretty clear that that this is not an  actual issue, though.

Closes: #929