### PR TITLE
Patch version from v3-0-2a to 3.0.2a

### DIFF
--- a/metadata/javascript-v3-0-2a-darwin-wx32-universal-10.xml
+++ b/metadata/javascript-v3-0-2a-darwin-wx32-universal-10.xml
@@ -2,7 +2,7 @@
 <!-- https://circleci.com/gh/antipole2/JavaScript_pi/5734 -->
 <plugin version="1">
   <name> javascript </name>
-  <version> v3-0-2a </version>
+  <version> 3.0.2a </version>
   <release> 0 </release>
   <summary> Run JavaScripts in the plugin </summary>
 

--- a/metadata/javascript-v3-0-2a-debian-arm64-A64-11.xml
+++ b/metadata/javascript-v3-0-2a-debian-arm64-A64-11.xml
@@ -2,7 +2,7 @@
 <!--  -->
 <plugin version="1">
   <name> javascript </name>
-  <version> v3-0-2a </version>
+  <version> 3.0.2a </version>
   <release> 0 </release>
   <summary> Run JavaScripts in the plugin </summary>
 

--- a/metadata/javascript-v3-0-2a-debian-arm64-A64-12.xml
+++ b/metadata/javascript-v3-0-2a-debian-arm64-A64-12.xml
@@ -2,7 +2,7 @@
 <!--  -->
 <plugin version="1">
   <name> javascript </name>
-  <version> v3-0-2a </version>
+  <version> 3.0.2a </version>
   <release> 0 </release>
   <summary> Run JavaScripts in the plugin </summary>
 

--- a/metadata/javascript-v3-0-2a-debian-armhf-A32-11.xml
+++ b/metadata/javascript-v3-0-2a-debian-armhf-A32-11.xml
@@ -2,7 +2,7 @@
 <!--  -->
 <plugin version="1">
   <name> javascript </name>
-  <version> v3-0-2a </version>
+  <version> 3.0.2a </version>
   <release> 0 </release>
   <summary> Run JavaScripts in the plugin </summary>
 

--- a/metadata/javascript-v3-0-2a-debian-armhf-A32-12.xml
+++ b/metadata/javascript-v3-0-2a-debian-armhf-A32-12.xml
@@ -2,7 +2,7 @@
 <!--  -->
 <plugin version="1">
   <name> javascript </name>
-  <version> v3-0-2a </version>
+  <version> 3.0.2a </version>
   <release> 0 </release>
   <summary> Run JavaScripts in the plugin </summary>
 

--- a/metadata/javascript-v3-0-2a-debian-wx32-arm64-A64-11.xml
+++ b/metadata/javascript-v3-0-2a-debian-wx32-arm64-A64-11.xml
@@ -2,7 +2,7 @@
 <!--  -->
 <plugin version="1">
   <name> javascript </name>
-  <version> v3-0-2a </version>
+  <version> 3.0.2a </version>
   <release> 0 </release>
   <summary> Run JavaScripts in the plugin </summary>
 

--- a/metadata/javascript-v3-0-2a-debian-wx32-armhf-A32-11.xml
+++ b/metadata/javascript-v3-0-2a-debian-wx32-armhf-A32-11.xml
@@ -2,7 +2,7 @@
 <!--  -->
 <plugin version="1">
   <name> javascript </name>
-  <version> v3-0-2a </version>
+  <version> 3.0.2a </version>
   <release> 0 </release>
   <summary> Run JavaScripts in the plugin </summary>
 

--- a/metadata/javascript-v3-0-2a-debian-wx32-x86_64-11.xml
+++ b/metadata/javascript-v3-0-2a-debian-wx32-x86_64-11.xml
@@ -2,7 +2,7 @@
 <!-- https://circleci.com/gh/antipole2/JavaScript_pi/5730 -->
 <plugin version="1">
   <name> javascript </name>
-  <version> v3-0-2a </version>
+  <version> 3.0.2a </version>
   <release> 0 </release>
   <summary> Run JavaScripts in the plugin </summary>
 

--- a/metadata/javascript-v3-0-2a-debian-x86_64-11.xml
+++ b/metadata/javascript-v3-0-2a-debian-x86_64-11.xml
@@ -2,7 +2,7 @@
 <!-- https://circleci.com/gh/antipole2/JavaScript_pi/5726 -->
 <plugin version="1">
   <name> javascript </name>
-  <version> v3-0-2a </version>
+  <version>3.0.2a </version>
   <release> 0 </release>
   <summary> Run JavaScripts in the plugin </summary>
 

--- a/metadata/javascript-v3-0-2a-debian-x86_64-12.xml
+++ b/metadata/javascript-v3-0-2a-debian-x86_64-12.xml
@@ -2,7 +2,7 @@
 <!--  -->
 <plugin version="1">
   <name> javascript </name>
-  <version> v3-0-2a </version>
+  <version> 3.0.2a </version>
   <release> 0 </release>
   <summary> Run JavaScripts in the plugin </summary>
 

--- a/metadata/javascript-v3-0-2a-flatpak-aarch64-A64-22.08.xml
+++ b/metadata/javascript-v3-0-2a-flatpak-aarch64-A64-22.08.xml
@@ -2,7 +2,7 @@
 <!-- https://circleci.com/gh/antipole2/JavaScript_pi/5733 -->
 <plugin version="1">
   <name> javascript </name>
-  <version> v3-0-2a </version>
+  <version> 3.0.2a </version>
   <release> 0 </release>
   <summary> Run JavaScripts in the plugin </summary>
 

--- a/metadata/javascript-v3-0-2a-flatpak-x86_64-22.08.xml
+++ b/metadata/javascript-v3-0-2a-flatpak-x86_64-22.08.xml
@@ -2,7 +2,7 @@
 <!-- https://circleci.com/gh/antipole2/JavaScript_pi/5732 -->
 <plugin version="1">
   <name> javascript </name>
-  <version> v3-0-2a </version>
+  <version> 3.0.2a </version>
   <release> 0 </release>
   <summary> Run JavaScripts in the plugin </summary>
 

--- a/metadata/javascript-v3-0-2a-msvc-wx32-10.xml
+++ b/metadata/javascript-v3-0-2a-msvc-wx32-10.xml
@@ -2,7 +2,7 @@
 <!-- https://ci.appveyor.com/project/antipole2/javascript-pi/builds/49639706 -->
 <plugin version="1">
   <name> javascript </name>
-  <version> v3-0-2a </version>
+  <version> 3.0.2a </version>
   <release> 0 </release>
   <summary> Run JavaScripts in the plugin </summary>
 


### PR DESCRIPTION
Github (Github desktop at least) does not allow tags ending in '.' and, as you type, advises it will use '_' instead.
This led me to use a tag v3_0.2a.  However, in the plugin catalogue this is shown as -1.0.0-0-2a.  Very misleading for the user.

I have now found that it is only a trailing '.' that causes the issue and, if you type on regardless, v3.0.2a would be acceptable.

This pull patches the version number in the metadata files from v3-0-2a to 3.0.2a