### PR TITLE
vdr 1.3.65 and remove previous 

### DIFF
--- a/metadata/VDR-v1.3.65.0-android-arm64-A64-16.xml
+++ b/metadata/VDR-v1.3.65.0-android-arm64-A64-16.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--  -->
+<!-- https://circleci.com/gh/rgleason/vdr_pi/6552 -->
 <plugin version="1">
   <name> VDR </name>
-  <version> v1.3.63.0 </version>
+  <version> v1.3.65.0 </version>
   <release> 0 </release>
   <summary> Voyage Data Recorder </summary>
 
@@ -16,9 +16,9 @@
 Save NMEA stream to a file.  Replay NMEA stream previously saved. Used to test plugins.
  </description>
 
-  <target>debian-wx32-arm64</target>
-  <target-version>11</target-version>
+  <target>android-arm64</target>
+  <target-version>16</target-version>
   <target-arch>arm64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.63.0-debian-wx32-arm64-A64-11-tarball/versions/v1.3.63.0/VDR-v1.3.63.0_debian-wx32-arm64-11-arm64.tar.gz </tarball-url>
-  <tarball-checksum> 1e7825764189cdba4d772380175e0411abf3f7241eb600d2e24ea75b915d8e6d </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.65.0-android-arm64-A64-16-tarball/versions/v1.3.65.0/VDR-v1.3.65.0_android-arm64-16-arm64.tar.gz </tarball-url>
+  <tarball-checksum> 17d48ff41e5b691f53f38898838f84cfd48c5c313bedf077fbf1a53fe5d7e494 </tarball-checksum>
 </plugin>

--- a/metadata/VDR-v1.3.65.0-android-armhf-A32-16.xml
+++ b/metadata/VDR-v1.3.65.0-android-armhf-A32-16.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/rgleason/vdr_pi/6497 -->
+<!-- https://circleci.com/gh/rgleason/vdr_pi/6554 -->
 <plugin version="1">
   <name> VDR </name>
-  <version> v1.3.63.0 </version>
+  <version> v1.3.65.0 </version>
   <release> 0 </release>
   <summary> Voyage Data Recorder </summary>
 
@@ -16,9 +16,9 @@
 Save NMEA stream to a file.  Replay NMEA stream previously saved. Used to test plugins.
  </description>
 
-  <target>android-arm64</target>
+  <target>android-armhf</target>
   <target-version>16</target-version>
-  <target-arch>arm64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.63.0-android-arm64-A64-16-tarball/versions/v1.3.63.0/VDR-v1.3.63.0_android-arm64-16-arm64.tar.gz </tarball-url>
-  <tarball-checksum> 9124f5514e85c5eb21cca131220a934f0f3c7b49d14d257042049d16a4494345 </tarball-checksum>
+  <target-arch>armhf</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.65.0-android-armhf-A32-16-tarball/versions/v1.3.65.0/VDR-v1.3.65.0_android-armhf-16-armhf.tar.gz </tarball-url>
+  <tarball-checksum> 8dcb7ea3fb5fe9363202386db347cefa4bf53bee4c615b46c32fdcabb652a2ee </tarball-checksum>
 </plugin>

--- a/metadata/VDR-v1.3.65.0-darwin-wx32-universal-10.xml
+++ b/metadata/VDR-v1.3.65.0-darwin-wx32-universal-10.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--  -->
+<!-- https://circleci.com/gh/rgleason/vdr_pi/6543 -->
 <plugin version="1">
   <name> VDR </name>
-  <version> v1.3.63.0 </version>
+  <version> v1.3.65.0 </version>
   <release> 0 </release>
   <summary> Voyage Data Recorder </summary>
 
@@ -16,9 +16,9 @@
 Save NMEA stream to a file.  Replay NMEA stream previously saved. Used to test plugins.
  </description>
 
-  <target>debian-arm64</target>
-  <target-version>12</target-version>
-  <target-arch>arm64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.63.0-debian-arm64-A64-12-tarball/versions/v1.3.63.0/VDR-v1.3.63.0_debian-arm64-12-arm64.tar.gz </tarball-url>
-  <tarball-checksum> f86bf118a4f04249f42e8d02b4b890083814c79d969dc645239c2b1f2e1a1aa5 </tarball-checksum>
+  <target>darwin-wx32</target>
+  <target-version>10</target-version>
+  <target-arch>arm64;x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.65.0-darwin-wx32-universal-10-tarball/versions/v1.3.65.0/VDR-v1.3.65.0_darwin-wx32-10-arm64-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 7476cb013f6b26ebf27ea320d2d25e1cb18d1104ae52f6f9e56c1dc3675ca2ed </tarball-checksum>
 </plugin>

