### PR TITLE
New <target-arch> i386

### DIFF
--- a/ocpn-plugin.xsd
+++ b/ocpn-plugin.xsd
@@ -44,6 +44,7 @@
   <xs:simpleType>
     <xs:restriction base = "xs:string">
       <xs:enumeration value = "x86_64"/>
+      <xs:enumeration value = "x86"/>    <!-- windows, see opencpn/OpenCPN#2027 -->
       <xs:enumeration value = "armhf"/>
       <xs:enumeration value = "arm64"/>    <!-- Used on Debian -->
       <xs:enumeration value = "aarch64"/>  <!-- Used for flatpak -->


### PR DESCRIPTION
Per discussions in https://github.com/OpenCPN/OpenCPN/issues/2027 we need windows arch specifier which reflects the actual win32 plugins we build. Added _x86_.