### PR TITLE
dashboard-tactics 1.7.65.0

### DIFF
--- a/metadata/dashboard_tactics_pi-1.7.65.0-android-arm64-16-android-arm64.xml
+++ b/metadata/dashboard_tactics_pi-1.7.65.0-android-arm64-16-android-arm64.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> DashboardTactics </name>
+<version> 1.7.65.0 </version>
+<release> 0 </release>
+<summary> Dashboard and Tactics </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Rick Gleason </author>
+<source> https://github.com/rgleason/dashboard_tactics_pi </source>
+
+<description>
+Dashboard PlugIn with Tactics for OpenCPN Provides navigation instruments enhanced with performance functions and alternative input/output functions.
+</description>
+
+<target>android-arm64</target>
+<build-target>android</build-target>
+<build-gtk></build-gtk>
+<target-version>16</target-version>
+<target-arch>arm64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboard_tactics_pi-1.7.65.0-android-arm64-16-android-arm64-tarball/versions/v1.7.65.0/dashboard_tactics_pi-1.7.65.0-android-arm64-16-android-arm64.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/dashboardtactics.html </info-url>
+</plugin>

--- a/metadata/dashboard_tactics_pi-1.7.65.0-android-armhf-16-android-armhf.xml
+++ b/metadata/dashboard_tactics_pi-1.7.65.0-android-armhf-16-android-armhf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> DashboardTactics </name>
+<version> 1.7.65.0 </version>
+<release> 0 </release>
+<summary> Dashboard and Tactics </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Rick Gleason </author>
+<source> https://github.com/rgleason/dashboard_tactics_pi </source>
+
+<description>
+Dashboard PlugIn with Tactics for OpenCPN Provides navigation instruments enhanced with performance functions and alternative input/output functions.
+</description>
+
+<target>android-armhf</target>
+<build-target>android</build-target>
+<build-gtk></build-gtk>
+<target-version>16</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboard_tactics_pi-1.7.65.0-android-armhf-16-android-armhf-tarball/versions/v1.7.65.0/dashboard_tactics_pi-1.7.65.0-android-armhf-16-android-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/dashboardtactics.html </info-url>
+</plugin>

--- a/metadata/dashboard_tactics_pi-1.7.65.0-darwin-wx32-arm64-x86_64-14.1-macos.xml
+++ b/metadata/dashboard_tactics_pi-1.7.65.0-darwin-wx32-arm64-x86_64-14.1-macos.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> DashboardTactics </name>
+<version> 1.7.65.0 </version>
+<release> 0 </release>
+<summary> Dashboard and Tactics </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Rick Gleason </author>
+<source> https://github.com/rgleason/dashboard_tactics_pi </source>
+
+<description>
+Dashboard PlugIn with Tactics for OpenCPN Provides navigation instruments enhanced with performance functions and alternative input/output functions.
+</description>
+
+<target>darwin-wx32</target>
+<build-target>darwin</build-target>
+<build-gtk></build-gtk>
+<target-version>14.1</target-version>
+<target-arch>arm64;x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboard_tactics_pi-1.7.65.0-darwin-wx32-arm64-x86_64-14.1-macos-tarball/versions/v1.7.65.0/dashboard_tactics_pi-1.7.65.0-darwin-wx32-arm64-x86_64-14.1-macos.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/dashboardtactics.html </info-url>
+</plugin>

--- a/metadata/dashboard_tactics_pi-1.7.65.0-debian-arm64-11-bullseye-arm64.xml
+++ b/metadata/dashboard_tactics_pi-1.7.65.0-debian-arm64-11-bullseye-arm64.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> DashboardTactics </name>
+<version> 1.7.65.0 </version>
+<release> 0 </release>
+<summary> Dashboard and Tactics </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Rick Gleason </author>
+<source> https://github.com/rgleason/dashboard_tactics_pi </source>
+
+<description>
+Dashboard PlugIn with Tactics for OpenCPN Provides navigation instruments enhanced with performance functions and alternative input/output functions.
+</description>
+
+<target>debian-arm64</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>11</target-version>
+<target-arch>arm64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboard_tactics_pi-1.7.65.0-debian-arm64-11-bullseye-arm64-tarball/versions/v1.7.65.0/dashboard_tactics_pi-1.7.65.0-debian-arm64-11-bullseye-arm64.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/dashboardtactics.html </info-url>
+</plugin>

