### PR TITLE
Add frozen metadata mechanisms

### DIFF
--- a/ci/ga_merge.sh
+++ b/ci/ga_merge.sh
@@ -18,7 +18,8 @@ echo "Using upstream: ... ${upstream##https:}"
 git remote add upstream $upstream
 git fetch upstream $GITHUB_REF:base_branch
 
-tools/ocpn-metadata generate --userdir metadata --destfile ocpn-plugins.new
+tools/ocpn-metadata generate --userdir metadata --frozendir frozen-metadata \
+    --destfile ocpn-plugins.new
 sed  -ie  '/<date>/d' ocpn-plugins.new ocpn-plugins.xml
 if git diff -b --quiet --no-index ocpn-plugins.xml ocpn-plugins.new; then
     echo "ocpn-plugins.xml is already  up do date -- exiting"
@@ -26,8 +27,8 @@ if git diff -b --quiet --no-index ocpn-plugins.xml ocpn-plugins.new; then
 fi
 
 echo "Re-generating ocpn-plugins.xml to match metadata."
-tools/ocpn-metadata generate \
-    --userdir metadata --destfile ocpn-plugins.xml  --force
+tools/ocpn-metadata generate --userdir metadata --frozendir frozen-metadata \
+    --destfile ocpn-plugins.xmlö --force
 git config --local user.email "action@github.com"
 git config --local user.name "$GITHUB_ACTOR"
 git add ocpn-plugins.xml

--- a/tools/ocpn-metadata
+++ b/tools/ocpn-metadata
@@ -69,7 +69,10 @@ def get_args(paths):
             help='Overwrite possibly existing source files.')
     generate_parser.add_argument(
             '--userdir', metavar='dir', default=paths["userdir"],
-            help='source directory [%s]' % paths["userdir"])
+            help='regular source directory [%s]' % paths["userdir"])
+    generate_parser.add_argument(
+            '--frozendir', metavar='dir', default='',
+            help='frozen source directory [""]')
     generate_parser.add_argument(
             '--destfile', metavar='path', default=paths["destfile"],
             help='destination path [%s]' % paths["destfile"])
@@ -86,7 +89,7 @@ def get_args(paths):
     return args
 
 
-def generate(sourcedir, destfile, version, date):
+def generate(sourcedir, frozendir, destfile, version, date):
     """Generate a new ocpn-plugins.xml."""
     tree = ET.Element('plugins')
     version_elem = ET.SubElement(tree, "version")
@@ -94,7 +97,9 @@ def generate(sourcedir, destfile, version, date):
     date_elem = ET.SubElement(tree, "date")
     date_elem.text = \
         date if date else datetime.datetime.now().strftime('%Y-%m-%d %H:%M')
-    for path in sorted(Path(sourcedir).glob("*.xml")):
+    paths = sorted(Path(sourcedir).glob("*.xml"))
+    if bool(frozendir): paths.extend(sorted(Path(frozendir).glob("*.xml")))
+    for path in paths:
         try:
             subtree = ET.parse(str(path))
         except ET.ParseError as ex:
@@ -142,7 +147,7 @@ def main():
             errprint("The file %s is in the way" % args.destfile)
             errprint("Please remove or use --force")
             sys.exit(1)
-        generate(args.userdir, args.destfile, args.version, args.date)
+        generate(args.userdir, args.frozendir, args.destfile, args.version, args.date)
         print("Generated new ocpn-plugins.xml at " + args.destfile)
 
 


### PR DESCRIPTION
Maintaining  frozen metadata is a major pain for plugin devs. The basic problem is  to track what is frozen or not.

This PR adds a new. source directory *frozen-metadata*. It is aimed for plugins for old distros which we don't build anymore but still keeps around.  The basic change is to the ocpn-metadata scripts whichnow is able to use sources from both  directories.

For a plugin dev the act of freezing a plugin is
1. In the plugins local copy, move the last build of plugin to frozen-metadata
2. Make sure that no new builds are done for given plugin and OS version

The PR is ready, but we might need to reflect on if this is the right solution