--- a/metadata/VDR-v1.3.65.0-debian-arm64-A64-11.xml
+++ b/metadata/VDR-v1.3.65.0-debian-arm64-A64-11.xml
@@ -2,7 +2,7 @@
 <!--  -->
 <plugin version="1">
   <name> VDR </name>
-  <version> v1.3.63.0 </version>
+  <version> v1.3.65.0 </version>
   <release> 0 </release>
   <summary> Voyage Data Recorder </summary>
 
@@ -16,9 +16,9 @@
 Save NMEA stream to a file.  Replay NMEA stream previously saved. Used to test plugins.
  </description>
 
-  <target>debian-armhf</target>
-  <target-version>12</target-version>
-  <target-arch>armhf</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.63.0-debian-armhf-A32-12-tarball/versions/v1.3.63.0/VDR-v1.3.63.0_debian-armhf-12-armhf.tar.gz </tarball-url>
-  <tarball-checksum> 3037b4654c0a0423ea04e829dd06db42da84de06d9bdbb2d493e899678aa8911 </tarball-checksum>
+  <target>debian-arm64</target>
+  <target-version>11</target-version>
+  <target-arch>arm64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.65.0-debian-arm64-A64-11-tarball/versions/v1.3.65.0/VDR-v1.3.65.0_debian-arm64-11-arm64.tar.gz </tarball-url>
+  <tarball-checksum> b43e4d9b04c67f97f3f6e57c6c6329ec73b76ccaaaebe402ef55a9fa9e19be75 </tarball-checksum>
 </plugin>

--- a/metadata/VDR-v1.3.65.0-debian-arm64-A64-12.xml
+++ b/metadata/VDR-v1.3.65.0-debian-arm64-A64-12.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/rgleason/vdr_pi/6503 -->
+<!--  -->
 <plugin version="1">
   <name> VDR </name>
-  <version> v1.3.63.0 </version>
+  <version> v1.3.65.0 </version>
   <release> 0 </release>
   <summary> Voyage Data Recorder </summary>
 
@@ -16,9 +16,9 @@
 Save NMEA stream to a file.  Replay NMEA stream previously saved. Used to test plugins.
  </description>
 
-  <target>android-armhf</target>
-  <target-version>16</target-version>
-  <target-arch>armhf</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.63.0-android-armhf-A32-16-tarball/versions/v1.3.63.0/VDR-v1.3.63.0_android-armhf-16-armhf.tar.gz </tarball-url>
-  <tarball-checksum> 9057a7ce2286c3623af52a4d58cf61aba4a0c0120943913d8cf86c8c83311c66 </tarball-checksum>
+  <target>debian-arm64</target>
+  <target-version>12</target-version>
+  <target-arch>arm64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.65.0-debian-arm64-A64-12-tarball/versions/v1.3.65.0/VDR-v1.3.65.0_debian-arm64-12-arm64.tar.gz </tarball-url>
+  <tarball-checksum> 4aad4000af368208ed2afe88737a2343ca70cd3f6ea01b7565d8b3131ac7ee5a </tarball-checksum>
 </plugin>

--- a/metadata/VDR-v1.3.65.0-debian-armhf-A32-11.xml
+++ b/metadata/VDR-v1.3.65.0-debian-armhf-A32-11.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/rgleason/vdr_pi/6504 -->
+<!--  -->
 <plugin version="1">
   <name> VDR </name>
-  <version> v1.3.63.0 </version>
+  <version> v1.3.65.0 </version>
   <release> 0 </release>
   <summary> Voyage Data Recorder </summary>
 
@@ -16,9 +16,9 @@
 Save NMEA stream to a file.  Replay NMEA stream previously saved. Used to test plugins.
  </description>
 
-  <target>debian-x86_64</target>
+  <target>debian-armhf</target>
   <target-version>11</target-version>
