### PR TITLE
gpsodometer 0.8.11 + rm 0.8.10

### DIFF
--- a/metadata/gpsodometer_pi-0.8.11.0-android-arm64-16-android-arm64.xml
+++ b/metadata/gpsodometer_pi-0.8.11.0-android-arm64-16-android-arm64.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> GPS Odometer </name>
-<version> 0.8.10.0 </version>
+<version> 0.8.11.0 </version>
 <release> 0 </release>
 <summary> GPS/GNSS based for release 5.8 and above </summary>
 
@@ -14,13 +14,13 @@
 Using GPS/GNSS satellite data to calculate log and trip information as well as deparure and arrival times
 </description>
 
-<target>debian-armhf</target>
-<build-target>debian</build-target>
+<target>android-arm64</target>
+<build-target>android</build-target>
 <build-gtk></build-gtk>
-<target-version>11</target-version>
-<target-arch>armhf</target-arch>
+<target-version>16</target-version>
+<target-arch>arm64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.10.0-debian-armhf-11-bullseye-armhf-tarball/versions/v0.8.10.0/gpsodometer_pi-0.8.10.0-debian-armhf-11-bullseye-armhf.tar.gz
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.11.0-android-arm64-16-android-arm64-tarball/versions/v0.8.11.0/gpsodometer_pi-0.8.11.0-android-arm64-16-android-arm64.tar.gz
 </tarball-url>
 <info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
 </plugin>

--- a/metadata/gpsodometer_pi-0.8.11.0-android-armhf-16-android-armhf.xml
+++ b/metadata/gpsodometer_pi-0.8.11.0-android-armhf-16-android-armhf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> GPS Odometer </name>
-<version> 0.8.10.0 </version>
+<version> 0.8.11.0 </version>
 <release> 0 </release>
 <summary> GPS/GNSS based for release 5.8 and above </summary>
 
@@ -14,13 +14,13 @@
 Using GPS/GNSS satellite data to calculate log and trip information as well as deparure and arrival times
 </description>
 
-<target>debian-arm64</target>
-<build-target>debian</build-target>
+<target>android-armhf</target>
+<build-target>android</build-target>
 <build-gtk></build-gtk>
-<target-version>12</target-version>
-<target-arch>arm64</target-arch>
+<target-version>16</target-version>
+<target-arch>armhf</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.10.0-debian-arm64-12-bookworm-arm64-tarball/versions/v0.8.10.0/gpsodometer_pi-0.8.10.0-debian-arm64-12-bookworm-arm64.tar.gz
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.11.0-android-armhf-16-android-armhf-tarball/versions/v0.8.11.0/gpsodometer_pi-0.8.11.0-android-armhf-16-android-armhf.tar.gz
 </tarball-url>
 <info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
 </plugin>

--- a/metadata/gpsodometer_pi-0.8.11.0-darwin-wx32-arm64-x86_64-14.1-macos.xml
+++ b/metadata/gpsodometer_pi-0.8.11.0-darwin-wx32-arm64-x86_64-14.1-macos.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> GPS Odometer </name>
-<version> 0.8.10.0 </version>
+<version> 0.8.11.0 </version>
 <release> 0 </release>
 <summary> GPS/GNSS based for release 5.8 and above </summary>
 
@@ -14,13 +14,13 @@
 Using GPS/GNSS satellite data to calculate log and trip information as well as deparure and arrival times
 </description>
 
-<target>msvc</target>
-<build-target>msvc</build-target>
+<target>darwin-wx32</target>
+<build-target>darwin</build-target>
 <build-gtk></build-gtk>
-<target-version>10.0.20348</target-version>
-<target-arch>x86</target-arch>
+<target-version>14.1</target-version>
+<target-arch>arm64;x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.10.0-msvc-x86-10.0.20348-MSVC-tarball/versions/v0.8.10.0/gpsodometer_pi-0.8.10.0-msvc-x86-10.0.20348-MSVC.tar.gz
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.11.0-darwin-wx32-arm64-x86_64-14.1-macos-tarball/versions/v0.8.11.0/gpsodometer_pi-0.8.11.0-darwin-wx32-arm64-x86_64-14.1-macos.tar.gz
 </tarball-url>
 <info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
 </plugin>

