### PR TITLE
Add xGRIB 0.2.3.1

### DIFF
--- a/metadata/xgrib_pi-0.2.3.1-darwin-wx32-arm64-15.3.2-macos-arm64.xml
+++ b/metadata/xgrib_pi-0.2.3.1-darwin-wx32-arm64-15.3.2-macos-arm64.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+  <name> xGRIB </name>
+  <version> 0.2.3.1 </version>
+  <release> 1 </release>
+  <summary> Display, download, and generate environmental GRIB files. </summary>
+
+  <api-version> 1.21 </api-version>
+  <open-source> yes </open-source>
+  <author> Paul </author>
+  <source> https://github.com/pob220/xgrib_pi </source>
+
+  <description>
+    A catalogue-installable GRIB viewer with integrated generation of combined weather, wave, and current GRIB files using an isolated native helper.
+  </description>
+
+  <target>darwin-wx32</target>
+  <build-target>darwin</build-target>
+  <build-gtk></build-gtk>
+  <target-version>15.3.2</target-version>
+  <target-arch>arm64</target-arch>
+  <tarball-url>
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.3.1-darwin-wx32-15.3.2-tarball/versions/0.2.3.1+401.32a4465/xgrib_pi-0.2.3.1-darwin-wx32-arm64-15.3.2-macos-arm64.tar.gz
+  </tarball-url>
+  <info-url> https://github.com/pob220/xgrib_pi </info-url>
+</plugin>

--- a/metadata/xgrib_pi-0.2.3.1-debian-x86_64-12-bookworm.xml
+++ b/metadata/xgrib_pi-0.2.3.1-debian-x86_64-12-bookworm.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+  <name> xGRIB </name>
+  <version> 0.2.3.1 </version>
+  <release> 1 </release>
+  <summary> Display, download, and generate environmental GRIB files. </summary>
+
+  <api-version> 1.21 </api-version>
+  <open-source> yes </open-source>
+  <author> Paul </author>
+  <source> https://github.com/pob220/xgrib_pi </source>
+
+  <description>
+    A catalogue-installable GRIB viewer with integrated generation of combined weather, wave, and current GRIB files using an isolated native helper.
+  </description>
+
+  <target>debian-x86_64</target>
+  <build-target>debian</build-target>
+  <build-gtk>gtk3</build-gtk>
+  <target-version>12</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url>
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.3.1-debian-x86_64-12-tarball/versions/0.2.3.1+401.32a4465/xgrib_pi-0.2.3.1-debian-x86_64-12-bookworm.tar.gz
+  </tarball-url>
+  <info-url> https://github.com/pob220/xgrib_pi </info-url>
+</plugin>

--- a/metadata/xgrib_pi-0.2.3.1-debian-x86_64-13-trixie.xml
+++ b/metadata/xgrib_pi-0.2.3.1-debian-x86_64-13-trixie.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+  <name> xGRIB </name>
+  <version> 0.2.3.1 </version>
+  <release> 1 </release>
+  <summary> Display, download, and generate environmental GRIB files. </summary>
+
+  <api-version> 1.21 </api-version>
+  <open-source> yes </open-source>
+  <author> Paul </author>
+  <source> https://github.com/pob220/xgrib_pi </source>
+
+  <description>
+    A catalogue-installable GRIB viewer with integrated generation of combined weather, wave, and current GRIB files using an isolated native helper.
+  </description>
+
+  <target>debian-x86_64</target>
+  <build-target>debian</build-target>
+  <build-gtk>gtk3</build-gtk>
+  <target-version>13</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url>
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.3.1-debian-x86_64-13-tarball/versions/0.2.3.1+401.32a4465/xgrib_pi-0.2.3.1-debian-x86_64-13-trixie.tar.gz
+  </tarball-url>
+  <info-url> https://github.com/pob220/xgrib_pi </info-url>
+</plugin>

--- a/metadata/xgrib_pi-0.2.3.1-flatpak-x86_64-25.08-flatpak.xml
+++ b/metadata/xgrib_pi-0.2.3.1-flatpak-x86_64-25.08-flatpak.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+  <name> xGRIB </name>
+  <version> 0.2.3.1 </version>
+  <release> 1 </release>
+  <summary> Display, download, and generate environmental GRIB files. </summary>
+
+  <api-version> 1.21 </api-version>
+  <open-source> yes </open-source>
+  <author> Paul </author>
+  <source> https://github.com/pob220/xgrib_pi </source>
+
+  <description>
+    A catalogue-installable GRIB viewer with integrated generation of combined weather, wave, and current GRIB files using an isolated native helper.
+  </description>
+
+  <target>flatpak-x86_64</target>
+  <build-target>flatpak</build-target>
+  <build-gtk></build-gtk>
+  <target-version>25.08</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url>
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.3.1-flatpak-x86_64-25.08-tarball/versions/0.2.3.1+401.32a4465/xgrib_pi-0.2.3.1-x86_64_flatpak-25.08.tar.gz
+  </tarball-url>
+  <info-url> https://github.com/pob220/xgrib_pi </info-url>
+</plugin>