-  <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.63.0-debian-x86_64-11-tarball/versions/v1.3.63.0/VDR-v1.3.63.0_debian-x86_64-11-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 0b6909c20469052f878a7be7e8a64d7cad50253b311d69476c497afcc0d8980c </tarball-checksum>
+  <target-arch>armhf</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.65.0-debian-armhf-A32-11-tarball/versions/v1.3.65.0/VDR-v1.3.65.0_debian-armhf-11-armhf.tar.gz </tarball-url>
+  <tarball-checksum> 0f79ffeee46dda86c868aacee4b5cc4f7c28c5c627215fee1296acdc70600f4a </tarball-checksum>
 </plugin>

--- a/metadata/VDR-v1.3.65.0-debian-armhf-A32-12.xml
+++ b/metadata/VDR-v1.3.65.0-debian-armhf-A32-12.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/rgleason/vdr_pi/6502 -->
+<!--  -->
 <plugin version="1">
   <name> VDR </name>
-  <version> v1.3.63.0 </version>
+  <version> v1.3.65.0 </version>
   <release> 0 </release>
   <summary> Voyage Data Recorder </summary>
 
@@ -16,9 +16,9 @@
 Save NMEA stream to a file.  Replay NMEA stream previously saved. Used to test plugins.
  </description>
 
-  <target>debian-wx32-x86_64</target>
-  <target-version>11</target-version>
-  <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.63.0-debian-wx32-x86_64-11-tarball/versions/v1.3.63.0/VDR-v1.3.63.0_debian-wx32-x86_64-11-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 73433d3ae94daf80a925fa99f9081ae1bdc6fdbd5f03f8d9d89914ba80d776d1 </tarball-checksum>
+  <target>debian-armhf</target>
+  <target-version>12</target-version>
+  <target-arch>armhf</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.65.0-debian-armhf-A32-12-tarball/versions/v1.3.65.0/VDR-v1.3.65.0_debian-armhf-12-armhf.tar.gz </tarball-url>
+  <tarball-checksum> f835970144cddb1f9eee4a3778a44e4eda1deaa9cc6ee5f5ac88bd8ac3d8c072 </tarball-checksum>
 </plugin>

--- a/metadata/VDR-v1.3.65.0-debian-wx32-arm64-A64-11.xml
+++ b/metadata/VDR-v1.3.65.0-debian-wx32-arm64-A64-11.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/rgleason/vdr_pi/6494 -->
+<!--  -->
 <plugin version="1">
   <name> VDR </name>
-  <version> v1.3.63.0 </version>
+  <version> v1.3.65.0 </version>
   <release> 0 </release>
   <summary> Voyage Data Recorder </summary>
 
@@ -16,9 +16,9 @@
 Save NMEA stream to a file.  Replay NMEA stream previously saved. Used to test plugins.
  </description>
 
-  <target>flatpak-aarch64</target>
-  <target-version>24.08</target-version>
-  <target-arch>aarch64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.63.0-flatpak-aarch64-A64-24.08-tarball/versions/v1.3.63.0/VDR-v1.3.63.0_flatpak-aarch64-24.08-aarch64.tar.gz </tarball-url>
-  <tarball-checksum> 8eefb1668670f18abd27ec9b17a41f13477cbe79a0da6579c5a1a03190d69738 </tarball-checksum>
+  <target>debian-wx32-arm64</target>
+  <target-version>11</target-version>
+  <target-arch>arm64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.65.0-debian-wx32-arm64-A64-11-tarball/versions/v1.3.65.0/VDR-v1.3.65.0_debian-wx32-arm64-11-arm64.tar.gz </tarball-url>
+  <tarball-checksum> 417facd2a1ebaac0259a6f8ee93bcc57c87f4d7b502b27fe6a462433d4517527 </tarball-checksum>
 </plugin>

--- a/metadata/VDR-v1.3.65.0-debian-wx32-armhf-A32-11.xml
+++ b/metadata/VDR-v1.3.65.0-debian-wx32-armhf-A32-11.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/rgleason/vdr_pi/6505 -->
+<!--  -->
 <plugin version="1">
   <name> VDR </name>
-  <version> v1.3.63.0 </version>
+  <version> v1.3.65.0 </version>
   <release> 0 </release>
   <summary> Voyage Data Recorder </summary>
 
@@ -16,9 +16,9 @@
 Save NMEA stream to a file.  Replay NMEA stream previously saved. Used to test plugins.
  </description>
 