--- a/metadata/gpsodometer_pi-0.8.11.0-debian-arm64-11-bullseye-arm64.xml
+++ b/metadata/gpsodometer_pi-0.8.11.0-debian-arm64-11-bullseye-arm64.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> GPS Odometer </name>
-<version> 0.8.10.0 </version>
+<version> 0.8.11.0 </version>
 <release> 0 </release>
 <summary> GPS/GNSS based for release 5.8 and above </summary>
 
@@ -14,13 +14,13 @@
 Using GPS/GNSS satellite data to calculate log and trip information as well as deparure and arrival times
 </description>
 
-<target>debian-x86_64</target>
+<target>debian-arm64</target>
 <build-target>debian</build-target>
-<build-gtk>gtk3</build-gtk>
+<build-gtk></build-gtk>
 <target-version>11</target-version>
-<target-arch>x86_64</target-arch>
+<target-arch>arm64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.10.0-debian-x86_64-11-bullseye-tarball/versions/v0.8.10.0/gpsodometer_pi-0.8.10.0-debian-x86_64-11-bullseye.tar.gz
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.11.0-debian-arm64-11-bullseye-arm64-tarball/versions/v0.8.11.0/gpsodometer_pi-0.8.11.0-debian-arm64-11-bullseye-arm64.tar.gz
 </tarball-url>
 <info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
 </plugin>

--- a/metadata/gpsodometer_pi-0.8.11.0-debian-arm64-12-bookworm-arm64.xml
+++ b/metadata/gpsodometer_pi-0.8.11.0-debian-arm64-12-bookworm-arm64.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> GPS Odometer </name>
-<version> 0.8.10.0 </version>
+<version> 0.8.11.0 </version>
 <release> 0 </release>
 <summary> GPS/GNSS based for release 5.8 and above </summary>
 
@@ -14,13 +14,13 @@
 Using GPS/GNSS satellite data to calculate log and trip information as well as deparure and arrival times
 </description>
 
-<target>debian-x86_64</target>
+<target>debian-arm64</target>
 <build-target>debian</build-target>
 <build-gtk></build-gtk>
 <target-version>12</target-version>
-<target-arch>x86_64</target-arch>
+<target-arch>arm64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.10.0-debian-x86_64-12-bookworm-tarball/versions/v0.8.10.0/gpsodometer_pi-0.8.10.0-debian-x86_64-12-bookworm.tar.gz
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.11.0-debian-arm64-12-bookworm-arm64-tarball/versions/v0.8.11.0/gpsodometer_pi-0.8.11.0-debian-arm64-12-bookworm-arm64.tar.gz
 </tarball-url>
 <info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
 </plugin>

--- a/metadata/gpsodometer_pi-0.8.11.0-debian-armhf-11-bullseye-armhf.xml
+++ b/metadata/gpsodometer_pi-0.8.11.0-debian-armhf-11-bullseye-armhf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> GPS Odometer </name>
-<version> 0.8.10.0 </version>
+<version> 0.8.11.0 </version>
 <release> 0 </release>
 <summary> GPS/GNSS based for release 5.8 and above </summary>
 
@@ -14,13 +14,13 @@
 Using GPS/GNSS satellite data to calculate log and trip information as well as deparure and arrival times
 </description>
 
-<target>ubuntu-wx32-x86_64</target>
-<build-target>ubuntu</build-target>
-<build-gtk>gtk3</build-gtk>
-<target-version>22.04</target-version>
-<target-arch>x86_64</target-arch>
+<target>debian-armhf</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>11</target-version>
+<target-arch>armhf</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.10.0-ubuntu-x86_64-wx32-22.04-jammy-tarball/versions/v0.8.10.0/gpsodometer_pi-0.8.10.0-ubuntu-x86_64-22.04-jammy.tar.gz
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.11.0-debian-armhf-11-bullseye-armhf-tarball/versions/v0.8.11.0/gpsodometer_pi-0.8.11.0-debian-armhf-11-bullseye-armhf.tar.gz
 </tarball-url>
 <info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
 </plugin>

--- a/metadata/gpsodometer_pi-0.8.11.0-debian-armhf-12-bookworm-armhf.xml
+++ b/metadata/gpsodometer_pi-0.8.11.0-debian-armhf-12-bookworm-armhf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> GPS Odometer </name>
-<version> 0.8.10.0 </version>
+<version> 0.8.11.0 </version>
 <release> 0 </release>
 <summary> GPS/GNSS based for release 5.8 and above </summary>
 