--- a/metadata/dashboard_tactics_pi-1.7.65.0-debian-arm64-12-bookworm-arm64.xml
+++ b/metadata/dashboard_tactics_pi-1.7.65.0-debian-arm64-12-bookworm-arm64.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> DashboardTactics </name>
+<version> 1.7.65.0 </version>
+<release> 0 </release>
+<summary> Dashboard and Tactics </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Rick Gleason </author>
+<source> https://github.com/rgleason/dashboard_tactics_pi </source>
+
+<description>
+Dashboard PlugIn with Tactics for OpenCPN Provides navigation instruments enhanced with performance functions and alternative input/output functions.
+</description>
+
+<target>debian-arm64</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>12</target-version>
+<target-arch>arm64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboard_tactics_pi-1.7.65.0-debian-arm64-12-bookworm-arm64-tarball/versions/v1.7.65.0/dashboard_tactics_pi-1.7.65.0-debian-arm64-12-bookworm-arm64.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/dashboardtactics.html </info-url>
+</plugin>

--- a/metadata/dashboard_tactics_pi-1.7.65.0-debian-armhf-11-bullseye-armhf.xml
+++ b/metadata/dashboard_tactics_pi-1.7.65.0-debian-armhf-11-bullseye-armhf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> DashboardTactics </name>
+<version> 1.7.65.0 </version>
+<release> 0 </release>
+<summary> Dashboard and Tactics </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Rick Gleason </author>
+<source> https://github.com/rgleason/dashboard_tactics_pi </source>
+
+<description>
+Dashboard PlugIn with Tactics for OpenCPN Provides navigation instruments enhanced with performance functions and alternative input/output functions.
+</description>
+
+<target>debian-armhf</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>11</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboard_tactics_pi-1.7.65.0-debian-armhf-11-bullseye-armhf-tarball/versions/v1.7.65.0/dashboard_tactics_pi-1.7.65.0-debian-armhf-11-bullseye-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/dashboardtactics.html </info-url>
+</plugin>

--- a/metadata/dashboard_tactics_pi-1.7.65.0-debian-armhf-12-bookworm-armhf.xml
+++ b/metadata/dashboard_tactics_pi-1.7.65.0-debian-armhf-12-bookworm-armhf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> DashboardTactics </name>
+<version> 1.7.65.0 </version>
+<release> 0 </release>
+<summary> Dashboard and Tactics </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Rick Gleason </author>
+<source> https://github.com/rgleason/dashboard_tactics_pi </source>
+
+<description>
+Dashboard PlugIn with Tactics for OpenCPN Provides navigation instruments enhanced with performance functions and alternative input/output functions.
+</description>
+
+<target>debian-armhf</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>12</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboard_tactics_pi-1.7.65.0-debian-armhf-12-bookworm-armhf-tarball/versions/v1.7.65.0/dashboard_tactics_pi-1.7.65.0-debian-armhf-12-bookworm-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/dashboardtactics.html </info-url>
+</plugin>

--- a/metadata/dashboard_tactics_pi-1.7.65.0-debian-x86_64-11-bullseye.xml
+++ b/metadata/dashboard_tactics_pi-1.7.65.0-debian-x86_64-11-bullseye.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> DashboardTactics </name>
+<version> 1.7.65.0 </version>
+<release> 0 </release>
+<summary> Dashboard and Tactics </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Rick Gleason </author>
+<source> https://github.com/rgleason/dashboard_tactics_pi </source>
+
+<description>
+Dashboard PlugIn with Tactics for OpenCPN Provides navigation instruments enhanced with performance functions and alternative input/output functions.
+</description>
+
+<target>debian-x86_64</target>
+<build-target>debian</build-target>
+<build-gtk>gtk3</build-gtk>
+<target-version>11</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboard_tactics_pi-1.7.65.0-debian-x86_64-11-bullseye-tarball/versions/v1.7.65.0/dashboard_tactics_pi-1.7.65.0-debian-x86_64-11-bullseye.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/dashboardtactics.html </info-url>
+</plugin>

--- a/metadata/dashboard_tactics_pi-1.7.65.0-debian-x86_64-12-bookworm.xml
+++ b/metadata/dashboard_tactics_pi-1.7.65.0-debian-x86_64-12-bookworm.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> DashboardTactics </name>
+<version> 1.7.65.0 </version>
+<release> 0 </release>
+<summary> Dashboard and Tactics </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Rick Gleason </author>
+<source> https://github.com/rgleason/dashboard_tactics_pi </source>
+
+<description>
+Dashboard PlugIn with Tactics for OpenCPN Provides navigation instruments enhanced with performance functions and alternative input/output functions.
+</description>
+
+<target>debian-x86_64</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>12</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboard_tactics_pi-1.7.65.0-debian-x86_64-12-bookworm-tarball/versions/v1.7.65.0/dashboard_tactics_pi-1.7.65.0-debian-x86_64-12-bookworm.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/dashboardtactics.html </info-url>
+</plugin>

