### PR TITLE
Add xGRIB 0.2.0.0 to Alpha catalogue

### DIFF
--- a/metadata/xgrib_pi-0.2.0.0-darwin-wx32-arm64-15.3.2-macos-arm64.xml
+++ b/metadata/xgrib_pi-0.2.0.0-darwin-wx32-arm64-15.3.2-macos-arm64.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+  <name> xGRIB </name>
+  <version> 0.2.0.0 </version>
+  <release> 0 </release>
+  <summary> Display, download, and generate environmental GRIB files. </summary>
+
+  <api-version> 1.21 </api-version>
+  <open-source> yes </open-source>
+  <author> Paul </author>
+  <source> https://github.com/pob220/xgrib_pi </source>
+
+  <description>
+    A catalogue-installable GRIB viewer with integrated generation of combined weather, wave, and current GRIB files using an isolated native helper.
+  </description>
+
+  <target>darwin-wx32</target>
+  <build-target>darwin</build-target>
+  <build-gtk></build-gtk>
+  <target-version>15.3.2</target-version>
+  <target-arch>arm64</target-arch>
+  <tarball-url>
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.0.0-darwin-wx32-15.3.2-tarball/versions/0.2.0.0+287.c098c9c/xgrib_pi-0.2.0.0-darwin-wx32-arm64-15.3.2-macos-arm64.tar.gz
+  </tarball-url>
+  <info-url> https://github.com/pob220/xgrib_pi </info-url>
+</plugin>

--- a/metadata/xgrib_pi-0.2.0.0-debian-x86_64-12-bookworm.xml
+++ b/metadata/xgrib_pi-0.2.0.0-debian-x86_64-12-bookworm.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+  <name> xGRIB </name>
+  <version> 0.2.0.0 </version>
+  <release> 0 </release>
+  <summary> Display, download, and generate environmental GRIB files. </summary>
+
+  <api-version> 1.21 </api-version>
+  <open-source> yes </open-source>
+  <author> Paul </author>
+  <source> https://github.com/pob220/xgrib_pi </source>
+
+  <description>
+    A catalogue-installable GRIB viewer with integrated generation of combined weather, wave, and current GRIB files using an isolated native helper.
+  </description>
+
+  <target>debian-x86_64</target>
+  <build-target>debian</build-target>
+  <build-gtk>gtk3</build-gtk>
+  <target-version>12</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url>
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.0.0-debian-x86_64-12-tarball/versions/0.2.0.0+287.c098c9c/xgrib_pi-0.2.0.0-debian-x86_64-12-bookworm.tar.gz
+  </tarball-url>
+  <info-url> https://github.com/pob220/xgrib_pi </info-url>
+</plugin>

--- a/metadata/xgrib_pi-0.2.0.0-debian-x86_64-13-trixie.xml
+++ b/metadata/xgrib_pi-0.2.0.0-debian-x86_64-13-trixie.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+  <name> xGRIB </name>
+  <version> 0.2.0.0 </version>
+  <release> 0 </release>
+  <summary> Display, download, and generate environmental GRIB files. </summary>
+
+  <api-version> 1.21 </api-version>
+  <open-source> yes </open-source>
+  <author> Paul </author>
+  <source> https://github.com/pob220/xgrib_pi </source>
+
+  <description>
+    A catalogue-installable GRIB viewer with integrated generation of combined weather, wave, and current GRIB files using an isolated native helper.
+  </description>
+
+  <target>debian-x86_64</target>
+  <build-target>debian</build-target>
+  <build-gtk>gtk3</build-gtk>
+  <target-version>13</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url>
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.0.0-debian-x86_64-13-tarball/versions/0.2.0.0+287.c098c9c/xgrib_pi-0.2.0.0-debian-x86_64-13-trixie.tar.gz
+  </tarball-url>
+  <info-url> https://github.com/pob220/xgrib_pi </info-url>
+</plugin>

--- a/metadata/xgrib_pi-0.2.0.0-flatpak-x86_64-25.08-flatpak.xml
+++ b/metadata/xgrib_pi-0.2.0.0-flatpak-x86_64-25.08-flatpak.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+  <name> xGRIB </name>
+  <version> 0.2.0.0 </version>
+  <release> 0 </release>
+  <summary> Display, download, and generate environmental GRIB files. </summary>
+
+  <api-version> 1.21 </api-version>
+  <open-source> yes </open-source>
+  <author> Paul </author>
+  <source> https://github.com/pob220/xgrib_pi </source>
+
+  <description>
+    A catalogue-installable GRIB viewer with integrated generation of combined weather, wave, and current GRIB files using an isolated native helper.
+  </description>
+
+  <target>flatpak-x86_64</target>
+  <build-target>flatpak</build-target>
+  <build-gtk></build-gtk>
+  <target-version>25.08</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url>
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.0.0-flatpak-x86_64-25.08-tarball/versions/0.2.0.0+287.c098c9c/xgrib_pi-0.2.0.0-x86_64_flatpak-25.08.tar.gz
+  </tarball-url>
+  <info-url> https://github.com/pob220/xgrib_pi </info-url>
+</plugin>