@@ -14,13 +14,13 @@
 Using GPS/GNSS satellite data to calculate log and trip information as well as deparure and arrival times
 </description>
 
-<target>android-armhf</target>
-<build-target>android</build-target>
+<target>debian-armhf</target>
+<build-target>debian</build-target>
 <build-gtk></build-gtk>
-<target-version>16</target-version>
+<target-version>12</target-version>
 <target-arch>armhf</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.10.0-android-armhf-16-android-armhf-tarball/versions/v0.8.10.0/gpsodometer_pi-0.8.10.0-android-armhf-16-android-armhf.tar.gz
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.11.0-debian-armhf-12-bookworm-armhf-tarball/versions/v0.8.11.0/gpsodometer_pi-0.8.11.0-debian-armhf-12-bookworm-armhf.tar.gz
 </tarball-url>
 <info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
 </plugin>

--- a/metadata/gpsodometer_pi-0.8.11.0-debian-x86_64-11-bullseye.xml
+++ b/metadata/gpsodometer_pi-0.8.11.0-debian-x86_64-11-bullseye.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> GPS Odometer </name>
-<version> 0.8.10.0 </version>
+<version> 0.8.11.0 </version>
 <release> 0 </release>
 <summary> GPS/GNSS based for release 5.8 and above </summary>
 
@@ -14,13 +14,13 @@
 Using GPS/GNSS satellite data to calculate log and trip information as well as deparure and arrival times
 </description>
 
-<target>debian-arm64</target>
+<target>debian-x86_64</target>
 <build-target>debian</build-target>
-<build-gtk></build-gtk>
+<build-gtk>gtk3</build-gtk>
 <target-version>11</target-version>
-<target-arch>arm64</target-arch>
+<target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.10.0-debian-arm64-11-bullseye-arm64-tarball/versions/v0.8.10.0/gpsodometer_pi-0.8.10.0-debian-arm64-11-bullseye-arm64.tar.gz
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.11.0-debian-x86_64-11-bullseye-tarball/versions/v0.8.11.0/gpsodometer_pi-0.8.11.0-debian-x86_64-11-bullseye.tar.gz
 </tarball-url>
 <info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
 </plugin>

--- a/metadata/gpsodometer_pi-0.8.11.0-debian-x86_64-12-bookworm.xml
+++ b/metadata/gpsodometer_pi-0.8.11.0-debian-x86_64-12-bookworm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> GPS Odometer </name>
-<version> 0.8.10.0 </version>
+<version> 0.8.11.0 </version>
 <release> 0 </release>
 <summary> GPS/GNSS based for release 5.8 and above </summary>
 
@@ -14,13 +14,13 @@
 Using GPS/GNSS satellite data to calculate log and trip information as well as deparure and arrival times
 </description>
 
-<target>debian-armhf</target>
+<target>debian-x86_64</target>
 <build-target>debian</build-target>
 <build-gtk></build-gtk>
 <target-version>12</target-version>
-<target-arch>armhf</target-arch>
+<target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.10.0-debian-armhf-12-bookworm-armhf-tarball/versions/v0.8.10.0/gpsodometer_pi-0.8.10.0-debian-armhf-12-bookworm-armhf.tar.gz
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.11.0-debian-x86_64-12-bookworm-tarball/versions/v0.8.11.0/gpsodometer_pi-0.8.11.0-debian-x86_64-12-bookworm.tar.gz
 </tarball-url>
 <info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
 </plugin>

--- a/metadata/gpsodometer_pi-0.8.11.0-flatpak-aarch64-22.08-flatpak.xml
+++ b/metadata/gpsodometer_pi-0.8.11.0-flatpak-aarch64-22.08-flatpak.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> GPS Odometer </name>
-<version> 0.8.10.0 </version>
+<version> 0.8.11.0 </version>
 <release> 0 </release>
 <summary> GPS/GNSS based for release 5.8 and above </summary>
 
@@ -14,13 +14,13 @@
 Using GPS/GNSS satellite data to calculate log and trip information as well as deparure and arrival times
 </description>
 
-<target>darwin-wx32</target>
-<build-target>darwin</build-target>
+<target>flatpak-aarch64</target>
+<build-target>flatpak</build-target>
 <build-gtk></build-gtk>