--- a/metadata/dashboard_tactics_pi-1.7.65.0-flatpak-aarch64-22.08-flatpak.xml
+++ b/metadata/dashboard_tactics_pi-1.7.65.0-flatpak-aarch64-22.08-flatpak.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> DashboardTactics </name>
+<version> 1.7.65.0 </version>
+<release> 0 </release>
+<summary> Dashboard and Tactics </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Rick Gleason </author>
+<source> https://github.com/rgleason/dashboard_tactics_pi </source>
+
+<description>
+Dashboard PlugIn with Tactics for OpenCPN Provides navigation instruments enhanced with performance functions and alternative input/output functions.
+</description>
+
+<target>flatpak-aarch64</target>
+<build-target>flatpak</build-target>
+<build-gtk></build-gtk>
+<target-version>22.08</target-version>
+<target-arch>aarch64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboard_tactics_pi-1.7.65.0-flatpak-aarch64-22.08-flatpak-tarball/versions/v1.7.65.0/dashboard_tactics_pi-1.7.65.0-aarch64_flatpak-22.08.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/dashboardtactics.html </info-url>
+</plugin>

--- a/metadata/dashboard_tactics_pi-1.7.65.0-flatpak-aarch64-24.08-flatpak.xml
+++ b/metadata/dashboard_tactics_pi-1.7.65.0-flatpak-aarch64-24.08-flatpak.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> DashboardTactics </name>
+<version> 1.7.65.0 </version>
+<release> 0 </release>
+<summary> Dashboard and Tactics </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Rick Gleason </author>
+<source> https://github.com/rgleason/dashboard_tactics_pi </source>
+
+<description>
+Dashboard PlugIn with Tactics for OpenCPN Provides navigation instruments enhanced with performance functions and alternative input/output functions.
+</description>
+
+<target>flatpak-aarch64</target>
+<build-target>flatpak</build-target>
+<build-gtk></build-gtk>
+<target-version>24.08</target-version>
+<target-arch>aarch64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboard_tactics_pi-1.7.65.0-flatpak-aarch64-24.08-flatpak-tarball/versions/v1.7.65.0/dashboard_tactics_pi-1.7.65.0-aarch64_flatpak-24.08.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/dashboardtactics.html </info-url>
+</plugin>

--- a/metadata/dashboard_tactics_pi-1.7.65.0-flatpak-x86_64-22.08-flatpak.xml
+++ b/metadata/dashboard_tactics_pi-1.7.65.0-flatpak-x86_64-22.08-flatpak.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> DashboardTactics </name>
+<version> 1.7.65.0 </version>
+<release> 0 </release>
+<summary> Dashboard and Tactics </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Rick Gleason </author>
+<source> https://github.com/rgleason/dashboard_tactics_pi </source>
+
+<description>
+Dashboard PlugIn with Tactics for OpenCPN Provides navigation instruments enhanced with performance functions and alternative input/output functions.
+</description>
+
+<target>flatpak-x86_64</target>
+<build-target>flatpak</build-target>
+<build-gtk></build-gtk>
+<target-version>22.08</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboard_tactics_pi-1.7.65.0-flatpak-x86_64-22.08-flatpak-tarball/versions/v1.7.65.0/dashboard_tactics_pi-1.7.65.0-x86_64_flatpak-22.08.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/dashboardtactics.html </info-url>
+</plugin>

--- a/metadata/dashboard_tactics_pi-1.7.65.0-flatpak-x86_64-24.08-flatpak.xml
+++ b/metadata/dashboard_tactics_pi-1.7.65.0-flatpak-x86_64-24.08-flatpak.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> DashboardTactics </name>
+<version> 1.7.65.0 </version>
+<release> 0 </release>
+<summary> Dashboard and Tactics </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Rick Gleason </author>
+<source> https://github.com/rgleason/dashboard_tactics_pi </source>
+
+<description>
+Dashboard PlugIn with Tactics for OpenCPN Provides navigation instruments enhanced with performance functions and alternative input/output functions.
+</description>
+
+<target>flatpak-x86_64</target>
+<build-target>flatpak</build-target>
+<build-gtk></build-gtk>
+<target-version>24.08</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboard_tactics_pi-1.7.65.0-flatpak-x86_64-24.08-flatpak-tarball/versions/v1.7.65.0/dashboard_tactics_pi-1.7.65.0-x86_64_flatpak-24.08.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/dashboardtactics.html </info-url>
+</plugin>

