### PR TITLE
Add OfflineTides 1.0.2.0 to Alpha catalogue

### DIFF
--- a/metadata/offlinetides_pi-1.0.2.0-debian-x86_64-12-bookworm.xml
+++ b/metadata/offlinetides_pi-1.0.2.0-debian-x86_64-12-bookworm.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+  <name> OfflineTides </name>
+  <version> 1.0.2.0 </version>
+  <release> 0 </release>
+  <summary> Offline tidal-height forecasts from authenticated .xtdt packages. </summary>
+
+  <api-version> 1.21 </api-version>
+  <open-source> yes </open-source>
+  <author> Paul (pob220) </author>
+  <source> https://github.com/pob220/offlinetides_pi </source>
+
+  <description>
+    OfflineTides predicts offline water-level height at the chart cursor, an OpenCPN waypoint or mark, or manual WGS84 coordinates. It displays datum-labelled rolling or selected-date curves, interpolated high and low water events, local data quality and daylight-saving-aware display times while retaining UTC internally.
+  </description>
+
+  <target>debian-x86_64</target>
+  <build-target>debian</build-target>
+  <build-gtk>gtk3</build-gtk>
+  <target-version>12</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url>
+    https://github.com/pob220/offlinetides_pi/releases/download/v1.0.2.0-alpha1/offlinetides_pi-1.0.2.0-debian-x86_64-12-bookworm.tar.gz
+  </tarball-url>
+  <info-url> https://github.com/pob220/offlinetides_pi </info-url>
+</plugin>

--- a/metadata/offlinetides_pi-1.0.2.0-debian-x86_64-13-trixie.xml
+++ b/metadata/offlinetides_pi-1.0.2.0-debian-x86_64-13-trixie.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+  <name> OfflineTides </name>
+  <version> 1.0.2.0 </version>
+  <release> 0 </release>
+  <summary> Offline tidal-height forecasts from authenticated .xtdt packages. </summary>
+
+  <api-version> 1.21 </api-version>
+  <open-source> yes </open-source>
+  <author> Paul (pob220) </author>
+  <source> https://github.com/pob220/offlinetides_pi </source>
+
+  <description>
+    OfflineTides predicts offline water-level height at the chart cursor, an OpenCPN waypoint or mark, or manual WGS84 coordinates. It displays datum-labelled rolling or selected-date curves, interpolated high and low water events, local data quality and daylight-saving-aware display times while retaining UTC internally.
+  </description>
+
+  <target>debian-x86_64</target>
+  <build-target>debian</build-target>
+  <build-gtk>gtk3</build-gtk>
+  <target-version>13</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url>
+    https://github.com/pob220/offlinetides_pi/releases/download/v1.0.2.0-alpha1/offlinetides_pi-1.0.2.0-debian-x86_64-13-trixie.tar.gz
+  </tarball-url>
+  <info-url> https://github.com/pob220/offlinetides_pi </info-url>
+</plugin>

--- a/metadata/offlinetides_pi-1.0.2.0-ubuntu-x86_64-22.04-jammy.xml
+++ b/metadata/offlinetides_pi-1.0.2.0-ubuntu-x86_64-22.04-jammy.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+  <name> OfflineTides </name>
+  <version> 1.0.2.0 </version>
+  <release> 0 </release>
+  <summary> Offline tidal-height forecasts from authenticated .xtdt packages. </summary>
+
+  <api-version> 1.21 </api-version>
+  <open-source> yes </open-source>
+  <author> Paul (pob220) </author>
+  <source> https://github.com/pob220/offlinetides_pi </source>
+
+  <description>
+    OfflineTides predicts offline water-level height at the chart cursor, an OpenCPN waypoint or mark, or manual WGS84 coordinates. It displays datum-labelled rolling or selected-date curves, interpolated high and low water events, local data quality and daylight-saving-aware display times while retaining UTC internally.
+  </description>
+
+  <target>ubuntu-x86_64</target>
+  <build-target>ubuntu</build-target>
+  <build-gtk>gtk3</build-gtk>
+  <target-version>22.04</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url>
+    https://github.com/pob220/offlinetides_pi/releases/download/v1.0.2.0-alpha1/offlinetides_pi-1.0.2.0-ubuntu-x86_64-22.04-jammy.tar.gz
+  </tarball-url>
+  <info-url> https://github.com/pob220/offlinetides_pi </info-url>
+</plugin>