-  <target>flatpak-aarch64</target>
-  <target-version>22.08</target-version>
-  <target-arch>aarch64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.63.0-flatpak-aarch64-A64-22.08-tarball/versions/v1.3.63.0/VDR-v1.3.63.0_flatpak-aarch64-22.08-aarch64.tar.gz </tarball-url>
-  <tarball-checksum> 3e59f4fdffb2904a847a6d2d966b1126e7f03637dcec99c0bd54b272c1f6b509 </tarball-checksum>
+  <target>debian-wx32-armhf</target>
+  <target-version>11</target-version>
+  <target-arch>armhf</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.65.0-debian-wx32-armhf-A32-11-tarball/versions/v1.3.65.0/VDR-v1.3.65.0_debian-wx32-armhf-11-armhf.tar.gz </tarball-url>
+  <tarball-checksum> a914ac9d4df445782ecd6340f48ef8ac809f3cc3a3f641adbb3ed321a7ab2f4c </tarball-checksum>
 </plugin>

--- a/metadata/VDR-v1.3.65.0-debian-wx32-x86_64-11.xml
+++ b/metadata/VDR-v1.3.65.0-debian-wx32-x86_64-11.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/rgleason/vdr_pi/6492 -->
+<!-- https://circleci.com/gh/rgleason/vdr_pi/6542 -->
 <plugin version="1">
   <name> VDR </name>
-  <version> v1.3.63.0 </version>
+  <version> v1.3.65.0 </version>
   <release> 0 </release>
   <summary> Voyage Data Recorder </summary>
 
@@ -16,9 +16,9 @@
 Save NMEA stream to a file.  Replay NMEA stream previously saved. Used to test plugins.
  </description>
 
-  <target>flatpak-x86_64</target>
-  <target-version>22.08</target-version>
+  <target>debian-wx32-x86_64</target>
+  <target-version>11</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.63.0-flatpak-x86_64-22.08-tarball/versions/v1.3.63.0/VDR-v1.3.63.0_flatpak-x86_64-22.08-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 7abb321544d9af6ae17f1fec79a9a1a2f9bfc3e980ea46c28bf4880338902b7e </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.65.0-debian-wx32-x86_64-11-tarball/versions/v1.3.65.0/VDR-v1.3.65.0_debian-wx32-x86_64-11-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 485329d3520b6c6e3d0eae4febc992c57553cd968d838e39066890ea69047781 </tarball-checksum>
 </plugin>

--- a/metadata/VDR-v1.3.65.0-debian-x86_64-11.xml
+++ b/metadata/VDR-v1.3.65.0-debian-x86_64-11.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/rgleason/vdr_pi/6501 -->
+<!-- https://circleci.com/gh/rgleason/vdr_pi/6551 -->
 <plugin version="1">
   <name> VDR </name>
-  <version> v1.3.63.0 </version>
+  <version> v1.3.65.0 </version>
   <release> 0 </release>
   <summary> Voyage Data Recorder </summary>
 
@@ -16,9 +16,9 @@
 Save NMEA stream to a file.  Replay NMEA stream previously saved. Used to test plugins.
  </description>
 
-  <target>flatpak-x86_64</target>
-  <target-version>24.08</target-version>
+  <target>debian-x86_64</target>
+  <target-version>11</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.63.0-flatpak-x86_64-24.08-tarball/versions/v1.3.63.0/VDR-v1.3.63.0_flatpak-x86_64-24.08-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 6e4d67d97e764fbeeef195d3ecba0cba9c301b24289b58710684bc5ed6d387f2 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.65.0-debian-x86_64-11-tarball/versions/v1.3.65.0/VDR-v1.3.65.0_debian-x86_64-11-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 7a9f5af1648ac39f41b2eef0b5b7758bc78ecf8fcaabb41fe6ca4ee6ed4bd1a2 </tarball-checksum>
 </plugin>

--- a/metadata/VDR-v1.3.65.0-debian-x86_64-12.xml
+++ b/metadata/VDR-v1.3.65.0-debian-x86_64-12.xml
@@ -2,7 +2,7 @@
 <!--  -->
 <plugin version="1">
   <name> VDR </name>
-  <version> v1.3.63.0 </version>
+  <version> v1.3.65.0 </version>
   <release> 0 </release>
   <summary> Voyage Data Recorder </summary>
 
@@ -16,9 +16,9 @@
 Save NMEA stream to a file.  Replay NMEA stream previously saved. Used to test plugins.
  </description>
 