--- a/metadata/dashboard_tactics_pi-1.7.65.0-msvc-x86-10.0.20348-MSVC.xml
+++ b/metadata/dashboard_tactics_pi-1.7.65.0-msvc-x86-10.0.20348-MSVC.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> DashboardTactics </name>
+<version> 1.7.65.0 </version>
+<release> 0 </release>
+<summary> Dashboard and Tactics </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Rick Gleason </author>
+<source> https://github.com/rgleason/dashboard_tactics_pi </source>
+
+<description>
+Dashboard PlugIn with Tactics for OpenCPN Provides navigation instruments enhanced with performance functions and alternative input/output functions.
+</description>
+
+<target>msvc</target>
+<build-target>msvc</build-target>
+<build-gtk></build-gtk>
+<target-version>10.0.20348</target-version>
+<target-arch>x86</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboard_tactics_pi-1.7.65.0-msvc-x86-10.0.20348-MSVC-tarball/versions/v1.7.65.0/dashboard_tactics_pi-1.7.65.0-msvc-x86-10.0.20348-MSVC.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/dashboardtactics.html </info-url>
+</plugin>

--- a/metadata/dashboard_tactics_pi-1.7.65.0-msvc-x86-wx32-10.0.20348-MSVC.xml
+++ b/metadata/dashboard_tactics_pi-1.7.65.0-msvc-x86-wx32-10.0.20348-MSVC.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> DashboardTactics </name>
+<version> 1.7.65.0 </version>
+<release> 0 </release>
+<summary> Dashboard and Tactics </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Rick Gleason </author>
+<source> https://github.com/rgleason/dashboard_tactics_pi </source>
+
+<description>
+Dashboard PlugIn with Tactics for OpenCPN Provides navigation instruments enhanced with performance functions and alternative input/output functions.
+</description>
+
+<target>msvc-wx32</target>
+<build-target>msvc</build-target>
+<build-gtk></build-gtk>
+<target-version>10.0.20348</target-version>
+<target-arch>x86</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboard_tactics_pi-1.7.65.0-msvc-x86-wx32-10.0.20348-MSVC-tarball/versions/v1.7.65.0/dashboard_tactics_pi-1.7.65.0-msvc-x86-wx32-10.0.20348-MSVC.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/dashboardtactics.html </info-url>
+</plugin>

--- a/metadata/dashboard_tactics_pi-1.7.65.0-ubuntu-x86_64-22.04-jammy.xml
+++ b/metadata/dashboard_tactics_pi-1.7.65.0-ubuntu-x86_64-22.04-jammy.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> DashboardTactics </name>
+<version> 1.7.65.0 </version>
+<release> 0 </release>
+<summary> Dashboard and Tactics </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Rick Gleason </author>
+<source> https://github.com/rgleason/dashboard_tactics_pi </source>
+
+<description>
+Dashboard PlugIn with Tactics for OpenCPN Provides navigation instruments enhanced with performance functions and alternative input/output functions.
+</description>
+
+<target>ubuntu-wx32-x86_64</target>
+<build-target>ubuntu</build-target>
+<build-gtk>gtk3</build-gtk>
+<target-version>22.04</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/dashboardtactics-beta/raw/names/dashboard_tactics_pi-1.7.65.0-ubuntu-x86_64-wx32-22.04-jammy-tarball/versions/v1.7.65.0/dashboard_tactics_pi-1.7.65.0-ubuntu-x86_64-22.04-jammy.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/dashboardtactics.html </info-url>
+</plugin>

--- a/metadata/statusbar_pi-1.1.14.0-android-arm64-16-android-arm64.xml
+++ b/metadata/statusbar_pi-1.1.14.0-android-arm64-16-android-arm64.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> StatusBar </name>
+<version> 1.1.14.0 </version>
+<release> 0 </release>
+<summary> StatusBar Plugin is an optional replacement for the builtin statusbar </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Sean D'Epagnier </author>
+<source> https://github.com/rgleason/statusbar_pi </source>
+
+<description>
+The builtin status bar (disable from the User Interface tab) has limited configuration options and can be very difficult to read. The statusbar plugin improves on some of these difficulties. Best used with OpenGL enabled (requires some basic OpenGL extensions).
+</description>
+
+<target>android-arm64</target>
+<build-target>android</build-target>
+<build-gtk></build-gtk>
+<target-version>16</target-version>
+<target-arch>arm64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/statusbar-prod/raw/names/statusbar_pi-1.1.14.0-android-arm64-16-android-arm64-tarball/versions/v1.1.14.0/statusbar_pi-1.1.14.0-android-arm64-16-android-arm64.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/statusbar.html </info-url>
+</plugin>

