### PR TITLE
Radar v5.5.4-beta

### DIFF
--- a/metadata/Radar-v5.5.4-beta-darwin-wx32-universal-10.xml
+++ b/metadata/Radar-v5.5.4-beta-darwin-wx32-universal-10.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--  -->
+<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/3570 -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.5.3-beta </version>
-  <release>  </release>
+  <version> v5.5.4-beta </version>
+  <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
   <api-version> 1.16 </api-version>
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>debian-arm64</target>
-  <target-version>11</target-version>
-  <target-arch>arm64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.3-beta-debian-A64-11-tarball/versions/v5.5.3-beta/Radar-v5.5.3-beta_debian-11-arm64.tar.gz </tarball-url>
-  <tarball-checksum> faa87e562b850a06e3a9c7602cb72a7ac27ea73a84159c3743a55976ba9be3de </tarball-checksum>
+  <target>darwin-wx32</target>
+  <target-version>10</target-version>
+  <target-arch>arm64;x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-beta/raw/names/Radar-v5.5.4-beta-darwin-wx32-universal-10-tarball/versions/v5.5.4-beta/Radar-v5.5.4-beta_darwin-wx32-10-arm64-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 5b5d845c670f02bfc950d334c6e799891afe6283e2a2510392288711d319716e </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.4-beta-debian-11.xml
+++ b/metadata/Radar-v5.5.4-beta-debian-11.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/3328 -->
+<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/3569 -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.5.3-beta </version>
-  <release>  </release>
+  <version> v5.5.4-beta </version>
+  <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
   <api-version> 1.16 </api-version>
@@ -29,6 +29,6 @@ such as dual radar range and Doppler.
   <target>debian-x86_64</target>
   <target-version>11</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.3-beta-debian-11-tarball/versions/v5.5.3-beta/Radar-v5.5.3-beta_debian-11-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> c41c9186d2e150ca2698768367be81151b1463f8c846dbc4e82d4579ee6a8f64 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-beta/raw/names/Radar-v5.5.4-beta-debian-11-tarball/versions/v5.5.4-beta/Radar-v5.5.4-beta_debian-11-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> d724002d5eef5d0e8957b5da71450bf38f45d8a3bc360453e3aeeaa27ad24bf8 </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.4-beta-debian-12.xml
+++ b/metadata/Radar-v5.5.4-beta-debian-12.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/3324 -->
+<!--  -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.5.3-beta </version>
-  <release>  </release>
+  <version> v5.5.4-beta </version>
+  <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
   <api-version> 1.16 </api-version>
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>flatpak-aarch64</target>
-  <target-version>22.08</target-version>
-  <target-arch>aarch64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.3-beta-flatpak-A64-22.08-tarball/versions/v5.5.3-beta/Radar-v5.5.3-beta_flatpak-22.08-aarch64.tar.gz </tarball-url>
-  <tarball-checksum> 87083d9eb40b8125029d41836057283d5a4d32c01cbbdccd43eb0d9349b4ceb2 </tarball-checksum>
+  <target>debian-x86_64</target>
+  <target-version>12</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-beta/raw/names/Radar-v5.5.4-beta-debian-12-tarball/versions/v5.5.4-beta/Radar-v5.5.4-beta_debian-12-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 9ca006b5c32e06fe2a86c6eff3b3e085d554359c8eb38a633d6eda3f946aced8 </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.4-beta-debian-A32-11.xml
+++ b/metadata/Radar-v5.5.4-beta-debian-A32-11.xml
@@ -2,8 +2,8 @@
 <!--  -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.5.3-beta </version>
-  <release>  </release>
+  <version> v5.5.4-beta </version>
+  <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
   <api-version> 1.16 </api-version>
@@ -27,8 +27,8 @@ such as dual radar range and Doppler.
  </description>
 
   <target>debian-armhf</target>
