### PR TITLE
radar_pi v5.7.2

### DIFF
--- a/metadata/Radar-v5.7.2-darwin-wx32-universal-10.xml
+++ b/metadata/Radar-v5.7.2-darwin-wx32-universal-10.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--  -->
+<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/4925 -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.7.0 </version>
+  <version> v5.7.2 </version>
   <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>debian-arm64</target>
-  <target-version>12</target-version>
-  <target-arch>arm64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.0-debian-arm64-A64-12-tarball/versions/v5.7.0/Radar-v5.7.0_debian-arm64-12-arm64.tar.gz </tarball-url>
-  <tarball-checksum> 4f3cc9afc796d54a2bb0938dd5249339494f16010540da388cf2fc7cbf9bbb76 </tarball-checksum>
+  <target>darwin-wx32</target>
+  <target-version>10</target-version>
+  <target-arch>arm64;x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.2-darwin-wx32-universal-10-tarball/versions/v5.7.2/Radar-v5.7.2_darwin-wx32-10-arm64-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> abb706cf475320b504ad4318a65412804ac2d27699f9126dbcaef64ef52d301a </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.7.2-debian-arm64-A64-12.xml
+++ b/metadata/Radar-v5.7.2-debian-arm64-A64-12.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/4805 -->
+<!--  -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.7.0 </version>
+  <version> v5.7.2 </version>
   <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>flatpak-x86_64</target>
-  <target-version>25.08</target-version>
-  <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.0-flatpak-x86_64-25.08-tarball/versions/v5.7.0/Radar-v5.7.0_flatpak-x86_64-25.08-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> c30e757408054013627e62460a8064875e3ad4eb0cf090611267f584364541e6 </tarball-checksum>
+  <target>debian-arm64</target>
+  <target-version>12</target-version>
+  <target-arch>arm64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.2-debian-arm64-A64-12-tarball/versions/v5.7.2/Radar-v5.7.2_debian-arm64-12-arm64.tar.gz </tarball-url>
+  <tarball-checksum> f12678cefc47d971b85a56c68c9d72032911612019a559e53b652ec09872f37e </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.7.2-debian-arm64-A64-13.xml
+++ b/metadata/Radar-v5.7.2-debian-arm64-A64-13.xml
@@ -2,7 +2,7 @@
 <!--  -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.7.0 </version>
+  <version> v5.7.2 </version>
   <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -29,6 +29,6 @@ such as dual radar range and Doppler.
   <target>debian-arm64</target>
   <target-version>13</target-version>
   <target-arch>arm64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.0-debian-arm64-A64-13-tarball/versions/v5.7.0/Radar-v5.7.0_debian-arm64-13-arm64.tar.gz </tarball-url>
-  <tarball-checksum> 3eca3191444db7ddcee82295b0cecf50de9e97e73526843c5d29f5ded8bfdd93 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.2-debian-arm64-A64-13-tarball/versions/v5.7.2/Radar-v5.7.2_debian-arm64-13-arm64.tar.gz </tarball-url>
+  <tarball-checksum> e9667b325f8c749b441818bd99017a2ad7f40c663ed07f9379e453753b512b66 </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.7.2-debian-armhf-A32-12.xml
+++ b/metadata/Radar-v5.7.2-debian-armhf-A32-12.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/4803 -->
+<!--  -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.7.0 </version>
+  <version> v5.7.2 </version>
   <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>darwin-wx32</target>
-  <target-version>10</target-version>
-  <target-arch>arm64;x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.0-darwin-wx32-universal-10-tarball/versions/v5.7.0/Radar-v5.7.0_darwin-wx32-10-arm64-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 6fd4d41baf25c70927ab6799218264e3044c54de95a8d3b62662a47dd6051f75 </tarball-checksum>
+  <target>debian-armhf</target>
+  <target-version>12</target-version>
+  <target-arch>armhf</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.2-debian-armhf-A32-12-tarball/versions/v5.7.2/Radar-v5.7.2_debian-armhf-12-armhf.tar.gz </tarball-url>
+  <tarball-checksum> 496f785aa98e28cfc25ffb6f3f4a733f38efa29a6e4163b5eb5f1f407003181f </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.7.2-debian-armhf-A32-13.xml
+++ b/metadata/Radar-v5.7.2-debian-armhf-A32-13.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/4799 -->
+<!--  -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.7.0 </version>
+  <version> v5.7.2 </version>
   <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>debian-x86_64</target>
