### PR TITLE
Add stlaurent_indices_pi 1.0.4

### DIFF
--- a/metadata/catalog_macos-arm64.xml
+++ b/metadata/catalog_macos-arm64.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Métadonnées du plugin stlaurent_indices_pi pour le catalogue OpenCPN.
+  Ce fichier est un template : les variables @VAR@ sont remplacées par le
+  script CI (packaging/build_tarball.sh) lors de la publication d'un tag.
+
+  Pour soumettre au catalogue officiel :
+    1. Fork https://github.com/OpenCPN/plugins
+    2. Copier le fichier XML généré dans metadata/
+    3. Ouvrir une PR
+-->
+<plugins>
+  <plugin version="1">
+    <name>stlaurent_indices_pi</name>
+    <version>1.0.4</version>
+    <release>1</release>
+    <summary>Indices Saint-Laurent — météo-marine ECCC/RDWPS</summary>
+    <api-version>1.16</api-version>
+    <author>André Plante</author>
+    <description>
+      Affiche les indices météo-marins du Saint-Laurent produits par
+      iMeteo.ca a à partir des données GRIB d'Environnement et Changement climatique Canada
+      sur la carte nautique OpenCPN : indice d'agitation, flèches de direction,
+      palette de couleurs 20 niveaux, navigation entre 48 pas de temps.
+    </description>
+    <git>https://github.com/toutoumeteo/stlaurent_indices_pi</git>
+    <source>https://github.com/toutoumeteo/stlaurent_indices_pi/releases</source>
+    <tarball-url>https://dl.cloudsmith.io/public/imeteo/stlaurent-indices-pi/raw/files/stlaurent_indices_pi-1.0.4-macos-arm64.tar.gz</tarball-url>
+    <tarball-checksum>sha256:8fe73da8d2a735399c80ea9f91f3b4632128e381ff5fef7f77b8b49df300627d</tarball-checksum>
+    <info-url>https://github.com/toutoumeteo/stlaurent_indices_pi</info-url>
+    <target>macos-arm64</target>
+    <target-version>14</target-version>
+    <target-arch>arm64</target-arch>
+    <target-archs>arm64</target-archs>
+  </plugin>
+</plugins>

--- a/metadata/catalog_ubuntu-x86_64.xml
+++ b/metadata/catalog_ubuntu-x86_64.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Métadonnées du plugin stlaurent_indices_pi pour le catalogue OpenCPN.
+  Ce fichier est un template : les variables @VAR@ sont remplacées par le
+  script CI (packaging/build_tarball.sh) lors de la publication d'un tag.
+
+  Pour soumettre au catalogue officiel :
+    1. Fork https://github.com/OpenCPN/plugins
+    2. Copier le fichier XML généré dans metadata/
+    3. Ouvrir une PR
+-->
+<plugins>
+  <plugin version="1">
+    <name>stlaurent_indices_pi</name>
+    <version>1.0.4</version>
+    <release>1</release>
+    <summary>Indices Saint-Laurent — météo-marine ECCC/RDWPS</summary>
+    <api-version>1.16</api-version>
+    <author>André Plante</author>
+    <description>
+      Affiche les indices météo-marins du Saint-Laurent produits par
+      iMeteo.ca a à partir des données GRIB d'Environnement et Changement climatique Canada
+      sur la carte nautique OpenCPN : indice d'agitation, flèches de direction,
+      palette de couleurs 20 niveaux, navigation entre 48 pas de temps.
+    </description>
+    <git>https://github.com/toutoumeteo/stlaurent_indices_pi</git>
+    <source>https://github.com/toutoumeteo/stlaurent_indices_pi/releases</source>
+    <tarball-url>https://dl.cloudsmith.io/public/imeteo/stlaurent-indices-pi/raw/files/stlaurent_indices_pi-1.0.4-ubuntu-x86_64.tar.gz</tarball-url>
+    <tarball-checksum>sha256:dbe33f606c00d75065e458106f5593de83c1cf7e178f261c9bfe93806a098bfd</tarball-checksum>
+    <info-url>https://github.com/toutoumeteo/stlaurent_indices_pi</info-url>
+    <target>ubuntu-x86_64</target>
+    <target-version>24.04</target-version>
+    <target-arch>x86_64</target-arch>
+    <target-archs>x86_64</target-archs>
+  </plugin>
+</plugins>

--- a/metadata/catalog_win-x86_64.xml
+++ b/metadata/catalog_win-x86_64.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Métadonnées du plugin stlaurent_indices_pi pour le catalogue OpenCPN.
+  Ce fichier est un template : les variables @VAR@ sont remplacées par le
+  script CI (packaging/build_tarball.sh) lors de la publication d'un tag.
+
+  Pour soumettre au catalogue officiel :
+    1. Fork https://github.com/OpenCPN/plugins
+    2. Copier le fichier XML généré dans metadata/
+    3. Ouvrir une PR
+-->
+<plugins>
+  <plugin version="1">
+    <name>stlaurent_indices_pi</name>
+    <version>1.0.4</version>
+    <release>1</release>
+    <summary>Indices Saint-Laurent — météo-marine ECCC/RDWPS</summary>
+    <api-version>1.16</api-version>
+    <author>André Plante</author>
+    <description>
+      Affiche les indices météo-marins du Saint-Laurent produits par
+      iMeteo.ca a à partir des données GRIB d'Environnement et Changement climatique Canada
+      sur la carte nautique OpenCPN : indice d'agitation, flèches de direction,
+      palette de couleurs 20 niveaux, navigation entre 48 pas de temps.
+    </description>
+    <git>https://github.com/toutoumeteo/stlaurent_indices_pi</git>
+    <source>https://github.com/toutoumeteo/stlaurent_indices_pi/releases</source>
+    <tarball-url>https://dl.cloudsmith.io/public/imeteo/stlaurent-indices-pi/raw/files/stlaurent_indices_pi-1.0.4-win-x86_64.zip</tarball-url>
+    <tarball-checksum>sha256:b096891f04b74506ebb6b1dee3c685cae79af635520160a5ca2c2b660e665b7d</tarball-checksum>
+    <info-url>https://github.com/toutoumeteo/stlaurent_indices_pi</info-url>
+    <target>msvc-wx32</target>
+    <target-version>10</target-version>
+    <target-arch>x86_64</target-arch>
+    <target-archs>x86_64</target-archs>
+  </plugin>
+</plugins>


### PR DESCRIPTION
Plugin for displaying marine agitation indices for the St. Lawrence River and Gulf, on OpenCPN chart canvas.

Color overlay with 20-level. Direction arrows 48-step forecast navigation
Platforms: Ubuntu 24.04 x86_64, macOS arm64, Windows x86_64

Sample data can be found here:

https://imeteo.ca/sample_data/GRIB_Agitation_20260603-20260604.grib2
<img width="1068" height="685" alt="Capture d’écran, le 2026-06-03 à 12 01 40" src="https://github.com/user-attachments/assets/4afa7239-e53d-4839-8956-2ede9c058228" />
<img width="318" height="238" alt="Capture d’écran, le 2026-06-03 à 12 02 45" src="https://github.com/user-attachments/assets/1594226d-0630-47f1-9818-d80be49599b8" />