-  <target-version>12</target-version>
+  <target-version>11</target-version>
   <target-arch>armhf</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.3-beta-debian-A32-12-tarball/versions/v5.5.3-beta/Radar-v5.5.3-beta_debian-12-armhf.tar.gz </tarball-url>
-  <tarball-checksum> bb2cd3e0ff671c51a59ab068e766defe5f47ace8507610598be095cdc42ba58f </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-beta/raw/names/Radar-v5.5.4-beta-debian-A32-11-tarball/versions/v5.5.4-beta/Radar-v5.5.4-beta_debian-11-armhf.tar.gz </tarball-url>
+  <tarball-checksum> 9b34c16c89b2d8f9adf4a851dd486aeac5e665e3896d16b2472f976398652c16 </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.4-beta-debian-A32-12.xml
+++ b/metadata/Radar-v5.5.4-beta-debian-A32-12.xml
@@ -2,8 +2,8 @@
 <!--  -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.5.3-beta </version>
-  <release>  </release>
+  <version> v5.5.4-beta </version>
+  <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
   <api-version> 1.16 </api-version>
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>debian-wx32-arm64</target>
-  <target-version>11</target-version>
-  <target-arch>arm64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.3-beta-debian-wx32-A64-11-tarball/versions/v5.5.3-beta/Radar-v5.5.3-beta_debian-wx32-11-arm64.tar.gz </tarball-url>
-  <tarball-checksum> f76d5c32ff3b9572ccc1e321ad9a19dc7fb49e4cae479ddef2cfb85fc21b29d6 </tarball-checksum>
+  <target>debian-armhf</target>
+  <target-version>12</target-version>
+  <target-arch>armhf</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-beta/raw/names/Radar-v5.5.4-beta-debian-A32-12-tarball/versions/v5.5.4-beta/Radar-v5.5.4-beta_debian-12-armhf.tar.gz </tarball-url>
+  <tarball-checksum> 6523924c78f416a75cc72d734b5fb47d8487642f3f077c9de1cd93e80d765e77 </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.4-beta-debian-A64-11.xml
+++ b/metadata/Radar-v5.5.4-beta-debian-A64-11.xml
@@ -2,8 +2,8 @@
 <!--  -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.5.3-beta </version>
-  <release>  </release>
+  <version> v5.5.4-beta </version>
+  <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
   <api-version> 1.16 </api-version>
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>debian-x86_64</target>
-  <target-version>12</target-version>
-  <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.3-beta-debian-12-tarball/versions/v5.5.3-beta/Radar-v5.5.3-beta_debian-12-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 5c71f71a331f9f08ce31e9a18673e12c5ad31fc048acf37ebc7ab64a60dcd4df </tarball-checksum>
+  <target>debian-arm64</target>
+  <target-version>11</target-version>
+  <target-arch>arm64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-beta/raw/names/Radar-v5.5.4-beta-debian-A64-11-tarball/versions/v5.5.4-beta/Radar-v5.5.4-beta_debian-11-arm64.tar.gz </tarball-url>
+  <tarball-checksum> a4489749359bf26a1ed57b4a619c42081a128d42ea284893b42c76633fd7ac1b </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.4-beta-debian-A64-12.xml
+++ b/metadata/Radar-v5.5.4-beta-debian-A64-12.xml
@@ -2,8 +2,8 @@
 <!--  -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.5.3-beta </version>