-  <target>debian-armhf</target>
-  <target-version>11</target-version>
-  <target-arch>armhf</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.63.0-debian-armhf-A32-11-tarball/versions/v1.3.63.0/VDR-v1.3.63.0_debian-armhf-11-armhf.tar.gz </tarball-url>
-  <tarball-checksum> 3f390dc51a6e36a8d5f1c9911cc769749ecd0c0f24c959cf8418bd62d2bcae2b </tarball-checksum>
+  <target>debian-x86_64</target>
+  <target-version>12</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.65.0-debian-x86_64-12-tarball/versions/v1.3.65.0/VDR-v1.3.65.0_debian-x86_64-12-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> e42222182938b38af555d6074d6deac101f43cb0016cf34232f21df0e0adc1c5 </tarball-checksum>
 </plugin>

--- a/metadata/VDR-v1.3.65.0-flatpak-aarch64-A64-22.08.xml
+++ b/metadata/VDR-v1.3.65.0-flatpak-aarch64-A64-22.08.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://ci.appveyor.com/project/rgleason/vdr-pi/builds/51582601 -->
+<!-- https://circleci.com/gh/rgleason/vdr_pi/6540 -->
 <plugin version="1">
   <name> VDR </name>
-  <version> v1.3.63.0 </version>
+  <version> v1.3.65.0 </version>
   <release> 0 </release>
   <summary> Voyage Data Recorder </summary>
 
@@ -16,9 +16,9 @@
 Save NMEA stream to a file.  Replay NMEA stream previously saved. Used to test plugins.
  </description>
 
-  <target>msvc-wx32</target>
-  <target-version>10</target-version>
-  <target-arch>x86</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.63.0-msvc-wx32-10-tarball/versions/v1.3.63.0/VDR-v1.3.63.0_msvc-wx32-10-x86.tar.gz </tarball-url>
-  <tarball-checksum> 5a9f325e4373a032f9e2fe68d65a24a0a3c479d70e7a710a741637f8ef9d7d23 </tarball-checksum>
+  <target>flatpak-aarch64</target>
+  <target-version>22.08</target-version>
+  <target-arch>aarch64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.65.0-flatpak-aarch64-A64-22.08-tarball/versions/v1.3.65.0/VDR-v1.3.65.0_flatpak-aarch64-22.08-aarch64.tar.gz </tarball-url>
+  <tarball-checksum> 7dd6c702a3bed710ec55848e4ced1bc7afaf97ae1041de7cca816720ed5669dc </tarball-checksum>
 </plugin>

--- a/metadata/VDR-v1.3.65.0-flatpak-aarch64-A64-24.08.xml
+++ b/metadata/VDR-v1.3.65.0-flatpak-aarch64-A64-24.08.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--  -->
+<!-- https://circleci.com/gh/rgleason/vdr_pi/6546 -->
 <plugin version="1">
   <name> VDR </name>
-  <version> v1.3.63.0 </version>
+  <version> v1.3.65.0 </version>
   <release> 0 </release>
   <summary> Voyage Data Recorder </summary>
 
@@ -16,9 +16,9 @@
 Save NMEA stream to a file.  Replay NMEA stream previously saved. Used to test plugins.
  </description>
 
-  <target>debian-x86_64</target>
-  <target-version>12</target-version>
-  <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.63.0-debian-x86_64-12-tarball/versions/v1.3.63.0/VDR-v1.3.63.0_debian-x86_64-12-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 2b34ef7f42550bb2eb2f0cf082959f0f06deaf951cc913499eb62a3599694878 </tarball-checksum>
+  <target>flatpak-aarch64</target>
+  <target-version>24.08</target-version>
+  <target-arch>aarch64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.65.0-flatpak-aarch64-A64-24.08-tarball/versions/v1.3.65.0/VDR-v1.3.65.0_flatpak-aarch64-24.08-aarch64.tar.gz </tarball-url>
+  <tarball-checksum> 7059d5b3b38ab7fa1186bed99d5235e79c0b1efa81376c32117d6290c7696eb2 </tarball-checksum>
 </plugin>

--- a/metadata/VDR-v1.3.65.0-flatpak-x86_64-22.08.xml
+++ b/metadata/VDR-v1.3.65.0-flatpak-x86_64-22.08.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/rgleason/vdr_pi/6498 -->
+<!-- https://circleci.com/gh/rgleason/vdr_pi/6545 -->
 <plugin version="1">
   <name> VDR </name>
-  <version> v1.3.63.0 </version>
+  <version> v1.3.65.0 </version>
   <release> 0 </release>
   <summary> Voyage Data Recorder </summary>
 
