### PR TITLE
Add WeatherFiles plugin 0.1.0.0-alpha1

### DIFF
--- a/metadata/weatherfiles_pi-0.1.0.0-darwin-wx32-arm64-x86_64-14.3.1-macos.xml
+++ b/metadata/weatherfiles_pi-0.1.0.0-darwin-wx32-arm64-x86_64-14.3.1-macos.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> WeatherFiles </name>
+<version> 0.1.0.0 </version>
+<release> 0 </release>
+<summary> Browse WeatherFiles models, slice an area, and download GRIBs into OpenCPN </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Bart Manuel </author>
+<source> https://github.com/bartmanuel/weatherfiles_pi </source>
+
+<description>
+WeatherFiles plugin for OpenCPN: browse 27+ European weather models, pick an area on the chart, and download sliced GRIB2 files that open directly in the built-in GRIB display. Uses the WeatherFiles public API (api.weatherfiles.com/v1) with a personal access token. See developers.weatherfiles.com.
+</description>
+
+<target>darwin-wx32</target>
+<build-target>darwin</build-target>
+<build-gtk></build-gtk>
+<target-version>14.3.1</target-version>
+<target-arch>arm64;x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/bartmanuel-fgsm/weatherfiles-alpha/raw/names/weatherfiles_pi-0.1.0.0-darwin-wx32-arm64-x86_64-14.3.1-macos-tarball/versions/v0.1.0.0-alpha1/weatherfiles_pi-0.1.0.0-darwin-wx32-arm64-x86_64-14.3.1-macos.tar.gz
+</tarball-url>
+<info-url> https://developers.weatherfiles.com </info-url>
+</plugin>

--- a/metadata/weatherfiles_pi-0.1.0.0-darwin-wx32-arm64-x86_64-14.3.1-macos.xml
+++ b/metadata/weatherfiles_pi-0.1.0.0-darwin-wx32-arm64-x86_64-14.3.1-macos.xml
@@ -3,7 +3,7 @@
 <name> WeatherFiles </name>
 <version> 0.1.0.0 </version>
 <release> 0 </release>
-<summary> Browse WeatherFiles models, slice an area, and download GRIBs into OpenCPN </summary>
+<summary> Browse WeatherFiles models, slice an area, download GRIBs into OpenCPN </summary>
 
 <api-version> 1.18 </api-version>
 <open-source> yes </open-source>

--- a/metadata/weatherfiles_pi-0.1.0.0-debian-x86_64-12-bookworm.xml
+++ b/metadata/weatherfiles_pi-0.1.0.0-debian-x86_64-12-bookworm.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> WeatherFiles </name>
+<version> 0.1.0.0 </version>
+<release> 0 </release>
+<summary> Browse WeatherFiles models, slice an area, and download GRIBs into OpenCPN </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Bart Manuel </author>
+<source> https://github.com/bartmanuel/weatherfiles_pi </source>
+
+<description>
+WeatherFiles plugin for OpenCPN: browse 27+ European weather models, pick an area on the chart, and download sliced GRIB2 files that open directly in the built-in GRIB display. Uses the WeatherFiles public API (api.weatherfiles.com/v1) with a personal access token. See developers.weatherfiles.com.
+</description>
+
+<target>debian-x86_64</target>
+<build-target>debian</build-target>
+<build-gtk></build-gtk>
+<target-version>12</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/bartmanuel-fgsm/weatherfiles-alpha/raw/names/weatherfiles_pi-0.1.0.0-debian-x86_64-12-bookworm-tarball/versions/v0.1.0.0-alpha1/weatherfiles_pi-0.1.0.0-debian-x86_64-12-bookworm.tar.gz
+</tarball-url>
+<info-url> https://developers.weatherfiles.com </info-url>
+</plugin>

--- a/metadata/weatherfiles_pi-0.1.0.0-debian-x86_64-12-bookworm.xml
+++ b/metadata/weatherfiles_pi-0.1.0.0-debian-x86_64-12-bookworm.xml
@@ -3,7 +3,7 @@
 <name> WeatherFiles </name>
 <version> 0.1.0.0 </version>
 <release> 0 </release>
-<summary> Browse WeatherFiles models, slice an area, and download GRIBs into OpenCPN </summary>
+<summary> Browse WeatherFiles models, slice an area, download GRIBs into OpenCPN </summary>
 
 <api-version> 1.18 </api-version>
 <open-source> yes </open-source>