--- a/metadata/xgrib_pi-0.2.3.1-msvc-x86-wx32-10.0.20348-MSVC.xml
+++ b/metadata/xgrib_pi-0.2.3.1-msvc-x86-wx32-10.0.20348-MSVC.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+  <name> xGRIB </name>
+  <version> 0.2.3.1 </version>
+  <release> 1 </release>
+  <summary> Display, download, and generate environmental GRIB files. </summary>
+
+  <api-version> 1.21 </api-version>
+  <open-source> yes </open-source>
+  <author> Paul </author>
+  <source> https://github.com/pob220/xgrib_pi </source>
+
+  <description>
+    A catalogue-installable GRIB viewer with integrated generation of combined weather, wave, and current GRIB files using an isolated native helper.
+  </description>
+
+  <target>msvc-wx32</target>
+  <build-target>msvc</build-target>
+  <build-gtk></build-gtk>
+  <target-version>10.0.20348</target-version>
+  <target-arch>x86</target-arch>
+  <tarball-url>
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.3.1-msvc-wx32-10.0.20348-tarball/versions/0.2.3.1+401.32a4465/xgrib_pi-0.2.3.1-msvc-x86-wx32-10.0.20348-MSVC.tar.gz
+  </tarball-url>
+  <info-url> https://github.com/pob220/xgrib_pi </info-url>
+</plugin>

--- a/metadata/xgrib_pi-0.2.3.1-ubuntu-x86_64-22.04-jammy.xml
+++ b/metadata/xgrib_pi-0.2.3.1-ubuntu-x86_64-22.04-jammy.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+  <name> xGRIB </name>
+  <version> 0.2.3.1 </version>
+  <release> 1 </release>
+  <summary> Display, download, and generate environmental GRIB files. </summary>
+
+  <api-version> 1.21 </api-version>
+  <open-source> yes </open-source>
+  <author> Paul </author>
+  <source> https://github.com/pob220/xgrib_pi </source>
+
+  <description>
+    A catalogue-installable GRIB viewer with integrated generation of combined weather, wave, and current GRIB files using an isolated native helper.
+  </description>
+
+  <target>ubuntu-wx32-x86_64</target>
+  <build-target>ubuntu</build-target>
+  <build-gtk>gtk3</build-gtk>
+  <target-version>22.04</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url>
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.3.1-ubuntu-wx32-x86_64-22.04-tarball/versions/0.2.3.1+401.32a4465/xgrib_pi-0.2.3.1-ubuntu-x86_64-22.04-jammy.tar.gz
+  </tarball-url>
+  <info-url> https://github.com/pob220/xgrib_pi </info-url>
+</plugin>

--- a/metadata/xgrib_pi-0.2.3.1-ubuntu-x86_64-24.04-gtk3-noble.xml
+++ b/metadata/xgrib_pi-0.2.3.1-ubuntu-x86_64-24.04-gtk3-noble.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+  <name> xGRIB </name>
+  <version> 0.2.3.1 </version>
+  <release> 1 </release>
+  <summary> Display, download, and generate environmental GRIB files. </summary>
+
+  <api-version> 1.21 </api-version>
+  <open-source> yes </open-source>
+  <author> Paul </author>
+  <source> https://github.com/pob220/xgrib_pi </source>
+
+  <description>
+    A catalogue-installable GRIB viewer with integrated generation of combined weather, wave, and current GRIB files using an isolated native helper.
+  </description>
+
+  <target>ubuntu-gtk3-x86_64</target>
+  <build-target>ubuntu</build-target>
+  <build-gtk>gtk3</build-gtk>
+  <target-version>24.04</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url>
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.3.1-ubuntu-gtk3-x86_64-24.04-tarball/versions/0.2.3.1+401.32a4465/xgrib_pi-0.2.3.1-ubuntu-x86_64-24.04-gtk3-noble.tar.gz
+  </tarball-url>
+  <info-url> https://github.com/pob220/xgrib_pi </info-url>
+</plugin>


### PR DESCRIPTION
## Summary

Publishes xGRIB 0.2.3.1 to the OpenCPN Alpha catalogue.

This important hotfix prevents long-range offline-current generation from failing after hour 255 with the ecCodes error "setting P1: Encoding invalid". The generator now uses GRIB edition 2 whenever the forecast lead cannot be represented safely in GRIB1, while retaining GRIB1 for compatible lead times.

## Release evidence

- xGRIB tag: v0.2.3.1 at 0df306a1c677f9802a85122d5164c59c00dc2d04
- Generator tag: v0.1.5 at f17e8d27e043985138af600f4b933cffbf65fb5c
- Ordinary validation: all 11 CircleCI platform checks passed
- Gated release workflow: 6f4321b1-3e2f-4077-b4d7-a22d258ed9a4; all 11 release jobs passed and deploy-alpha succeeded after manual approval
- Cloudsmith: 18/18 release objects completed (nine metadata plus nine tarballs)
- All nine deployed metadata files pass the OpenCPN XSD and all nine tarball URLs return HTTP 200
- The seven catalogue metadata files in this PR pass the XSD and all 14 info/tarball URL checks

## Catalogue targets

- macOS arm64
- Debian 12 x86_64
- Debian 13 x86_64
- Flatpak 25.08 x86_64
- Windows MSVC x86/wx32
- Ubuntu 22.04 x86_64/wx32
- Ubuntu 24.04 x86_64/GTK3

As in the previous xGRIB Alpha publication, Debian ARM64 and Flatpak ARM64 artifacts were built and validated in CI but are intentionally omitted from catalogue metadata pending physical Raspberry Pi runtime testing.