@@ -16,9 +16,9 @@
 Save NMEA stream to a file.  Replay NMEA stream previously saved. Used to test plugins.
  </description>
 
-  <target>darwin-wx32</target>
-  <target-version>10</target-version>
-  <target-arch>arm64;x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.63.0-darwin-wx32-universal-10-tarball/versions/v1.3.63.0/VDR-v1.3.63.0_darwin-wx32-10-arm64-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 7875cf3a8457d545c60a3dacc53fc3f4184f1135a84ebc36200aa117b26525a4 </tarball-checksum>
+  <target>flatpak-x86_64</target>
+  <target-version>22.08</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.65.0-flatpak-x86_64-22.08-tarball/versions/v1.3.65.0/VDR-v1.3.65.0_flatpak-x86_64-22.08-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> f1e168f362b6ad0b7e982d8163bc1f063922c6c18e25e678db7db41219b083eb </tarball-checksum>
 </plugin>

--- a/metadata/VDR-v1.3.65.0-flatpak-x86_64-24.08.xml
+++ b/metadata/VDR-v1.3.65.0-flatpak-x86_64-24.08.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--  -->
+<!-- https://circleci.com/gh/rgleason/vdr_pi/6548 -->
 <plugin version="1">
   <name> VDR </name>
-  <version> v1.3.63.0 </version>
+  <version> v1.3.65.0 </version>
   <release> 0 </release>
   <summary> Voyage Data Recorder </summary>
 
@@ -16,9 +16,9 @@
 Save NMEA stream to a file.  Replay NMEA stream previously saved. Used to test plugins.
  </description>
 
-  <target>debian-wx32-armhf</target>
-  <target-version>11</target-version>
-  <target-arch>armhf</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.63.0-debian-wx32-armhf-A32-11-tarball/versions/v1.3.63.0/VDR-v1.3.63.0_debian-wx32-armhf-11-armhf.tar.gz </tarball-url>
-  <tarball-checksum> f98d8976373b96a400e1af7e56a96dbb4c8ca581d6184af6c0ebd52c9fc36477 </tarball-checksum>
+  <target>flatpak-x86_64</target>
+  <target-version>24.08</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.65.0-flatpak-x86_64-24.08-tarball/versions/v1.3.65.0/VDR-v1.3.65.0_flatpak-x86_64-24.08-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 59d928e0876e3b39d8242ba874bbe02110b5880cc4ba056069f721f07d14bae7 </tarball-checksum>
 </plugin>

--- a/metadata/VDR-v1.3.65.0-msvc-wx32-10.xml
+++ b/metadata/VDR-v1.3.65.0-msvc-wx32-10.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--  -->
+<!-- https://ci.appveyor.com/project/rgleason/vdr-pi/builds/51595132 -->
 <plugin version="1">
   <name> VDR </name>
-  <version> v1.3.63.0 </version>
+  <version> v1.3.65.0 </version>
   <release> 0 </release>
   <summary> Voyage Data Recorder </summary>
 
@@ -16,9 +16,9 @@
 Save NMEA stream to a file.  Replay NMEA stream previously saved. Used to test plugins.
  </description>
 
-  <target>debian-arm64</target>
-  <target-version>11</target-version>
-  <target-arch>arm64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.63.0-debian-arm64-A64-11-tarball/versions/v1.3.63.0/VDR-v1.3.63.0_debian-arm64-11-arm64.tar.gz </tarball-url>
-  <tarball-checksum> 5dce327fd23f0a9e127f7836e477eef94626610a5473c47a257fa025cb723b14 </tarball-checksum>
+  <target>msvc-wx32</target>
+  <target-version>10</target-version>
+  <target-arch>x86</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/vdr-prod/raw/names/VDR-v1.3.65.0-msvc-wx32-10-tarball/versions/v1.3.65.0/VDR-v1.3.65.0_msvc-wx32-10-x86.tar.gz </tarball-url>
+  <tarball-checksum> 933029d284c6df6b6affa4da357f0192266ec393549a1ca3302a5592fad0dc42 </tarball-checksum>
 </plugin>


### PR DESCRIPTION
bdbcat Fixed by [Adjust SVG icon sizes for scaled display on Windows](https://github.com/rgleason/vdr_pi/commit/c895a03b979f4862973b5cafbdf6b22f415f3f44)  Badly Sized Icons.