-<target-version>14.1</target-version>
-<target-arch>arm64;x86_64</target-arch>
+<target-version>22.08</target-version>
+<target-arch>aarch64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.10.0-darwin-wx32-arm64-x86_64-14.1-macos-tarball/versions/v0.8.10.0/gpsodometer_pi-0.8.10.0-darwin-wx32-arm64-x86_64-14.1-macos.tar.gz
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.11.0-flatpak-aarch64-22.08-flatpak-tarball/versions/v0.8.11.0/gpsodometer_pi-0.8.11.0-aarch64_flatpak-22.08.tar.gz
 </tarball-url>
 <info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
 </plugin>

--- a/metadata/gpsodometer_pi-0.8.11.0-flatpak-aarch64-24.08-flatpak.xml
+++ b/metadata/gpsodometer_pi-0.8.11.0-flatpak-aarch64-24.08-flatpak.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.8.11.0 </version>
+<release> 0 </release>
+<summary> GPS/GNSS based for release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/rgleason/GPS-Odometer_pi </source>
+
+<description>
+Using GPS/GNSS satellite data to calculate log and trip information as well as deparure and arrival times
+</description>
+
+<target>flatpak-aarch64</target>
+<build-target>flatpak</build-target>
+<build-gtk></build-gtk>
+<target-version>24.08</target-version>
+<target-arch>aarch64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.11.0-flatpak-aarch64-24.08-flatpak-tarball/versions/v0.8.11.0/gpsodometer_pi-0.8.11.0-aarch64_flatpak-24.08.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.8.11.0-flatpak-x86_64-22.08-flatpak.xml
+++ b/metadata/gpsodometer_pi-0.8.11.0-flatpak-x86_64-22.08-flatpak.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> GPS Odometer </name>
-<version> 0.8.10.0 </version>
+<version> 0.8.11.0 </version>
 <release> 0 </release>
 <summary> GPS/GNSS based for release 5.8 and above </summary>
 
@@ -14,13 +14,13 @@
 Using GPS/GNSS satellite data to calculate log and trip information as well as deparure and arrival times
 </description>
 
-<target>msvc-wx32</target>
-<build-target>msvc</build-target>
+<target>flatpak-x86_64</target>
+<build-target>flatpak</build-target>
 <build-gtk></build-gtk>
-<target-version>10.0.20348</target-version>
-<target-arch>x86</target-arch>
+<target-version>22.08</target-version>
+<target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.10.0-msvc-x86-wx32-10.0.20348-MSVC-tarball/versions/v0.8.10.0/gpsodometer_pi-0.8.10.0-msvc-x86-wx32-10.0.20348-MSVC.tar.gz
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.11.0-flatpak-x86_64-22.08-flatpak-tarball/versions/v0.8.11.0/gpsodometer_pi-0.8.11.0-x86_64_flatpak-22.08.tar.gz
 </tarball-url>
 <info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
 </plugin>

--- a/metadata/gpsodometer_pi-0.8.11.0-flatpak-x86_64-24.08-flatpak.xml
+++ b/metadata/gpsodometer_pi-0.8.11.0-flatpak-x86_64-24.08-flatpak.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> GPS Odometer </name>
-<version> 0.8.10.0 </version>
+<version> 0.8.11.0 </version>
 <release> 0 </release>
 <summary> GPS/GNSS based for release 5.8 and above </summary>
 
@@ -14,13 +14,13 @@
 Using GPS/GNSS satellite data to calculate log and trip information as well as deparure and arrival times
 </description>
 
-<target>flatpak-aarch64</target>
+<target>flatpak-x86_64</target>
 <build-target>flatpak</build-target>
 <build-gtk></build-gtk>
 <target-version>24.08</target-version>
-<target-arch>aarch64</target-arch>
+<target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.10.0-flatpak-aarch64-24.08-flatpak-tarball/versions/v0.8.10.0/gpsodometer_pi-0.8.10.0-aarch64_flatpak-24.08.tar.gz
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.11.0-flatpak-x86_64-24.08-flatpak-tarball/versions/v0.8.11.0/gpsodometer_pi-0.8.11.0-x86_64_flatpak-24.08.tar.gz
 </tarball-url>
 <info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
 </plugin>

--- a/metadata/gpsodometer_pi-0.8.11.0-msvc-x86-10.0.20348-MSVC.xml
+++ b/metadata/gpsodometer_pi-0.8.11.0-msvc-x86-10.0.20348-MSVC.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> GPS Odometer </name>
-<version> 0.8.10.0 </version>
+<version> 0.8.11.0 </version>
 <release> 0 </release>
 <summary> GPS/GNSS based for release 5.8 and above </summary>
 
