### PR TITLE
Add EncManaged_pi 0.1.1

### DIFF
--- a/metadata/encmanaged_pi-0.1.1-darwin-arm64.xml
+++ b/metadata/encmanaged_pi-0.1.1-darwin-arm64.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+  <name>EncManaged</name>
+  <version>0.1.1</version>
+  <release>0</release>
+  <summary>Automated NOAA ENC chart sync for OpenCPN</summary>
+  <api-version>1.18</api-version>
+  <open-source>yes</open-source>
+  <author>Ryan Housand</author>
+  <source>https://github.com/rhousand/EncManaged_pi</source>
+  <info-url>https://github.com/rhousand/EncManaged_pi</info-url>
+  <description>
+    EncManaged automatically syncs NOAA Electronic Navigational Charts.
+    Scheduled background sync with atomic updates and parallel downloads.
+  </description>
+  <target>darwin-arm64</target>
+  <target-version>14</target-version>
+  <target-arch>arm64</target-arch>
+  <tarball-url>https://github.com/rhousand/EncManaged_pi/releases/download/v0.1.1/encmanaged_pi-0.1.1-darwin-arm64.tar.gz</tarball-url>
+</plugin>

--- a/metadata/encmanaged_pi-0.1.1-ubuntu-wx32-x86_64.xml
+++ b/metadata/encmanaged_pi-0.1.1-ubuntu-wx32-x86_64.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+  <name>EncManaged</name>
+  <version>0.1.1</version>
+  <release>0</release>
+  <summary>Automated NOAA ENC chart sync for OpenCPN</summary>
+  <api-version>1.18</api-version>
+  <open-source>yes</open-source>
+  <author>Ryan Housand</author>
+  <source>https://github.com/rhousand/EncManaged_pi</source>
+  <info-url>https://github.com/rhousand/EncManaged_pi</info-url>
+  <description>
+    EncManaged automatically syncs NOAA Electronic Navigational Charts.
+    Scheduled background sync with atomic updates and parallel downloads.
+  </description>
+  <target>ubuntu-wx32-x86_64</target>
+  <target-version>24.04</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url>https://github.com/rhousand/EncManaged_pi/releases/download/v0.1.1/encmanaged_pi-0.1.1-linux-x86_64.tar.gz</tarball-url>
+</plugin>


### PR DESCRIPTION
New plugin: automated NOAA ENC sync. darwin-arm64 + ubuntu-24.04-x86_64 builds via GitHub Actions releases.