-  <target-version>11</target-version>
-  <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.0-debian-x86_64-11-tarball/versions/v5.7.0/Radar-v5.7.0_debian-x86_64-11-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 135a7e9c64a1ceb0058ee41b969f93d3c322e4c2bd1805d8e2c9882748f1e874 </tarball-checksum>
+  <target>debian-armhf</target>
+  <target-version>13</target-version>
+  <target-arch>armhf</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.2-debian-armhf-A32-13-tarball/versions/v5.7.2/Radar-v5.7.2_debian-armhf-13-armhf.tar.gz </tarball-url>
+  <tarball-checksum> 824687ac27b3482c7e7ff3abdcec24c9699e8590a1039ac204c2b45a9471736b </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.7.2-debian-wx32-x86_64-11.xml
+++ b/metadata/Radar-v5.7.2-debian-wx32-x86_64-11.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/4806 -->
+<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/4935 -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.7.0 </version>
+  <version> v5.7.2 </version>
   <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>flatpak-x86_64</target>
-  <target-version>22.08</target-version>
+  <target>debian-wx32-x86_64</target>
+  <target-version>11</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.0-flatpak-x86_64-22.08-tarball/versions/v5.7.0/Radar-v5.7.0_flatpak-x86_64-22.08-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 6caeb28a980ba64ced7f7352228646aa48b1a58e6f176cb3f4d3fa34f9e2d210 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.2-debian-wx32-x86_64-11-tarball/versions/v5.7.2/Radar-v5.7.2_debian-wx32-x86_64-11-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 5da9103e59129a88f12a53ba83de8ea336427258aa9d6ec9ca9e1c53ff385112 </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.7.2-debian-x86_64-11.xml
+++ b/metadata/Radar-v5.7.2-debian-x86_64-11.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--  -->
+<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/4932 -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.7.0 </version>
+  <version> v5.7.2 </version>
   <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -27,8 +27,8 @@ such as dual radar range and Doppler.
  </description>
 
   <target>debian-x86_64</target>
-  <target-version>13</target-version>
+  <target-version>11</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.0-debian-x86_64-13-tarball/versions/v5.7.0/Radar-v5.7.0_debian-x86_64-13-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 728197bb52bdf6d7299cfdc9f8fd884c73ef8ec620fb0be9870ea5aa736c7a93 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.2-debian-x86_64-11-tarball/versions/v5.7.2/Radar-v5.7.2_debian-x86_64-11-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> e99f2a34fd392ebf6c8bba4711f4ee36d8c014cfc683b0f1e49cdb28033d3e70 </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.7.2-debian-x86_64-12.xml
+++ b/metadata/Radar-v5.7.2-debian-x86_64-12.xml
@@ -2,7 +2,7 @@
 <!--  -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.7.0 </version>
+  <version> v5.7.2 </version>
   <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>debian-armhf</target>
+  <target>debian-x86_64</target>
   <target-version>12</target-version>
-  <target-arch>armhf</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.0-debian-armhf-A32-12-tarball/versions/v5.7.0/Radar-v5.7.0_debian-armhf-12-armhf.tar.gz </tarball-url>
-  <tarball-checksum> 2dd24b56902a2d3d8ed7eac88cf10cce8e7726fb935c721d881e606b4a3c20fc </tarball-checksum>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.2-debian-x86_64-12-tarball/versions/v5.7.2/Radar-v5.7.2_debian-x86_64-12-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 27b13d72dbf2a646e29b254c898a53fb758c529b196caad53cb27a5a16a5dcbe </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.7.2-debian-x86_64-13.xml
+++ b/metadata/Radar-v5.7.2-debian-x86_64-13.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/4809 -->
+<!--  -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.7.0 </version>
+  <version> v5.7.2 </version>
   <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>flatpak-x86_64</target>
-  <target-version>24.08</target-version>
+  <target>debian-x86_64</target>
+  <target-version>13</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.0-flatpak-x86_64-24.08-tarball/versions/v5.7.0/Radar-v5.7.0_flatpak-x86_64-24.08-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> a205aa809bc97402c1ef399279d213dd0914b85b0e9d40c06f3de410bf3a61d3 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.2-debian-x86_64-13-tarball/versions/v5.7.2/Radar-v5.7.2_debian-x86_64-13-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 5925cd4da1e2c707cd410b06b932cca50059d658a3210d10034c76648a65aa56 </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.7.2-flatpak-aarch64-A64-22.08.xml
+++ b/metadata/Radar-v5.7.2-flatpak-aarch64-A64-22.08.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/4798 -->
+<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/4920 -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.7.0 </version>
+  <version> v5.7.2 </version>
   <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -27,8 +27,8 @@ such as dual radar range and Doppler.
  </description>
 
   <target>flatpak-aarch64</target>