--- a/metadata/statusbar_pi-1.1.14.0-android-armhf-16-android-armhf.xml
+++ b/metadata/statusbar_pi-1.1.14.0-android-armhf-16-android-armhf.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> StatusBar </name>
-<version> 1.1.10.0 </version>
+<version> 1.1.14.0 </version>
 <release> 0 </release>
 <summary> StatusBar Plugin is an optional replacement for the builtin statusbar </summary>
 
-<api-version> 1.17 </api-version>
+<api-version> 1.18 </api-version>
 <open-source> yes </open-source>
 <author> Sean D'Epagnier </author>
 <source> https://github.com/rgleason/statusbar_pi </source>
@@ -20,7 +20,7 @@ The builtin status bar (disable from the User Interface tab) has limited configu
 <target-version>16</target-version>
 <target-arch>armhf</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/statusbar-prod/raw/names/statusbar_pi-1.1.10.0-android-armhf-16-android-armhf-tarball/versions/v1.1.10.0/statusbar_pi-1.1.10.0-android-armhf-16-android-armhf.tar.gz
+https://dl.cloudsmith.io/public/opencpn/statusbar-prod/raw/names/statusbar_pi-1.1.14.0-android-armhf-16-android-armhf-tarball/versions/v1.1.14.0/statusbar_pi-1.1.14.0-android-armhf-16-android-armhf.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/statusbar.html </info-url>
 </plugin>

--- a/metadata/statusbar_pi-1.1.14.0-darwin-wx32-arm64-x86_64-14.1-macos.xml
+++ b/metadata/statusbar_pi-1.1.14.0-darwin-wx32-arm64-x86_64-14.1-macos.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> StatusBar </name>
+<version> 1.1.14.0 </version>
+<release> 0 </release>
+<summary> StatusBar Plugin is an optional replacement for the builtin statusbar </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Sean D'Epagnier </author>
+<source> https://github.com/rgleason/statusbar_pi </source>
+
+<description>
+The builtin status bar (disable from the User Interface tab) has limited configuration options and can be very difficult to read. The statusbar plugin improves on some of these difficulties. Best used with OpenGL enabled (requires some basic OpenGL extensions).
+</description>
+
+<target>darwin-wx32</target>
+<build-target>darwin</build-target>
+<build-gtk></build-gtk>
+<target-version>14.1</target-version>
+<target-arch>arm64;x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/statusbar-prod/raw/names/statusbar_pi-1.1.14.0-darwin-wx32-arm64-x86_64-14.1-macos-tarball/versions/v1.1.14.0/statusbar_pi-1.1.14.0-darwin-wx32-arm64-x86_64-14.1-macos.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/statusbar.html </info-url>
+</plugin>

--- a/metadata/statusbar_pi-1.1.14.0-debian-arm64-11-bullseye-arm64.xml
+++ b/metadata/statusbar_pi-1.1.14.0-debian-arm64-11-bullseye-arm64.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> StatusBar </name>
+<version> 1.1.14.0 </version>
+<release> 0 </release>
+<summary> StatusBar Plugin is an optional replacement for the builtin statusbar </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Sean D'Epagnier </author>
+<source> https://github.com/rgleason/statusbar_pi </source>
+
+<description>
+The builtin status bar (disable from the User Interface tab) has limited configuration options and can be very difficult to read. The statusbar plugin improves on some of these difficulties. Best used with OpenGL enabled (requires some basic OpenGL extensions).
+</description>
+
+<target>debian-arm64</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>11</target-version>
+<target-arch>arm64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/statusbar-prod/raw/names/statusbar_pi-1.1.14.0-debian-arm64-11-bullseye-arm64-tarball/versions/v1.1.14.0/statusbar_pi-1.1.14.0-debian-arm64-11-bullseye-arm64.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/statusbar.html </info-url>
+</plugin>