@@ -14,13 +14,13 @@
 Using GPS/GNSS satellite data to calculate log and trip information as well as deparure and arrival times
 </description>
 
-<target>flatpak-aarch64</target>
-<build-target>flatpak</build-target>
+<target>msvc</target>
+<build-target>msvc</build-target>
 <build-gtk></build-gtk>
-<target-version>22.08</target-version>
-<target-arch>aarch64</target-arch>
+<target-version>10.0.20348</target-version>
+<target-arch>x86</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.10.0-flatpak-aarch64-22.08-flatpak-tarball/versions/v0.8.10.0/gpsodometer_pi-0.8.10.0-aarch64_flatpak-22.08.tar.gz
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.11.0-msvc-x86-10.0.20348-MSVC-tarball/versions/v0.8.11.0/gpsodometer_pi-0.8.11.0-msvc-x86-10.0.20348-MSVC.tar.gz
 </tarball-url>
 <info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
 </plugin>

--- a/metadata/gpsodometer_pi-0.8.11.0-msvc-x86-wx32-10.0.20348-MSVC.xml
+++ b/metadata/gpsodometer_pi-0.8.11.0-msvc-x86-wx32-10.0.20348-MSVC.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> GPS Odometer </name>
+<version> 0.8.11.0 </version>
+<release> 0 </release>
+<summary> GPS/GNSS based for release 5.8 and above </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> LennartG </author>
+<source> https://github.com/rgleason/GPS-Odometer_pi </source>
+
+<description>
+Using GPS/GNSS satellite data to calculate log and trip information as well as deparure and arrival times
+</description>
+
+<target>msvc-wx32</target>
+<build-target>msvc</build-target>
+<build-gtk></build-gtk>
+<target-version>10.0.20348</target-version>
+<target-arch>x86</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.11.0-msvc-x86-wx32-10.0.20348-MSVC-tarball/versions/v0.8.11.0/gpsodometer_pi-0.8.11.0-msvc-x86-wx32-10.0.20348-MSVC.tar.gz
+</tarball-url>
+<info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
+</plugin>

--- a/metadata/gpsodometer_pi-0.8.11.0-ubuntu-x86_64-22.04-jammy.xml
+++ b/metadata/gpsodometer_pi-0.8.11.0-ubuntu-x86_64-22.04-jammy.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> GPS Odometer </name>
-<version> 0.8.10.0 </version>
+<version> 0.8.11.0 </version>
 <release> 0 </release>
 <summary> GPS/GNSS based for release 5.8 and above </summary>
 
@@ -14,13 +14,13 @@
 Using GPS/GNSS satellite data to calculate log and trip information as well as deparure and arrival times
 </description>
 
-<target>flatpak-x86_64</target>
-<build-target>flatpak</build-target>
-<build-gtk></build-gtk>
-<target-version>24.08</target-version>
+<target>ubuntu-wx32-x86_64</target>
+<build-target>ubuntu</build-target>
+<build-gtk>gtk3</build-gtk>
+<target-version>22.04</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.10.0-flatpak-x86_64-24.08-flatpak-tarball/versions/v0.8.10.0/gpsodometer_pi-0.8.10.0-x86_64_flatpak-24.08.tar.gz
+https://dl.cloudsmith.io/public/opencpn/gps-odometer-prod/raw/names/gpsodometer_pi-0.8.11.0-ubuntu-x86_64-wx32-22.04-jammy-tarball/versions/v0.8.11.0/gpsodometer_pi-0.8.11.0-ubuntu-x86_64-22.04-jammy.tar.gz
 </tarball-url>
 <info-url> https://opencpn-manuals.github.io/main/gps-odometer/index.html </info-url>
 </plugin>


### PR DESCRIPTION
Dave,
0.8.11   has 16 metadata files  - I hope they all work now.
0.8.10  had 14 metadata files - they are being removed.
I believe the problem for the  GPSodometer  3 PRs  was Cloudsmith was unable to accept the tarball for some glitch y reason and thus called it a "duplicate" and flagged it with a little red ball at the top left. There was a message to delete the second copy, which I did. However there then was no first copy either!  So the answer is to increment the version, build it and push again to catalog.

Hope this works.