--- a/metadata/weatherfiles_pi-0.1.0.0-flatpak-aarch64-25.08-flatpak.xml
+++ b/metadata/weatherfiles_pi-0.1.0.0-flatpak-aarch64-25.08-flatpak.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> WeatherFiles </name>
+<version> 0.1.0.0 </version>
+<release> 0 </release>
+<summary> Browse WeatherFiles models, slice an area, and download GRIBs into OpenCPN </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Bart Manuel </author>
+<source> https://github.com/bartmanuel/weatherfiles_pi </source>
+
+<description>
+WeatherFiles plugin for OpenCPN: browse 27+ European weather models, pick an area on the chart, and download sliced GRIB2 files that open directly in the built-in GRIB display. Uses the WeatherFiles public API (api.weatherfiles.com/v1) with a personal access token. See developers.weatherfiles.com.
+</description>
+
+<target>flatpak-aarch64</target>
+<build-target>flatpak</build-target>
+<build-gtk></build-gtk>
+<target-version>25.08</target-version>
+<target-arch>aarch64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/bartmanuel-fgsm/weatherfiles-alpha/raw/names/weatherfiles_pi-0.1.0.0-flatpak-aarch64-25.08-flatpak-tarball/versions/v0.1.0.0-alpha1/weatherfiles_pi-0.1.0.0-aarch64_flatpak-25.08.tar.gz
+</tarball-url>
+<info-url> https://developers.weatherfiles.com </info-url>
+</plugin>

--- a/metadata/weatherfiles_pi-0.1.0.0-flatpak-aarch64-25.08-flatpak.xml
+++ b/metadata/weatherfiles_pi-0.1.0.0-flatpak-aarch64-25.08-flatpak.xml
@@ -3,7 +3,7 @@
 <name> WeatherFiles </name>
 <version> 0.1.0.0 </version>
 <release> 0 </release>
-<summary> Browse WeatherFiles models, slice an area, and download GRIBs into OpenCPN </summary>
+<summary> Browse WeatherFiles models, slice an area, download GRIBs into OpenCPN </summary>
 
 <api-version> 1.18 </api-version>
 <open-source> yes </open-source>

--- a/metadata/weatherfiles_pi-0.1.0.0-flatpak-x86_64-25.08-flatpak.xml
+++ b/metadata/weatherfiles_pi-0.1.0.0-flatpak-x86_64-25.08-flatpak.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> WeatherFiles </name>
+<version> 0.1.0.0 </version>
+<release> 0 </release>
+<summary> Browse WeatherFiles models, slice an area, and download GRIBs into OpenCPN </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Bart Manuel </author>
+<source> https://github.com/bartmanuel/weatherfiles_pi </source>
+
+<description>
+WeatherFiles plugin for OpenCPN: browse 27+ European weather models, pick an area on the chart, and download sliced GRIB2 files that open directly in the built-in GRIB display. Uses the WeatherFiles public API (api.weatherfiles.com/v1) with a personal access token. See developers.weatherfiles.com.
+</description>
+
+<target>flatpak-x86_64</target>
+<build-target>flatpak</build-target>
+<build-gtk></build-gtk>
+<target-version>25.08</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/bartmanuel-fgsm/weatherfiles-alpha/raw/names/weatherfiles_pi-0.1.0.0-flatpak-x86_64-25.08-flatpak-tarball/versions/v0.1.0.0-alpha1/weatherfiles_pi-0.1.0.0-x86_64_flatpak-25.08.tar.gz
+</tarball-url>
+<info-url> https://developers.weatherfiles.com </info-url>
+</plugin>

--- a/metadata/weatherfiles_pi-0.1.0.0-flatpak-x86_64-25.08-flatpak.xml
+++ b/metadata/weatherfiles_pi-0.1.0.0-flatpak-x86_64-25.08-flatpak.xml
@@ -3,7 +3,7 @@
 <name> WeatherFiles </name>
 <version> 0.1.0.0 </version>
 <release> 0 </release>
-<summary> Browse WeatherFiles models, slice an area, and download GRIBs into OpenCPN </summary>
+<summary> Browse WeatherFiles models, slice an area, download GRIBs into OpenCPN </summary>
 
 <api-version> 1.18 </api-version>
 <open-source> yes </open-source>

