### PR TITLE
System  plugin metadata

### DIFF
--- a/metadata/chartdownloader-all.xml
+++ b/metadata/chartdownloader-all.xml
@@ -1,0 +1,18 @@
+<plugin version="1">
+    <name> ChartDownloader </name>
+    <version>1.13</version>
+    <release>0</release>
+    <summary> Download charts from NOAA Catalog </summary>
+    <api-version> 1.16 </api-version>
+    <open-source> yes </open-source>
+    <author> Pavel Kalian </author>
+    <source> https://github.com/OpenCPN/opencpn </source>
+    <info-url>https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:charts:chart_downloader_tab </info-url>
+    <description> Manage chart downloads and updates from
+sources supporting NOAA Chart Catalog format</description>
+    <target>all</target>
+    <target-version>0</target-version>
+    <target-arch>all</target-arch>
+    <tarball-url> </tarball-url>
+    <tarball-checksum> </tarball-checksum>
+</plugin>

--- a/metadata/dashboard-all.xml
+++ b/metadata/dashboard-all.xml
@@ -1,0 +1,17 @@
+<plugin version="1">
+    <name> Dashboard </name>
+    <version>1.8</version>
+    <release>0</release>
+    <summary> NMEA instruments display </summary>
+    <api-version> 1.16 </api-version>
+    <open-source> yes </open-source>
+    <author> David Register </author>
+    <source> https://github.com/OpenCPN/opencpn </source>
+    <info-url>  https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:included_plugins:dashboard </info-url>
+    <description> Configurable display of various NMEA sources </description>
+    <target>all</target>
+    <target-version>0</target-version>
+    <target-arch>all</target-arch>
+    <tarball-url> </tarball-url>
+    <tarball-checksum> </tarball-checksum>
+</plugin>

--- a/metadata/grib-all.xml
+++ b/metadata/grib-all.xml
@@ -1,0 +1,34 @@
+<plugin version="1">
+    <name> GRIB </name>
+    <version>4.1</version>
+    <release>0</release>
+    <summary> Grib weather info overlay </summary>
+    <api-version> 1.16 </api-version>
+    <open-source> yes </open-source>
+    <author> DAvid Register </author>
+    <source> https://github.com/OpenCPN/opencpn </source>
+    <info-url> https://opencpn-manuals.github.io/main/opencpn-plugins/grib_weather/grib_weather.html </info-url>
+    <description> Provides basic GRIB file overlay
+capabilities for several GRIB file
+types and a request function to get GRIB
+files by eMail.
+Supported GRIB data include:
+- wind direction and speed (at 10 m)
+- wind gust
+- surface pressure
+- rainfall
+- cloud cover
+- significant wave height and direction
+- air surface temperature (at 2 m)
+- sea surface temperature
+- surface current direction and speed
+- Convective Available Potential Energy (CAPE)
+- wind, altitude, temperature and relative
+  humidity at 300, 500, 700, 850 hPa.
+ </description>
+    <target>all</target>
+    <target-version>0</target-version>
+    <target-arch>all</target-arch>
+    <tarball-url> </tarball-url>
+    <tarball-checksum> </tarball-checksum>
+</plugin>

--- a/metadata/wmm-all.xml
+++ b/metadata/wmm-all.xml
@@ -1,0 +1,33 @@
+<plugin version="1">
+    <name> WMM </name>
+    <version>1.8</version>
+    <release>0</release>
+    <summary> Magnetic variation info</summary>
+    <api-version> 1.16 </api-version>
+    <open-source> yes </open-source>
+    <author> Pavel Kalian </author>
+    <source> https://github.com/OpenCPN/opencpn </source>
+    <info-url> https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:included_plugins:wmm </info-url>
+    <description>Allows users to cross reference
+magnetic variation values printed on many
+raster charts. Variation is the angle between
+true and magnetic north.  Inclination or dip,
+is the vertical angle of the magnetic field.
+\t(+- 90 at the magnetic poles)
+Field Strength is the magnetic field in nano
+tesla from \t20000 to 66000.
+The plotted lines are similar to a topographic
+map.  The space between them can be adjusted;
+more space takes less time to calculate.
+Step size and Pole accuracy sliders allow a
+trade off for speed vs computation time.
+The World Magnetic Model Plugin was written by
+Pavel Kalian and extended by Sean D'Epagnier to
+support plotting.
+ </description>
+    <target>all</target>
+    <target-version>0</target-version>
+    <target-arch>all</target-arch>
+    <tarball-url> </tarball-url>
+    <tarball-checksum> </tarball-checksum>
+</plugin>

--- a/ocpn-plugin.xsd
+++ b/ocpn-plugin.xsd
@@ -43,6 +43,7 @@
 <xs:element name="target-arch">
   <xs:simpleType>
     <xs:restriction base = "xs:string">
+      <xs:enumeration value = "all"/>
       <xs:enumeration value = "x86_64"/>
       <xs:enumeration value = "armhf"/>
       <xs:enumeration value = "arm64"/>    <!-- Used on Debian -->

--- a/tools/check-metadata-urls
+++ b/tools/check-metadata-urls
@@ -54,6 +54,8 @@ def check_urls(urls):
     col = 0
     bad_urls = []
     for url in urls:
+        if not url:
+            continue
         if col > 72:
             print("")
             col = 0


### PR DESCRIPTION
This is basically support for https://github.com/OpenCPN/OpenCPN/pull/3258 which notably adds the website button also to the system plugins. Overall, it also seems more consistent to have the metadata in  the catalog also for the system plugins.

While on it, fix two bugs: one in the xsd file and one on check-metadata-urls.

EDIT: The check-metadata-urls fix is basically a hack. We need to update basically all files besides the metadata  from master to Beta.