### PR TITLE
ShipDriver v3.4.6

### DIFF
--- a/metadata/ShipDriver-v3.4.6-android-arm64-A64-16.xml
+++ b/metadata/ShipDriver-v3.4.6-android-arm64-A64-16.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/10966 -->
+<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/11001 -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> v3.4.5 </version>
+  <version> v3.4.6 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -18,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>flatpak-aarch64</target>
-  <target-version>22.08</target-version>
-  <target-arch>aarch64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.5-flatpak-aarch64-A64-22.08-tarball/versions/v3.4.5/ShipDriver-v3.4.5_flatpak-aarch64-22.08-aarch64.tar.gz </tarball-url>
-  <tarball-checksum> 822d250f0c00f0aa9bea1502ee4872e3beb87dfb9a73bc436047990a3a730d04 </tarball-checksum>
+  <target>android-arm64</target>
+  <target-version>16</target-version>
+  <target-arch>arm64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.6-android-arm64-A64-16-tarball/versions/v3.4.6/ShipDriver-v3.4.6_android-arm64-16-arm64.tar.gz </tarball-url>
+  <tarball-checksum> 831cde31f3bf360092f471c3113b4ddedf2ef755467a10e75ff36c5e5624a658 </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v3.4.6-android-armhf-A32-16.xml
+++ b/metadata/ShipDriver-v3.4.6-android-armhf-A32-16.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://ci.appveyor.com/project/Rasbats/shipdriver-pi/builds/52315423 -->
+<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/10995 -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> v3.4.5 </version>
+  <version> v3.4.6 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -18,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>msvc-wx32</target>
-  <target-version>10</target-version>
-  <target-arch>x86</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.5-msvc-wx32-10-tarball/versions/v3.4.5/ShipDriver-v3.4.5_msvc-wx32-10-x86.tar.gz </tarball-url>
-  <tarball-checksum> 39567d7bfd829f022e2a0568ea7fab3594be17eac322bcc142ffd38ad7a2115f </tarball-checksum>
+  <target>android-armhf</target>
+  <target-version>16</target-version>
+  <target-arch>armhf</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.6-android-armhf-A32-16-tarball/versions/v3.4.6/ShipDriver-v3.4.6_android-armhf-16-armhf.tar.gz </tarball-url>
+  <tarball-checksum> 42856f5492ab94caaf1137d0a83916236b105340c12a321e9a9beb9201734a2d </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v3.4.6-darwin-wx32-universal-10.xml
+++ b/metadata/ShipDriver-v3.4.6-darwin-wx32-universal-10.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--  -->
+<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/11006 -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> v3.4.5 </version>
+  <version> v3.4.6 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -18,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>debian-wx32-arm64</target>
-  <target-version>11</target-version>
-  <target-arch>arm64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.5-debian-wx32-arm64-A64-11-tarball/versions/v3.4.5/ShipDriver-v3.4.5_debian-wx32-arm64-11-arm64.tar.gz </tarball-url>
-  <tarball-checksum> 88b0201e04d58509a5f240074c58d596baf95329eb3a976d2796fd515bd30582 </tarball-checksum>
+  <target>darwin-wx32</target>
+  <target-version>10</target-version>
+  <target-arch>arm64;x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.6-darwin-wx32-universal-10-tarball/versions/v3.4.6/ShipDriver-v3.4.6_darwin-wx32-10-arm64-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 6c10c3096239b49b25f5ec198ed9b3e419ac8580d23c3522d0d1cfa3eb6f643e </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v3.4.6-debian-arm64-A64-11.xml
+++ b/metadata/ShipDriver-v3.4.6-debian-arm64-A64-11.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/10968 -->
+<!--  -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> v3.4.5 </version>
+  <version> v3.4.6 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -18,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>flatpak-x86_64</target>
-  <target-version>24.08</target-version>
-  <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.5-flatpak-x86_64-24.08-tarball/versions/v3.4.5/ShipDriver-v3.4.5_flatpak-x86_64-24.08-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> c13e33b9c37bc2ffb67bb29ff34e51ce4bdbdea7fc41491d43c52c63fab542ac </tarball-checksum>
+  <target>debian-arm64</target>
+  <target-version>11</target-version>
+  <target-arch>arm64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.6-debian-arm64-A64-11-tarball/versions/v3.4.6/ShipDriver-v3.4.6_debian-arm64-11-arm64.tar.gz </tarball-url>
+  <tarball-checksum> f503a2b1741b428db1c338b41cb28c95e13511711341106c0b9e428e4314b4d5 </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v3.4.6-debian-arm64-A64-12.xml
+++ b/metadata/ShipDriver-v3.4.6-debian-arm64-A64-12.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/10962 -->
+<!--  -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> v3.4.5 </version>
+  <version> v3.4.6 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -18,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>flatpak-aarch64</target>
-  <target-version>24.08</target-version>
-  <target-arch>aarch64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.5-flatpak-aarch64-A64-24.08-tarball/versions/v3.4.5/ShipDriver-v3.4.5_flatpak-aarch64-24.08-aarch64.tar.gz </tarball-url>
-  <tarball-checksum> d416873d54db36b7eff65376ec27b5eb1e080c39f9bac975b2a1dc1fdd185198 </tarball-checksum>
+  <target>debian-arm64</target>
+  <target-version>12</target-version>
+  <target-arch>arm64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.6-debian-arm64-A64-12-tarball/versions/v3.4.6/ShipDriver-v3.4.6_debian-arm64-12-arm64.tar.gz </tarball-url>
+  <tarball-checksum> 2a6dc455aeea7fb3668f83e6fe5647bfefe3b102ce9e8ee2b031c56856f5bacb </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v3.4.6-debian-armhf-A32-11.xml
+++ b/metadata/ShipDriver-v3.4.6-debian-armhf-A32-11.xml
@@ -2,7 +2,7 @@
 <!--  -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> v3.4.5 </version>