--- a/metadata/statusbar_pi-1.1.14.0-debian-arm64-12-bookworm-arm64.xml
+++ b/metadata/statusbar_pi-1.1.14.0-debian-arm64-12-bookworm-arm64.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> StatusBar </name>
+<version> 1.1.14.0 </version>
+<release> 0 </release>
+<summary> StatusBar Plugin is an optional replacement for the builtin statusbar </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Sean D'Epagnier </author>
+<source> https://github.com/rgleason/statusbar_pi </source>
+
+<description>
+The builtin status bar (disable from the User Interface tab) has limited configuration options and can be very difficult to read. The statusbar plugin improves on some of these difficulties. Best used with OpenGL enabled (requires some basic OpenGL extensions).
+</description>
+
+<target>debian-arm64</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>12</target-version>
+<target-arch>arm64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/statusbar-prod/raw/names/statusbar_pi-1.1.14.0-debian-arm64-12-bookworm-arm64-tarball/versions/v1.1.14.0/statusbar_pi-1.1.14.0-debian-arm64-12-bookworm-arm64.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/statusbar.html </info-url>
+</plugin>

--- a/metadata/statusbar_pi-1.1.14.0-debian-armhf-11-bullseye-armhf.xml
+++ b/metadata/statusbar_pi-1.1.14.0-debian-armhf-11-bullseye-armhf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> StatusBar </name>
+<version> 1.1.14.0 </version>
+<release> 0 </release>
+<summary> StatusBar Plugin is an optional replacement for the builtin statusbar </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Sean D'Epagnier </author>
+<source> https://github.com/rgleason/statusbar_pi </source>
+
+<description>
+The builtin status bar (disable from the User Interface tab) has limited configuration options and can be very difficult to read. The statusbar plugin improves on some of these difficulties. Best used with OpenGL enabled (requires some basic OpenGL extensions).
+</description>
+
+<target>debian-armhf</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>11</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/statusbar-prod/raw/names/statusbar_pi-1.1.14.0-debian-armhf-11-bullseye-armhf-tarball/versions/v1.1.14.0/statusbar_pi-1.1.14.0-debian-armhf-11-bullseye-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/statusbar.html </info-url>
+</plugin>

--- a/metadata/statusbar_pi-1.1.14.0-debian-armhf-12-bookworm-armhf.xml
+++ b/metadata/statusbar_pi-1.1.14.0-debian-armhf-12-bookworm-armhf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> StatusBar </name>
+<version> 1.1.14.0 </version>
+<release> 0 </release>
+<summary> StatusBar Plugin is an optional replacement for the builtin statusbar </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Sean D'Epagnier </author>
+<source> https://github.com/rgleason/statusbar_pi </source>
+
+<description>
+The builtin status bar (disable from the User Interface tab) has limited configuration options and can be very difficult to read. The statusbar plugin improves on some of these difficulties. Best used with OpenGL enabled (requires some basic OpenGL extensions).
+</description>
+
+<target>debian-armhf</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>12</target-version>
+<target-arch>armhf</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/statusbar-prod/raw/names/statusbar_pi-1.1.14.0-debian-armhf-12-bookworm-armhf-tarball/versions/v1.1.14.0/statusbar_pi-1.1.14.0-debian-armhf-12-bookworm-armhf.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/statusbar.html </info-url>
+</plugin>

--- a/metadata/statusbar_pi-1.1.14.0-debian-x86_64-12-bookworm.xml
+++ b/metadata/statusbar_pi-1.1.14.0-debian-x86_64-12-bookworm.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> StatusBar </name>
+<version> 1.1.14.0 </version>
+<release> 0 </release>
+<summary> StatusBar Plugin is an optional replacement for the builtin statusbar </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Sean D'Epagnier </author>
+<source> https://github.com/rgleason/statusbar_pi </source>
+
+<description>
+The builtin status bar (disable from the User Interface tab) has limited configuration options and can be very difficult to read. The statusbar plugin improves on some of these difficulties. Best used with OpenGL enabled (requires some basic OpenGL extensions).
+</description>
+
+<target>debian-x86_64</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>12</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/statusbar-prod/raw/names/statusbar_pi-1.1.14.0-debian-x86_64-12-bookworm-tarball/versions/v1.1.14.0/statusbar_pi-1.1.14.0-debian-x86_64-12-bookworm.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/statusbar.html </info-url>
+</plugin>

--- a/metadata/statusbar_pi-1.1.14.0-flatpak-aarch64-22.08-flatpak.xml
+++ b/metadata/statusbar_pi-1.1.14.0-flatpak-aarch64-22.08-flatpak.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> StatusBar </name>
+<version> 1.1.14.0 </version>
+<release> 0 </release>
+<summary> StatusBar Plugin is an optional replacement for the builtin statusbar </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Sean D'Epagnier </author>
+<source> https://github.com/rgleason/statusbar_pi </source>
+
+<description>
+The builtin status bar (disable from the User Interface tab) has limited configuration options and can be very difficult to read. The statusbar plugin improves on some of these difficulties. Best used with OpenGL enabled (requires some basic OpenGL extensions).
+</description>
+
+<target>flatpak-aarch64</target>
+<build-target>flatpak</build-target>
+<build-gtk></build-gtk>
+<target-version>22.08</target-version>
+<target-arch>aarch64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/statusbar-prod/raw/names/statusbar_pi-1.1.14.0-flatpak-aarch64-22.08-flatpak-tarball/versions/v1.1.14.0/statusbar_pi-1.1.14.0-aarch64_flatpak-22.08.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/statusbar.html </info-url>
+</plugin>