--- a/metadata/offlinetides_pi-1.0.2.0-ubuntu-x86_64-22.04-jammy.xml
+++ b/metadata/offlinetides_pi-1.0.2.0-ubuntu-x86_64-22.04-jammy.xml
@@ -14,7 +14,7 @@
     OfflineTides predicts offline water-level height at the chart cursor, an OpenCPN waypoint or mark, or manual WGS84 coordinates. It displays datum-labelled rolling or selected-date curves, interpolated high and low water events, local data quality and daylight-saving-aware display times while retaining UTC internally.
   </description>
 
-  <target>ubuntu-x86_64</target>
+  <target>ubuntu-wx32-x86_64</target>
   <build-target>ubuntu</build-target>
   <build-gtk>gtk3</build-gtk>
   <target-version>22.04</target-version>

--- a/metadata/offlinetides_pi-1.0.2.0-ubuntu-x86_64-24.04-noble.xml
+++ b/metadata/offlinetides_pi-1.0.2.0-ubuntu-x86_64-24.04-noble.xml
@@ -14,7 +14,7 @@
     OfflineTides predicts offline water-level height at the chart cursor, an OpenCPN waypoint or mark, or manual WGS84 coordinates. It displays datum-labelled rolling or selected-date curves, interpolated high and low water events, local data quality and daylight-saving-aware display times while retaining UTC internally.
   </description>
 
-  <target>ubuntu-x86_64</target>
+  <target>ubuntu-gtk3-x86_64</target>
   <build-target>ubuntu</build-target>
   <build-gtk>gtk3</build-gtk>
   <target-version>24.04</target-version>

--- a/metadata/offlinetides_pi-1.0.2.0-ubuntu-x86_64-24.04-noble.xml
+++ b/metadata/offlinetides_pi-1.0.2.0-ubuntu-x86_64-24.04-noble.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+  <name> OfflineTides </name>
+  <version> 1.0.2.0 </version>
+  <release> 0 </release>
+  <summary> Offline tidal-height forecasts from authenticated .xtdt packages. </summary>
+
+  <api-version> 1.21 </api-version>
+  <open-source> yes </open-source>
+  <author> Paul (pob220) </author>
+  <source> https://github.com/pob220/offlinetides_pi </source>
+
+  <description>
+    OfflineTides predicts offline water-level height at the chart cursor, an OpenCPN waypoint or mark, or manual WGS84 coordinates. It displays datum-labelled rolling or selected-date curves, interpolated high and low water events, local data quality and daylight-saving-aware display times while retaining UTC internally.
+  </description>
+
+  <target>ubuntu-x86_64</target>
+  <build-target>ubuntu</build-target>
+  <build-gtk>gtk3</build-gtk>
+  <target-version>24.04</target-version>
+  <target-arch>x86_64</target-arch>
+  <tarball-url>
+    https://github.com/pob220/offlinetides_pi/releases/download/v1.0.2.0-alpha1/offlinetides_pi-1.0.2.0-ubuntu-x86_64-24.04-noble.tar.gz
+  </tarball-url>
+  <info-url> https://github.com/pob220/offlinetides_pi </info-url>
+</plugin>


### PR DESCRIPTION
## Summary

Adds the first public Alpha catalogue entries for OfflineTides 1.0.2.0.

OfflineTides provides offline astronomical tidal-height forecasts from a self-contained global `.xtdt` data package, including datum-labelled curves, HW/LW events, selectable dates and positions, native OpenCPN station comparison, and JSON/CSV export.

## Platforms

- Ubuntu 24.04 x86_64
- Ubuntu 22.04 x86_64
- Debian 13 x86_64
- Debian 12 x86_64

## Qualification

- All four CircleCI package jobs passed their five-test suites.
- All metadata entries pass `ocpn-plugins.xsd` validation.
- The OpenCPN metadata generator accepts all four entries.
- OpenCPN's URL checker reports 8 URLs checked and 0 errors.
- Each anonymously downloaded release tarball matches its published SHA-256 digest.
- Each package contains one `libofflinetides_pi.so` under the standard OpenCPN plugin path.

Release: https://github.com/pob220/offlinetides_pi/releases/tag/v1.0.2.0-alpha1

The separate global data archive is supplied on the release page and is intentionally not bundled into the small platform packages.