-  <release>  </release>
+  <version> v5.5.4-beta </version>
+  <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
   <api-version> 1.16 </api-version>
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>debian-armhf</target>
-  <target-version>11</target-version>
-  <target-arch>armhf</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.3-beta-debian-A32-11-tarball/versions/v5.5.3-beta/Radar-v5.5.3-beta_debian-11-armhf.tar.gz </tarball-url>
-  <tarball-checksum> 269ecb83bec6758649c2a1716dce138c2857d932bf992ddda305699835dce4b7 </tarball-checksum>
+  <target>debian-arm64</target>
+  <target-version>12</target-version>
+  <target-arch>arm64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-beta/raw/names/Radar-v5.5.4-beta-debian-A64-12-tarball/versions/v5.5.4-beta/Radar-v5.5.4-beta_debian-12-arm64.tar.gz </tarball-url>
+  <tarball-checksum> 0557f216b6b94f9b40a389c00bf15519a4ff971720d19cb750d366e5b02bb7ad </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.4-beta-debian-wx32-11.xml
+++ b/metadata/Radar-v5.5.4-beta-debian-wx32-11.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/3337 -->
+<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/3568 -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.5.3-beta </version>
-  <release>  </release>
+  <version> v5.5.4-beta </version>
+  <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
   <api-version> 1.16 </api-version>
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>darwin-wx32</target>
-  <target-version>10</target-version>
+  <target>debian-wx32-x86_64</target>
+  <target-version>11</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.3-beta-darwin-wx32-10-tarball/versions/v5.5.3-beta/Radar-v5.5.3-beta_darwin-wx32-10-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 7d8c6aee80b43ba8a9997fea344d8038cdc2baf641b7e6a82d9e2027a98125f8 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-beta/raw/names/Radar-v5.5.4-beta-debian-wx32-11-tarball/versions/v5.5.4-beta/Radar-v5.5.4-beta_debian-wx32-11-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 6c3ccd154ecabdf62cc766f87f63c2c2b2581b71d7647294389cecf6d408a4bc </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.4-beta-debian-wx32-A32-11.xml
+++ b/metadata/Radar-v5.5.4-beta-debian-wx32-A32-11.xml
@@ -2,8 +2,8 @@
 <!--  -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.5.3-beta </version>
-  <release>  </release>
+  <version> v5.5.4-beta </version>
+  <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
   <api-version> 1.16 </api-version>
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>debian-arm64</target>
-  <target-version>12</target-version>
-  <target-arch>arm64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.3-beta-debian-A64-12-tarball/versions/v5.5.3-beta/Radar-v5.5.3-beta_debian-12-arm64.tar.gz </tarball-url>
-  <tarball-checksum> 917800a3192a61dec7a6c4cf8708bc2c224c0c1dbbcd1f8494a4f22a69d3cb92 </tarball-checksum>
+  <target>debian-wx32-armhf</target>
+  <target-version>11</target-version>
+  <target-arch>armhf</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-beta/raw/names/Radar-v5.5.4-beta-debian-wx32-A32-11-tarball/versions/v5.5.4-beta/Radar-v5.5.4-beta_debian-wx32-11-armhf.tar.gz </tarball-url>
+  <tarball-checksum> ddf84a1a366c894c25530bfe1074361440a00a7cad20045cc6fca1bb6d34511e </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.4-beta-debian-wx32-A64-11.xml
+++ b/metadata/Radar-v5.5.4-beta-debian-wx32-A64-11.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/3338 -->
+<!--  -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.5.3-beta </version>
-  <release>  </release>
+  <version> v5.5.4-beta </version>
+  <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
   <api-version> 1.16 </api-version>
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>debian-wx32-x86_64</target>
+  <target>debian-wx32-arm64</target>
   <target-version>11</target-version>