+  <version> v3.4.6 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -18,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>debian-x86_64</target>
-  <target-version>12</target-version>
-  <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.5-debian-x86_64-12-tarball/versions/v3.4.5/ShipDriver-v3.4.5_debian-x86_64-12-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 0f80deea123ca77a83b1e891dd05f7791065ca6577196f66a16459dedd1a2758 </tarball-checksum>
+  <target>debian-armhf</target>
+  <target-version>11</target-version>
+  <target-arch>armhf</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.6-debian-armhf-A32-11-tarball/versions/v3.4.6/ShipDriver-v3.4.6_debian-armhf-11-armhf.tar.gz </tarball-url>
+  <tarball-checksum> b6380a251283a42f625506c07366271d01e7c9793c57e154c8672ee33205749b </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v3.4.6-debian-armhf-A32-12.xml
+++ b/metadata/ShipDriver-v3.4.6-debian-armhf-A32-12.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/10969 -->
+<!--  -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> v3.4.5 </version>
+  <version> v3.4.6 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -18,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>flatpak-x86_64</target>
-  <target-version>22.08</target-version>
-  <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.5-flatpak-x86_64-22.08-tarball/versions/v3.4.5/ShipDriver-v3.4.5_flatpak-x86_64-22.08-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 52b73b7f29f52beefea4ba905d013da57f16478910e1ceb17c77477c313e8b03 </tarball-checksum>
+  <target>debian-armhf</target>
+  <target-version>12</target-version>
+  <target-arch>armhf</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.6-debian-armhf-A32-12-tarball/versions/v3.4.6/ShipDriver-v3.4.6_debian-armhf-12-armhf.tar.gz </tarball-url>
+  <tarball-checksum> 0e04dc8ec6c0e37f1d6da4be14c2107af140bbf44d3136c05b651c4c21d0ab1f </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v3.4.6-debian-wx32-arm64-A64-11.xml
+++ b/metadata/ShipDriver-v3.4.6-debian-wx32-arm64-A64-11.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/10972 -->
+<!--  -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> v3.4.5 </version>
+  <version> v3.4.6 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -18,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>darwin-wx32</target>
-  <target-version>10</target-version>
-  <target-arch>arm64;x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.5-darwin-wx32-universal-10-tarball/versions/v3.4.5/ShipDriver-v3.4.5_darwin-wx32-10-arm64-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 4aec962a0d6a282c58586b1bf78c66e60675ba5a839cae47e3073b1990b56630 </tarball-checksum>
+  <target>debian-wx32-arm64</target>
+  <target-version>11</target-version>
+  <target-arch>arm64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.6-debian-wx32-arm64-A64-11-tarball/versions/v3.4.6/ShipDriver-v3.4.6_debian-wx32-arm64-11-arm64.tar.gz </tarball-url>
+  <tarball-checksum> 741f4b11d8a1c8265a4f26c1d82ba5f131a6d05b56cca08778b4924ae11bb6ad </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v3.4.6-debian-wx32-armhf-A32-11.xml
+++ b/metadata/ShipDriver-v3.4.6-debian-wx32-armhf-A32-11.xml
@@ -2,7 +2,7 @@
 <!--  -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> v3.4.5 </version>
+  <version> v3.4.6 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -18,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>debian-armhf</target>
-  <target-version>12</target-version>
+  <target>debian-wx32-armhf</target>
+  <target-version>11</target-version>
   <target-arch>armhf</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.5-debian-armhf-A32-12-tarball/versions/v3.4.5/ShipDriver-v3.4.5_debian-armhf-12-armhf.tar.gz </tarball-url>