--- a/metadata/statusbar_pi-1.1.14.0-flatpak-aarch64-24.08-flatpak.xml
+++ b/metadata/statusbar_pi-1.1.14.0-flatpak-aarch64-24.08-flatpak.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> StatusBar </name>
+<version> 1.1.14.0 </version>
+<release> 0 </release>
+<summary> StatusBar Plugin is an optional replacement for the builtin statusbar </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Sean D'Epagnier </author>
+<source> https://github.com/rgleason/statusbar_pi </source>
+
+<description>
+The builtin status bar (disable from the User Interface tab) has limited configuration options and can be very difficult to read. The statusbar plugin improves on some of these difficulties. Best used with OpenGL enabled (requires some basic OpenGL extensions).
+</description>
+
+<target>flatpak-aarch64</target>
+<build-target>flatpak</build-target>
+<build-gtk></build-gtk>
+<target-version>24.08</target-version>
+<target-arch>aarch64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/statusbar-prod/raw/names/statusbar_pi-1.1.14.0-flatpak-aarch64-24.08-flatpak-tarball/versions/v1.1.14.0/statusbar_pi-1.1.14.0-aarch64_flatpak-24.08.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/statusbar.html </info-url>
+</plugin>

--- a/metadata/statusbar_pi-1.1.14.0-flatpak-x86_64-22.08-flatpak.xml
+++ b/metadata/statusbar_pi-1.1.14.0-flatpak-x86_64-22.08-flatpak.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> StatusBar </name>
+<version> 1.1.14.0 </version>
+<release> 0 </release>
+<summary> StatusBar Plugin is an optional replacement for the builtin statusbar </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Sean D'Epagnier </author>
+<source> https://github.com/rgleason/statusbar_pi </source>
+
+<description>
+The builtin status bar (disable from the User Interface tab) has limited configuration options and can be very difficult to read. The statusbar plugin improves on some of these difficulties. Best used with OpenGL enabled (requires some basic OpenGL extensions).
+</description>
+
+<target>flatpak-x86_64</target>
+<build-target>flatpak</build-target>
+<build-gtk></build-gtk>
+<target-version>22.08</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/statusbar-prod/raw/names/statusbar_pi-1.1.14.0-flatpak-x86_64-22.08-flatpak-tarball/versions/v1.1.14.0/statusbar_pi-1.1.14.0-x86_64_flatpak-22.08.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/statusbar.html </info-url>
+</plugin>

--- a/metadata/statusbar_pi-1.1.14.0-flatpak-x86_64-24.08-flatpak.xml
+++ b/metadata/statusbar_pi-1.1.14.0-flatpak-x86_64-24.08-flatpak.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> StatusBar </name>
+<version> 1.1.14.0 </version>
+<release> 0 </release>
+<summary> StatusBar Plugin is an optional replacement for the builtin statusbar </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Sean D'Epagnier </author>
+<source> https://github.com/rgleason/statusbar_pi </source>
+
+<description>
+The builtin status bar (disable from the User Interface tab) has limited configuration options and can be very difficult to read. The statusbar plugin improves on some of these difficulties. Best used with OpenGL enabled (requires some basic OpenGL extensions).
+</description>
+
+<target>flatpak-x86_64</target>
+<build-target>flatpak</build-target>
+<build-gtk></build-gtk>
+<target-version>24.08</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/statusbar-prod/raw/names/statusbar_pi-1.1.14.0-flatpak-x86_64-24.08-flatpak-tarball/versions/v1.1.14.0/statusbar_pi-1.1.14.0-x86_64_flatpak-24.08.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/statusbar.html </info-url>
+</plugin>

--- a/metadata/statusbar_pi-1.1.14.0-msvc-x86-10.0.20348-MSVC.xml
+++ b/metadata/statusbar_pi-1.1.14.0-msvc-x86-10.0.20348-MSVC.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> StatusBar </name>
-<version> 1.1.10.0 </version>
+<version> 1.1.14.0 </version>
 <release> 0 </release>
 <summary> StatusBar Plugin is an optional replacement for the builtin statusbar </summary>
 