-  <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.3-beta-debian-wx32.wx32-11-tarball/versions/v5.5.3-beta/Radar-v5.5.3-beta_debian-wx32.wx32-11-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 378eb7b3497d874ff3d4e6119e4ad2906b9df2484d1dd34ebf6510950a2d0bc0 </tarball-checksum>
+  <target-arch>arm64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-beta/raw/names/Radar-v5.5.4-beta-debian-wx32-A64-11-tarball/versions/v5.5.4-beta/Radar-v5.5.4-beta_debian-wx32-11-arm64.tar.gz </tarball-url>
+  <tarball-checksum> 2b722556da4abb9627dc69f8b0fc268f9121773dc1641258a4c69e0ee5749856 </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.4-beta-flatpak-22.08.xml
+++ b/metadata/Radar-v5.5.4-beta-flatpak-22.08.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--  -->
+<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/3576 -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.5.3-beta </version>
-  <release>  </release>
+  <version> v5.5.4-beta </version>
+  <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
   <api-version> 1.16 </api-version>
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>debian-wx32-armhf</target>
-  <target-version>11</target-version>
-  <target-arch>armhf</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.3-beta-debian-wx32-A32-11-tarball/versions/v5.5.3-beta/Radar-v5.5.3-beta_debian-wx32-11-armhf.tar.gz </tarball-url>
-  <tarball-checksum> aee2818f9cb38f4906597379eb65a927957331db7c2c4185db4a4fd6471e6914 </tarball-checksum>
+  <target>flatpak-x86_64</target>
+  <target-version>22.08</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-beta/raw/names/Radar-v5.5.4-beta-flatpak-22.08-tarball/versions/v5.5.4-beta/Radar-v5.5.4-beta_flatpak-22.08-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> c2e7154d4fc63380eca666a6df71303b59170fd5fd8fec337c515f81145e4d65 </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.4-beta-flatpak-A64-22.08.xml
+++ b/metadata/Radar-v5.5.4-beta-flatpak-A64-22.08.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/3325 -->
+<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/3577 -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.5.3-beta </version>
-  <release>  </release>
+  <version> v5.5.4-beta </version>
+  <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
   <api-version> 1.16 </api-version>
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>flatpak-x86_64</target>
+  <target>flatpak-aarch64</target>
   <target-version>22.08</target-version>
-  <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.3-beta-flatpak-22.08-tarball/versions/v5.5.3-beta/Radar-v5.5.3-beta_flatpak-22.08-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 33b7f36592a8eaf0d73536b5d5272a00ce939ffa490ecae4b350ccc9f19e927f </tarball-checksum>
+  <target-arch>aarch64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-beta/raw/names/Radar-v5.5.4-beta-flatpak-A64-22.08-tarball/versions/v5.5.4-beta/Radar-v5.5.4-beta_flatpak-22.08-aarch64.tar.gz </tarball-url>
+  <tarball-checksum> e0d1ccd6ec69dfe594d0200b8e069206b8bdc3939f98a15b8d0e4f850dd530d0 </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.5.4-beta-msvc-wx32-10.0.20348.xml
+++ b/metadata/Radar-v5.5.4-beta-msvc-wx32-10.0.20348.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://ci.appveyor.com/project/keesverruijt/radar-pi/builds/50341986 -->
+<!-- fv-az1435-649 - 2408091251 -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.5.3-beta </version>
-  <release>  </release>
+  <version> v5.5.4-beta </version>
+  <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
   <api-version> 1.16 </api-version>
@@ -27,8 +27,8 @@ such as dual radar range and Doppler.
  </description>
 
   <target>msvc-wx32</target>
-  <target-version>10</target-version>
+  <target-version>10.0.20348</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/opencpn-radar-pi-beta/raw/names/Radar-v5.5.3-beta-msvc-wx32-10-tarball/versions/v5.5.3-beta/Radar-v5.5.3-beta_msvc-wx32-10-win32.tar.gz </tarball-url>
-  <tarball-checksum> 5bad06dd47f6632514469a72674186100fa4b631d19e6217c73da6f0dbae5fcf </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-beta/raw/names/Radar-v5.5.4-beta-msvc-wx32-10.0.20348-tarball/versions/v5.5.4-beta/Radar-v5.5.4-beta_msvc-wx32-10.0.20348-win32.tar.gz </tarball-url>
+  <tarball-checksum> 3be3af2704f87ee39e5fc0dbbaa40bf631004933b49f3d5aff854e530d719d52 </tarball-checksum>
 </plugin>


### PR DESCRIPTION
Testing found some build/git issues in 5.5.3, so we're up to 5.5.4. 