-  <tarball-checksum> 4470b098025a16e705a2911e5151ab5aa4ea4fb3b2da335de97ee25145e61996 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.6-debian-wx32-armhf-A32-11-tarball/versions/v3.4.6/ShipDriver-v3.4.6_debian-wx32-armhf-11-armhf.tar.gz </tarball-url>
+  <tarball-checksum> d3fb15975ebce1a5faa67a94a2cc97aae89f760f40e38ef978534a19d3f202b7 </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v3.4.6-debian-wx32-x86_64-11.xml
+++ b/metadata/ShipDriver-v3.4.6-debian-wx32-x86_64-11.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/10973 -->
+<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/10993 -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> v3.4.5 </version>
+  <version> v3.4.6 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -18,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>android-armhf</target>
-  <target-version>16</target-version>
-  <target-arch>armhf</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.5-android-armhf-A32-16-tarball/versions/v3.4.5/ShipDriver-v3.4.5_android-armhf-16-armhf.tar.gz </tarball-url>
-  <tarball-checksum> 709c95962f2d25af7cd3559a4fb0debe2d096e2b7b45ec529851656e39e6d279 </tarball-checksum>
+  <target>debian-wx32-x86_64</target>
+  <target-version>11</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.6-debian-wx32-x86_64-11-tarball/versions/v3.4.6/ShipDriver-v3.4.6_debian-wx32-x86_64-11-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 2890f5dd0168b0bc8164d404ea020b0ed8a45fdbf714492b3331c44dbacd999f </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v3.4.6-debian-x86_64-11.xml
+++ b/metadata/ShipDriver-v3.4.6-debian-x86_64-11.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/10964 -->
+<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/11000 -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> v3.4.5 </version>
+  <version> v3.4.6 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -18,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>android-arm64</target>
-  <target-version>16</target-version>
-  <target-arch>arm64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.5-android-arm64-A64-16-tarball/versions/v3.4.5/ShipDriver-v3.4.5_android-arm64-16-arm64.tar.gz </tarball-url>
-  <tarball-checksum> dc9e96f151cc97d579ebf2012e788aa81b8f59b0218dc29e334bb1bab6979d6a </tarball-checksum>
+  <target>debian-x86_64</target>
+  <target-version>11</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.6-debian-x86_64-11-tarball/versions/v3.4.6/ShipDriver-v3.4.6_debian-x86_64-11-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 9ee4d71c9a97154eb146a3605fe8b0f7d655cb97991c986df87b4bc84dea082c </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v3.4.6-debian-x86_64-12.xml
+++ b/metadata/ShipDriver-v3.4.6-debian-x86_64-12.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/10975 -->
+<!--  -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> v3.4.5 </version>
+  <version> v3.4.6 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -19,8 +19,8 @@ data from itself. This can be replayed to simulate collision situations.
  </description>
 
   <target>debian-x86_64</target>