-<api-version> 1.17 </api-version>
+<api-version> 1.18 </api-version>
 <open-source> yes </open-source>
 <author> Sean D'Epagnier </author>
 <source> https://github.com/rgleason/statusbar_pi </source>
@@ -14,13 +14,13 @@
 The builtin status bar (disable from the User Interface tab) has limited configuration options and can be very difficult to read. The statusbar plugin improves on some of these difficulties. Best used with OpenGL enabled (requires some basic OpenGL extensions).
 </description>
 
-<target>android-arm64</target>
-<build-target>android</build-target>
+<target>msvc</target>
+<build-target>msvc</build-target>
 <build-gtk></build-gtk>
-<target-version>16</target-version>
-<target-arch>arm64</target-arch>
+<target-version>10.0.20348</target-version>
+<target-arch>x86</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/statusbar-prod/raw/names/statusbar_pi-1.1.10.0-android-arm64-16-android-arm64-tarball/versions/v1.1.10.0/statusbar_pi-1.1.10.0-android-arm64-16-android-arm64.tar.gz
+https://dl.cloudsmith.io/public/opencpn/statusbar-prod/raw/names/statusbar_pi-1.1.14.0-msvc-x86-10.0.20348-MSVC-tarball/versions/v1.1.14.0/statusbar_pi-1.1.14.0-msvc-x86-10.0.20348-MSVC.tar.gz
 </tarball-url>
 <info-url> https://opencpn.org/OpenCPN/plugins/statusbar.html </info-url>
 </plugin>

--- a/metadata/statusbar_pi-1.1.14.0-msvc-x86-wx32-10.0.20348-MSVC.xml
+++ b/metadata/statusbar_pi-1.1.14.0-msvc-x86-wx32-10.0.20348-MSVC.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> StatusBar </name>
+<version> 1.1.14.0 </version>
+<release> 0 </release>
+<summary> StatusBar Plugin is an optional replacement for the builtin statusbar </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Sean D'Epagnier </author>
+<source> https://github.com/rgleason/statusbar_pi </source>
+
+<description>
+The builtin status bar (disable from the User Interface tab) has limited configuration options and can be very difficult to read. The statusbar plugin improves on some of these difficulties. Best used with OpenGL enabled (requires some basic OpenGL extensions).
+</description>
+
+<target>msvc-wx32</target>
+<build-target>msvc</build-target>
+<build-gtk></build-gtk>
+<target-version>10.0.20348</target-version>
+<target-arch>x86</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/statusbar-prod/raw/names/statusbar_pi-1.1.14.0-msvc-x86-wx32-10.0.20348-MSVC-tarball/versions/v1.1.14.0/statusbar_pi-1.1.14.0-msvc-x86-wx32-10.0.20348-MSVC.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/statusbar.html </info-url>
+</plugin>

--- a/metadata/statusbar_pi-1.1.14.0-ubuntu-x86_64-22.04-jammy.xml
+++ b/metadata/statusbar_pi-1.1.14.0-ubuntu-x86_64-22.04-jammy.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> StatusBar </name>
+<version> 1.1.14.0 </version>
+<release> 0 </release>
+<summary> StatusBar Plugin is an optional replacement for the builtin statusbar </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Sean D'Epagnier </author>
+<source> https://github.com/rgleason/statusbar_pi </source>
+
+<description>
+The builtin status bar (disable from the User Interface tab) has limited configuration options and can be very difficult to read. The statusbar plugin improves on some of these difficulties. Best used with OpenGL enabled (requires some basic OpenGL extensions).
+</description>
+
+<target>ubuntu-wx32-x86_64</target>
+<build-target>ubuntu</build-target>
+<build-gtk>gtk3</build-gtk>
+<target-version>22.04</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/statusbar-prod/raw/names/statusbar_pi-1.1.14.0-ubuntu-x86_64-wx32-22.04-jammy-tarball/versions/v1.1.14.0/statusbar_pi-1.1.14.0-ubuntu-x86_64-22.04-jammy.tar.gz
+</tarball-url>
+<info-url> https://opencpn.org/OpenCPN/plugins/statusbar.html </info-url>
+</plugin>


### PR DESCRIPTION
So far,
https://github.com/jongough/testplugin_pi/issues/177

Many of these have 20 metadata files from Dec 2024, these files support back to 5.6.4 I believe.
2025 has 16 metadata = 8 minute build time. I believe they support back to 5.8 (correct me if I am wrong here.)

Do you want me to delete all the 2024 metadata files for the plugins I am trying to maintain?