--- a/metadata/xgrib_pi-0.2.0.0-msvc-x86-wx32-10.0.20348-MSVC.xml
+++ b/metadata/xgrib_pi-0.2.0.0-msvc-x86-wx32-10.0.20348-MSVC.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+  <name> xGRIB </name>
+  <version> 0.2.0.0 </version>
+  <release> 0 </release>
+  <summary> Display, download, and generate environmental GRIB files. </summary>
+
+  <api-version> 1.21 </api-version>
+  <open-source> yes </open-source>
+  <author> Paul </author>
+  <source> https://github.com/pob220/xgrib_pi </source>
+
+  <description>
+    A catalogue-installable GRIB viewer with integrated generation of combined weather, wave, and current GRIB files using an isolated native helper.
+  </description>
+
+  <target>msvc-wx32</target>
+  <build-target>msvc</build-target>
+  <build-gtk></build-gtk>
+  <target-version>10.0.20348</target-version>
+  <target-arch>x86</target-arch>
+  <tarball-url>
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.0.0-msvc-wx32-10.0.20348-tarball/versions/0.2.0.0+287.c098c9c/xgrib_pi-0.2.0.0-msvc-x86-wx32-10.0.20348-MSVC.tar.gz
+  </tarball-url>
+  <info-url> https://github.com/pob220/xgrib_pi </info-url>
+</plugin>

--- a/metadata/xgrib_pi-0.2.0.0-ubuntu-x86_64-22.04-jammy.xml
+++ b/metadata/xgrib_pi-0.2.0.0-ubuntu-x86_64-22.04-jammy.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+  <name> xGRIB </name>
+  <version> 0.2.0.0 </version>
+  <release> 0 </release>
+  <summary> Display, download, and generate environmental GRIB files. </summary>
+
+  <api-version> 1.21 </api-version>
+  <open-source> yes </open-source>
+  <author> Paul </author>
+  <source> https://github.com/pob220/xgrib_pi </source>
+
+  <description>
+    A catalogue-installable GRIB viewer with integrated generation of combined weather, wave, and current GRIB files using an isolated native helper.
+  </description>
+
+  <target>ubuntu-wx32-x86_64</target>
+  <build-target>ubuntu</build-target>
+  <build-gtk>gtk3</build-gtk>
+  <target-version>22.04</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url>
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.0.0-ubuntu-wx32-x86_64-22.04-tarball/versions/0.2.0.0+287.c098c9c/xgrib_pi-0.2.0.0-ubuntu-x86_64-22.04-jammy.tar.gz
+  </tarball-url>
+  <info-url> https://github.com/pob220/xgrib_pi </info-url>
+</plugin>

--- a/metadata/xgrib_pi-0.2.0.0-ubuntu-x86_64-24.04-gtk3-noble.xml
+++ b/metadata/xgrib_pi-0.2.0.0-ubuntu-x86_64-24.04-gtk3-noble.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+  <name> xGRIB </name>
+  <version> 0.2.0.0 </version>
+  <release> 0 </release>
+  <summary> Display, download, and generate environmental GRIB files. </summary>
+
+  <api-version> 1.21 </api-version>
+  <open-source> yes </open-source>
+  <author> Paul </author>
+  <source> https://github.com/pob220/xgrib_pi </source>
+
+  <description>
+    A catalogue-installable GRIB viewer with integrated generation of combined weather, wave, and current GRIB files using an isolated native helper.
+  </description>
+
+  <target>ubuntu-gtk3-x86_64</target>
+  <build-target>ubuntu</build-target>
+  <build-gtk>gtk3</build-gtk>
+  <target-version>24.04</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url>
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.0.0-ubuntu-gtk3-x86_64-24.04-tarball/versions/0.2.0.0+287.c098c9c/xgrib_pi-0.2.0.0-ubuntu-x86_64-24.04-gtk3-noble.tar.gz
+  </tarball-url>
+  <info-url> https://github.com/pob220/xgrib_pi </info-url>
+</plugin>


### PR DESCRIPTION
Adds xGRIB 0.2.0.0 metadata for Debian 12/13 x86-64, Ubuntu 22.04/24.04 x86-64, Flatpak 25.08 x86-64, Windows x86 and macOS ARM64.

Packages: https://cloudsmith.io/~pob220/repos/xgrib-alpha/
Source: https://github.com/pob220/xgrib_pi/tree/v0.2.0.0
CircleCI: https://app.circleci.com/pipelines/circleci/K9DC7cYmiJNgi5mJSq9gdA/9i2h2Aqn6Ti4GKHkCjT89s/45/workflows/a5b4fb7d-8ae2-46b8-9d32-cfe3759c2ce6

Validation:
- All release build, test, package, metadata, merge and output-verification jobs passed.
- Windows package installed and loaded in OpenCPN 5.14; selected paths, 64-bit helper launch, merge and combined-file reopen passed.
- OpenCPN metadata schema validation passed.
- Official URL checker: 18 URLs checked, 0 errors.
- Published SHA-256 values match the retained release manifests.

ARM Linux/Flatpak metadata is intentionally omitted pending a physical Raspberry Pi runtime test.