-  <target-version>11</target-version>
+  <target-version>12</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.5-debian-x86_64-11-tarball/versions/v3.4.5/ShipDriver-v3.4.5_debian-x86_64-11-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> ab73313a3ca121fc1570b9b3486afceca16b01ce7f013ab5b45a3dca3105aadd </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.6-debian-x86_64-12-tarball/versions/v3.4.6/ShipDriver-v3.4.6_debian-x86_64-12-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> a57bcfaa9a9b6c6f3aa85296a0b1631cc06f4b064d36d90af77c5f75ac77c2ac </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v3.4.6-flatpak-aarch64-A64-22.08.xml
+++ b/metadata/ShipDriver-v3.4.6-flatpak-aarch64-A64-22.08.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--  -->
+<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/11007 -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> v3.4.5 </version>
+  <version> v3.4.6 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -18,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>debian-wx32-armhf</target>
-  <target-version>11</target-version>
-  <target-arch>armhf</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.5-debian-wx32-armhf-A32-11-tarball/versions/v3.4.5/ShipDriver-v3.4.5_debian-wx32-armhf-11-armhf.tar.gz </tarball-url>
-  <tarball-checksum> 39e6c76000e3791a1d733937c6e4d009f978e26ac3851c87d9de8fe2f1cd3082 </tarball-checksum>
+  <target>flatpak-aarch64</target>
+  <target-version>22.08</target-version>
+  <target-arch>aarch64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.6-flatpak-aarch64-A64-22.08-tarball/versions/v3.4.6/ShipDriver-v3.4.6_flatpak-aarch64-22.08-aarch64.tar.gz </tarball-url>
+  <tarball-checksum> 72120f750d0edbc236bec079f106c57a58df5b652b0a15f81128b1530dd7d4a6 </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v3.4.6-flatpak-aarch64-A64-24.08.xml
+++ b/metadata/ShipDriver-v3.4.6-flatpak-aarch64-A64-24.08.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--  -->
+<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/11003 -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> v3.4.5 </version>
+  <version> v3.4.6 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -18,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>debian-arm64</target>
-  <target-version>12</target-version>
-  <target-arch>arm64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.5-debian-arm64-A64-12-tarball/versions/v3.4.5/ShipDriver-v3.4.5_debian-arm64-12-arm64.tar.gz </tarball-url>
-  <tarball-checksum> e1d6d87447a4a193d109b9350f29623b6474d1e4f6650bf1ae2a8488b73131ff </tarball-checksum>
+  <target>flatpak-aarch64</target>
+  <target-version>24.08</target-version>
+  <target-arch>aarch64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.6-flatpak-aarch64-A64-24.08-tarball/versions/v3.4.6/ShipDriver-v3.4.6_flatpak-aarch64-24.08-aarch64.tar.gz </tarball-url>
+  <tarball-checksum> 45cea170e65a67024911e9f38e6a979c6797294de728b587bd9b48420e2bd08e </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v3.4.6-flatpak-x86_64-22.08.xml
+++ b/metadata/ShipDriver-v3.4.6-flatpak-x86_64-22.08.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--  -->
+<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/11005 -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> v3.4.5 </version>
+  <version> v3.4.6 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -18,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>debian-arm64</target>
-  <target-version>11</target-version>
-  <target-arch>arm64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.5-debian-arm64-A64-11-tarball/versions/v3.4.5/ShipDriver-v3.4.5_debian-arm64-11-arm64.tar.gz </tarball-url>
-  <tarball-checksum> ff157e8a3f3835abf8496a931c6467dfea3c884924f3a1178e84aab5d318379e </tarball-checksum>
+  <target>flatpak-x86_64</target>
+  <target-version>22.08</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.6-flatpak-x86_64-22.08-tarball/versions/v3.4.6/ShipDriver-v3.4.6_flatpak-x86_64-22.08-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> a06d6d0c9851cb440b7b9c6ae35f3664a855e71692656ce860b172c7a393cb99 </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v3.4.6-flatpak-x86_64-24.08.xml
+++ b/metadata/ShipDriver-v3.4.6-flatpak-x86_64-24.08.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/10961 -->
+<!-- https://circleci.com/gh/Rasbats/shipdriver_pi/10998 -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> v3.4.5 </version>
+  <version> v3.4.6 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -18,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>debian-wx32-x86_64</target>
-  <target-version>11</target-version>
+  <target>flatpak-x86_64</target>
+  <target-version>24.08</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.5-debian-wx32-x86_64-11-tarball/versions/v3.4.5/ShipDriver-v3.4.5_debian-wx32-x86_64-11-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 5106170f281f3734226be47f22f2a7a2dd5bb02b011b746a9975aa53b4873c92 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.6-flatpak-x86_64-24.08-tarball/versions/v3.4.6/ShipDriver-v3.4.6_flatpak-x86_64-24.08-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 206d9560e2f47d31ff198462239d522f7deb668f95c3b8dc70094e61058ba4f9 </tarball-checksum>
 </plugin>

--- a/metadata/ShipDriver-v3.4.6-msvc-wx32-10.xml
+++ b/metadata/ShipDriver-v3.4.6-msvc-wx32-10.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--  -->
+<!-- https://ci.appveyor.com/project/Rasbats/shipdriver-pi/builds/52326585 -->
 <plugin version="1">
   <name> ShipDriver </name>
-  <version> v3.4.5 </version>
+  <version> v3.4.6 </version>
   <release> 0 </release>
   <summary> Simulate ship movements </summary>
 
@@ -18,9 +18,9 @@ those conditions. Using 'Preferences' the simulator is able to record AIS
 data from itself. This can be replayed to simulate collision situations.
  </description>
 
-  <target>debian-armhf</target>
-  <target-version>11</target-version>
-  <target-arch>armhf</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.5-debian-armhf-A32-11-tarball/versions/v3.4.5/ShipDriver-v3.4.5_debian-armhf-11-armhf.tar.gz </tarball-url>
-  <tarball-checksum> a8a5b9b0787133e159d4d29f310726a136d55badf151491e2b21247517229e5b </tarball-checksum>
+  <target>msvc-wx32</target>
+  <target-version>10</target-version>
+  <target-arch>x86</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn/shipdriver-prod/raw/names/ShipDriver-v3.4.6-msvc-wx32-10-tarball/versions/v3.4.6/ShipDriver-v3.4.6_msvc-wx32-10-x86.tar.gz </tarball-url>
+  <tarball-checksum> 9e727c8e40996d9fa7974fa578dce46d00d511f60d539c36ca01c727fb06c7cc </tarball-checksum>
 </plugin>


### PR DESCRIPTION
Remove v3.4.5. 

v3.4.6 corrects a bug in the RMC Sentence generated by ShipDriver.

Thanks to the Data Monitor tool for detecting this.