-  <target-version>24.08</target-version>
+  <target-version>22.08</target-version>
   <target-arch>aarch64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.0-flatpak-aarch64-A64-24.08-tarball/versions/v5.7.0/Radar-v5.7.0_flatpak-aarch64-24.08-aarch64.tar.gz </tarball-url>
-  <tarball-checksum> 71991b5da3ff0b46077971157a78cac56d508da5fd2ee973b35690213d415908 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.2-flatpak-aarch64-A64-22.08-tarball/versions/v5.7.2/Radar-v5.7.2_flatpak-aarch64-22.08-aarch64.tar.gz </tarball-url>
+  <tarball-checksum> 2eb5765285aab2c3a4ca874f705c446bfefe22a46db6b4dec8fbf5e293224210 </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.7.2-flatpak-aarch64-A64-24.08.xml
+++ b/metadata/Radar-v5.7.2-flatpak-aarch64-A64-24.08.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/4795 -->
+<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/4929 -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.7.0 </version>
+  <version> v5.7.2 </version>
   <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -27,8 +27,8 @@ such as dual radar range and Doppler.
  </description>
 
   <target>flatpak-aarch64</target>
-  <target-version>25.08</target-version>
+  <target-version>24.08</target-version>
   <target-arch>aarch64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.0-flatpak-aarch64-A64-25.08-tarball/versions/v5.7.0/Radar-v5.7.0_flatpak-aarch64-25.08-aarch64.tar.gz </tarball-url>
-  <tarball-checksum> 22563f6410e33ff9de5417fefa30d8a4e0af0b0f74b58b459c992974189dbb57 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.2-flatpak-aarch64-A64-24.08-tarball/versions/v5.7.2/Radar-v5.7.2_flatpak-aarch64-24.08-aarch64.tar.gz </tarball-url>
+  <tarball-checksum> 51135591a0ab266ae33dc12907abccae12313376e1ad2b484d3c016be57cba4a </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.7.2-flatpak-aarch64-A64-25.08.xml
+++ b/metadata/Radar-v5.7.2-flatpak-aarch64-A64-25.08.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/4801 -->
+<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/4923 -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.7.0 </version>
+  <version> v5.7.2 </version>
   <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>debian-wx32-x86_64</target>
-  <target-version>11</target-version>
-  <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.0-debian-wx32-x86_64-11-tarball/versions/v5.7.0/Radar-v5.7.0_debian-wx32-x86_64-11-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> f22803005e92ce9230f1796a4a8297c3e26506e486d33612a6a705750073f5ac </tarball-checksum>
+  <target>flatpak-aarch64</target>
+  <target-version>25.08</target-version>
+  <target-arch>aarch64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.2-flatpak-aarch64-A64-25.08-tarball/versions/v5.7.2/Radar-v5.7.2_flatpak-aarch64-25.08-aarch64.tar.gz </tarball-url>
+  <tarball-checksum> 2bff4876771b935e8f0c9323c49ddbe4a642e7e8076a289eee1e64a9a0647554 </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.7.2-flatpak-x86_64-22.08.xml
+++ b/metadata/Radar-v5.7.2-flatpak-x86_64-22.08.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--  -->
+<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/4927 -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.7.0 </version>
+  <version> v5.7.2 </version>
   <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>debian-x86_64</target>
-  <target-version>12</target-version>
+  <target>flatpak-x86_64</target>
+  <target-version>22.08</target-version>
   <target-arch>x86_64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.0-debian-x86_64-12-tarball/versions/v5.7.0/Radar-v5.7.0_debian-x86_64-12-x86_64.tar.gz </tarball-url>