--- a/metadata/weatherfiles_pi-0.1.0.0-msvc-x86-wx32-10.0.20348-MSVC.xml
+++ b/metadata/weatherfiles_pi-0.1.0.0-msvc-x86-wx32-10.0.20348-MSVC.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> WeatherFiles </name>
+<version> 0.1.0.0 </version>
+<release> 0 </release>
+<summary> Browse WeatherFiles models, slice an area, and download GRIBs into OpenCPN </summary>
+
+<api-version> 1.18 </api-version>
+<open-source> yes </open-source>
+<author> Bart Manuel </author>
+<source> https://github.com/bartmanuel/weatherfiles_pi </source>
+
+<description>
+WeatherFiles plugin for OpenCPN: browse 27+ European weather models, pick an area on the chart, and download sliced GRIB2 files that open directly in the built-in GRIB display. Uses the WeatherFiles public API (api.weatherfiles.com/v1) with a personal access token. See developers.weatherfiles.com.
+</description>
+
+<target>msvc-wx32</target>
+<build-target>msvc</build-target>
+<build-gtk></build-gtk>
+<target-version>10.0.20348</target-version>
+<target-arch>x86</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/bartmanuel-fgsm/weatherfiles-alpha/raw/names/weatherfiles_pi-0.1.0.0-msvc-x86-wx32-10.0.20348-MSVC-tarball/versions/v0.1.0.0-alpha1/weatherfiles_pi-0.1.0.0-msvc-x86-wx32-10.0.20348-MSVC.tar.gz
+</tarball-url>
+<info-url> https://developers.weatherfiles.com </info-url>
+</plugin>

--- a/metadata/weatherfiles_pi-0.1.0.0-msvc-x86-wx32-10.0.20348-MSVC.xml
+++ b/metadata/weatherfiles_pi-0.1.0.0-msvc-x86-wx32-10.0.20348-MSVC.xml
@@ -3,7 +3,7 @@
 <name> WeatherFiles </name>
 <version> 0.1.0.0 </version>
 <release> 0 </release>
-<summary> Browse WeatherFiles models, slice an area, and download GRIBs into OpenCPN </summary>
+<summary> Browse WeatherFiles models, slice an area, download GRIBs into OpenCPN </summary>
 
 <api-version> 1.18 </api-version>
 <open-source> yes </open-source>


### PR DESCRIPTION
## Summary

Initial Alpha submission of **WeatherFiles** — an OpenCPN plugin that browses 27+ European weather models, lets the user pick an area on the chart, and downloads sliced GRIB2 files that open directly in OpenCPN's built-in GRIB display.

Backend lives at https://api.weatherfiles.com/v1 (free tier + paid plan, documented at https://developers.weatherfiles.com).

## Targets

5 metadata XMLs added, all pointing at a public Cloudsmith repo (`bartmanuel-fgsm/weatherfiles-alpha`, OSS plan):

| Platform | XML |
|---|---|
| Debian 12 x86_64 | `weatherfiles_pi-0.1.0.0-debian-x86_64-12-bookworm.xml` |
| macOS Universal (signed + notarized) | `weatherfiles_pi-0.1.0.0-darwin-wx32-arm64-x86_64-14.3.1-macos.xml` |
| Windows MSVC x86 wx32 | `weatherfiles_pi-0.1.0.0-msvc-x86-wx32-10.0.20348-MSVC.xml` |
| Flatpak x86_64 (KDE 25.08) | `weatherfiles_pi-0.1.0.0-flatpak-x86_64-25.08-flatpak.xml` |
| Flatpak aarch64 (KDE 25.08) | `weatherfiles_pi-0.1.0.0-flatpak-aarch64-25.08-flatpak.xml` |

## Testing

- All tarballs built from tag `v0.1.0.0-alpha1` on https://github.com/bartmanuel/weatherfiles_pi/.
- macOS dylib signed with Developer ID + Apple-notarized (`status: Accepted`).
- Flatpak (KDE 25.08) sideload-imported and verified end-to-end on Ubuntu by the author.
- Plugin uses C++14 + opencpn-libs (api-18, pinned to current main).
- API surface: bearer-token HTTPS to `api.weatherfiles.com/v1`; no inbound sockets.

## Plugin source

https://github.com/bartmanuel/weatherfiles_pi — `main` is at tag `v0.1.0.0-alpha1`. The repo's `README.md` walks through the 3-step download wizard, save-as-set, and the security model.

Happy to make any adjustments the maintainers want — first OpenCPN submission for me.