-  <tarball-checksum> 8e27ec033b553e063dc2ef8770c820ec9eba009d00d13f23c391ebfda0e1aaab </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.2-flatpak-x86_64-22.08-tarball/versions/v5.7.2/Radar-v5.7.2_flatpak-x86_64-22.08-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 57ead182b6e5c93bef7fd3589f18ba5bc76bad2ebc8f51253a1cad55fbdd9b60 </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.7.2-flatpak-x86_64-24.08.xml
+++ b/metadata/Radar-v5.7.2-flatpak-x86_64-24.08.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/4807 -->
+<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/4926 -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.7.0 </version>
+  <version> v5.7.2 </version>
   <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>flatpak-aarch64</target>
-  <target-version>22.08</target-version>
-  <target-arch>aarch64</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.0-flatpak-aarch64-A64-22.08-tarball/versions/v5.7.0/Radar-v5.7.0_flatpak-aarch64-22.08-aarch64.tar.gz </tarball-url>
-  <tarball-checksum> aba2f410984127e301b243c42f0307430c635365daee54521513bc0c688d9598 </tarball-checksum>
+  <target>flatpak-x86_64</target>
+  <target-version>24.08</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.2-flatpak-x86_64-24.08-tarball/versions/v5.7.2/Radar-v5.7.2_flatpak-x86_64-24.08-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> d1952ad45cede15a59b1d88806b5257aa9dc7fdbc81e13c9ebc59db5ae86b88b </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.7.2-flatpak-x86_64-25.08.xml
+++ b/metadata/Radar-v5.7.2-flatpak-x86_64-25.08.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--  -->
+<!-- https://circleci.com/gh/opencpn-radar-pi/radar_pi/4921 -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.7.0 </version>
+  <version> v5.7.2 </version>
   <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -26,9 +26,9 @@ Guard zones, AIS overlay on PPI, and various radar dependent features
 such as dual radar range and Doppler.
  </description>
 
-  <target>debian-armhf</target>
-  <target-version>13</target-version>
-  <target-arch>armhf</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.0-debian-armhf-A32-13-tarball/versions/v5.7.0/Radar-v5.7.0_debian-armhf-13-armhf.tar.gz </tarball-url>
-  <tarball-checksum> 9114c84583dac53499126b46fa0d304ebb531b6daa6c735f917e7d0a77b784db </tarball-checksum>
+  <target>flatpak-x86_64</target>
+  <target-version>25.08</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.2-flatpak-x86_64-25.08-tarball/versions/v5.7.2/Radar-v5.7.2_flatpak-x86_64-25.08-x86_64.tar.gz </tarball-url>
+  <tarball-checksum> 14e37e3bfd349ff87ee3d7ca25a54f7a7fcda4e0bd5a33bc03981c8c39f1eb14 </tarball-checksum>
 </plugin>

--- a/metadata/Radar-v5.7.2-msvc-wx32-10.xml
+++ b/metadata/Radar-v5.7.2-msvc-wx32-10.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://ci.appveyor.com/project/keesverruijt/radar-pi/builds/53978183 -->
+<!-- https://ci.appveyor.com/project/keesverruijt/radar-pi/builds/54475686 -->
 <plugin version="1">
   <name> Radar </name>
-  <version> v5.7.0 </version>
+  <version> v5.7.2 </version>
   <release> 0 </release>
   <summary> Overlays the radar picture on OpenCPN </summary>
 
@@ -29,6 +29,6 @@ such as dual radar range and Doppler.
   <target>msvc-wx32</target>
   <target-version>10</target-version>
   <target-arch>x86</target-arch>
-  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.0-msvc-wx32-10-tarball/versions/v5.7.0/Radar-v5.7.0_msvc-wx32-10-x86.tar.gz </tarball-url>
-  <tarball-checksum> 48bb8b316a8c7ce2dd75109f616ca1ac7edd7595ab0ce63f493153d35a7f8358 </tarball-checksum>
+  <tarball-url> https://dl.cloudsmith.io/public/opencpn-radar-pi/radar-prod/raw/names/Radar-v5.7.2-msvc-wx32-10-tarball/versions/v5.7.2/Radar-v5.7.2_msvc-wx32-10-x86.tar.gz </tarball-url>
+  <tarball-checksum> 7ba150fc3c955c7ef78bad9fd930fac2e673ea219506f9eeabe1304fb8f3ebdc </tarball-checksum>
 </plugin>


### PR DESCRIPTION
Next radar_pi patch release. Fixes a Garmin xHD dual range issue and a radar locator thread failure on some Linux systems.

The obsolete Darwin non-universal build stays removed, as in 7197791f.