### PR TITLE
Add Mayara plugin metadata

### DIFF
--- a/metadata/mayara_pi-0.1.0.0-darwin-wx32-arm64-x86_64-14.8.7-macos.xml
+++ b/metadata/mayara_pi-0.1.0.0-darwin-wx32-arm64-x86_64-14.8.7-macos.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Mayara </name>
+<version> 0.1.0.0 </version>
+<release> 0 </release>
+<summary> Marine radar overlay and PPI, served by mayara-server </summary>
+
+<api-version> 1.21 </api-version>
+<open-source> yes </open-source>
+<author> opencpn-radar-pi </author>
+<source> https://github.com/opencpn-radar-pi/mayara_pi </source>
+
+<description>
+mayara_pi displays marine radar as a chart overlay and in a PPI window. Unlike radar_pi it does not talk to radar hardware directly; it consumes the mayara-server REST and WebSocket API, which supports Navico, Garmin, Furuno and Raymarine radars.
+</description>
+
+<target>darwin-wx32</target>
+<build-target>darwin</build-target>
+<build-gtk></build-gtk>
+<target-version>14.8.7</target-version>
+<target-arch>arm64;x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.0.0-darwin-wx32-arm64-x86_64-14.8.7-macos-tarball/versions/0.1.0.0+100.e125946/mayara_pi-0.1.0.0-darwin-wx32-arm64-x86_64-14.8.7-macos.tar.gz
+</tarball-url>
+<info-url> https://github.com/opencpn-radar-pi/mayara_pi </info-url>
+</plugin>

--- a/metadata/mayara_pi-0.1.0.0-debian-arm64-12-bookworm.xml
+++ b/metadata/mayara_pi-0.1.0.0-debian-arm64-12-bookworm.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Mayara </name>
+<version> 0.1.0.0 </version>
+<release> 0 </release>
+<summary> Marine radar overlay and PPI, served by mayara-server </summary>
+
+<api-version> 1.21 </api-version>
+<open-source> yes </open-source>
+<author> opencpn-radar-pi </author>
+<source> https://github.com/opencpn-radar-pi/mayara_pi </source>
+
+<description>
+mayara_pi displays marine radar as a chart overlay and in a PPI window. Unlike radar_pi it does not talk to radar hardware directly; it consumes the mayara-server REST and WebSocket API, which supports Navico, Garmin, Furuno and Raymarine radars.
+</description>
+
+<target>debian-arm64</target>
+<build-target>debian</build-target>
+<build-gtk>gtk3</build-gtk>
+<target-version>12</target-version>
+<target-arch>arm64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.0.0-debian-arm64-12-bookworm-tarball/versions/0.1.0.0+100.e125946/mayara_pi-0.1.0.0-debian-arm64-12-bookworm.tar.gz
+</tarball-url>
+<info-url> https://github.com/opencpn-radar-pi/mayara_pi </info-url>
+</plugin>

--- a/metadata/mayara_pi-0.1.0.0-debian-arm64-13-trixie.xml
+++ b/metadata/mayara_pi-0.1.0.0-debian-arm64-13-trixie.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Mayara </name>
+<version> 0.1.0.0 </version>
+<release> 0 </release>
+<summary> Marine radar overlay and PPI, served by mayara-server </summary>
+
+<api-version> 1.21 </api-version>
+<open-source> yes </open-source>
+<author> opencpn-radar-pi </author>
+<source> https://github.com/opencpn-radar-pi/mayara_pi </source>
+
+<description>
+mayara_pi displays marine radar as a chart overlay and in a PPI window. Unlike radar_pi it does not talk to radar hardware directly; it consumes the mayara-server REST and WebSocket API, which supports Navico, Garmin, Furuno and Raymarine radars.
+</description>
+
+<target>debian-arm64</target>
+<build-target>debian</build-target>
+<build-gtk>gtk3</build-gtk>
+<target-version>13</target-version>
+<target-arch>arm64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.0.0-debian-arm64-13-trixie-tarball/versions/0.1.0.0+100.e125946/mayara_pi-0.1.0.0-debian-arm64-13-trixie.tar.gz
+</tarball-url>
+<info-url> https://github.com/opencpn-radar-pi/mayara_pi </info-url>
+</plugin>

--- a/metadata/mayara_pi-0.1.0.0-debian-x86_64-12-bookworm.xml
+++ b/metadata/mayara_pi-0.1.0.0-debian-x86_64-12-bookworm.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Mayara </name>
+<version> 0.1.0.0 </version>
+<release> 0 </release>
+<summary> Marine radar overlay and PPI, served by mayara-server </summary>
+
+<api-version> 1.21 </api-version>
+<open-source> yes </open-source>
+<author> opencpn-radar-pi </author>
+<source> https://github.com/opencpn-radar-pi/mayara_pi </source>
+
+<description>
+mayara_pi displays marine radar as a chart overlay and in a PPI window. Unlike radar_pi it does not talk to radar hardware directly; it consumes the mayara-server REST and WebSocket API, which supports Navico, Garmin, Furuno and Raymarine radars.
+</description>
+
+<target>debian-x86_64</target>
+<build-target>debian</build-target>
+<build-gtk>gtk3</build-gtk>
+<target-version>12</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.0.0-debian-x86_64-12-bookworm-tarball/versions/0.1.0.0+100.e125946/mayara_pi-0.1.0.0-debian-x86_64-12-bookworm.tar.gz
+</tarball-url>
+<info-url> https://github.com/opencpn-radar-pi/mayara_pi </info-url>
+</plugin>

--- a/metadata/mayara_pi-0.1.0.0-debian-x86_64-13-trixie.xml
+++ b/metadata/mayara_pi-0.1.0.0-debian-x86_64-13-trixie.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Mayara </name>
+<version> 0.1.0.0 </version>
+<release> 0 </release>
+<summary> Marine radar overlay and PPI, served by mayara-server </summary>
+
+<api-version> 1.21 </api-version>
+<open-source> yes </open-source>
+<author> opencpn-radar-pi </author>
+<source> https://github.com/opencpn-radar-pi/mayara_pi </source>
+
+<description>
+mayara_pi displays marine radar as a chart overlay and in a PPI window. Unlike radar_pi it does not talk to radar hardware directly; it consumes the mayara-server REST and WebSocket API, which supports Navico, Garmin, Furuno and Raymarine radars.
+</description>
+
+<target>debian-x86_64</target>
+<build-target>debian</build-target>
+<build-gtk>gtk3</build-gtk>
+<target-version>13</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.0.0-debian-x86_64-13-trixie-tarball/versions/0.1.0.0+100.e125946/mayara_pi-0.1.0.0-debian-x86_64-13-trixie.tar.gz
+</tarball-url>
+<info-url> https://github.com/opencpn-radar-pi/mayara_pi </info-url>
+</plugin>

--- a/metadata/mayara_pi-0.1.0.0-debian-x86_64-24.04-noble.xml
+++ b/metadata/mayara_pi-0.1.0.0-debian-x86_64-24.04-noble.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Mayara </name>
+<version> 0.1.0.0 </version>
+<release> 0 </release>
+<summary> Marine radar overlay and PPI, served by mayara-server </summary>
+
+<api-version> 1.21 </api-version>
+<open-source> yes </open-source>
+<author> opencpn-radar-pi </author>
+<source> https://github.com/opencpn-radar-pi/mayara_pi </source>
+
+<description>
+mayara_pi displays marine radar as a chart overlay and in a PPI window. Unlike radar_pi it does not talk to radar hardware directly; it consumes the mayara-server REST and WebSocket API, which supports Navico, Garmin, Furuno and Raymarine radars.
+</description>
+
+<target>debian-x86_64</target>
+<build-target>debian</build-target>
+<build-gtk>gtk3</build-gtk>
+<target-version>24.04</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.0.0-debian-x86_64-24.04-noble-tarball/versions/0.1.0.0+100.e125946/mayara_pi-0.1.0.0-debian-x86_64-24.04-noble.tar.gz
+</tarball-url>
+<info-url> https://github.com/opencpn-radar-pi/mayara_pi </info-url>
+</plugin>

--- a/metadata/mayara_pi-0.1.0.0-flatpak-aarch64-25.08-flatpak.xml
+++ b/metadata/mayara_pi-0.1.0.0-flatpak-aarch64-25.08-flatpak.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Mayara </name>
+<version> 0.1.0.0 </version>
+<release> 0 </release>
+<summary> Marine radar overlay and PPI, served by mayara-server </summary>
+
+<api-version> 1.21 </api-version>
+<open-source> yes </open-source>
+<author> opencpn-radar-pi </author>
+<source> https://github.com/opencpn-radar-pi/mayara_pi </source>
+
+<description>
+mayara_pi displays marine radar as a chart overlay and in a PPI window. Unlike radar_pi it does not talk to radar hardware directly; it consumes the mayara-server REST and WebSocket API, which supports Navico, Garmin, Furuno and Raymarine radars.
+</description>
+
+<target>flatpak-aarch64</target>
+<build-target>flatpak</build-target>
+<build-gtk></build-gtk>
+<target-version>25.08</target-version>
+<target-arch>aarch64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.0.0-flatpak-aarch64-25.08-flatpak-tarball/versions/0.1.0.0+100.e125946/mayara_pi-0.1.0.0-aarch64_flatpak-25.08.tar.gz
+</tarball-url>
+<info-url> https://github.com/opencpn-radar-pi/mayara_pi </info-url>
+</plugin>

--- a/metadata/mayara_pi-0.1.0.0-flatpak-x86_64-25.08-flatpak.xml
+++ b/metadata/mayara_pi-0.1.0.0-flatpak-x86_64-25.08-flatpak.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Mayara </name>
+<version> 0.1.0.0 </version>
+<release> 0 </release>
+<summary> Marine radar overlay and PPI, served by mayara-server </summary>
+
+<api-version> 1.21 </api-version>
+<open-source> yes </open-source>
+<author> opencpn-radar-pi </author>
+<source> https://github.com/opencpn-radar-pi/mayara_pi </source>
+
+<description>
+mayara_pi displays marine radar as a chart overlay and in a PPI window. Unlike radar_pi it does not talk to radar hardware directly; it consumes the mayara-server REST and WebSocket API, which supports Navico, Garmin, Furuno and Raymarine radars.
+</description>
+
+<target>flatpak-x86_64</target>
+<build-target>flatpak</build-target>
+<build-gtk></build-gtk>
+<target-version>25.08</target-version>
+<target-arch>x86_64</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.0.0-flatpak-x86_64-25.08-flatpak-tarball/versions/0.1.0.0+100.e125946/mayara_pi-0.1.0.0-x86_64_flatpak-25.08.tar.gz
+</tarball-url>
+<info-url> https://github.com/opencpn-radar-pi/mayara_pi </info-url>
+</plugin>

--- a/metadata/mayara_pi-0.1.0.0-msvc-x86-wx32-10.0.20348-MSVC.xml
+++ b/metadata/mayara_pi-0.1.0.0-msvc-x86-wx32-10.0.20348-MSVC.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin version="1">
+<name> Mayara </name>
+<version> 0.1.0.0 </version>
+<release> 0 </release>
+<summary> Marine radar overlay and PPI, served by mayara-server </summary>
+
+<api-version> 1.21 </api-version>
+<open-source> yes </open-source>
+<author> opencpn-radar-pi </author>
+<source> https://github.com/opencpn-radar-pi/mayara_pi </source>
+
+<description>
+mayara_pi displays marine radar as a chart overlay and in a PPI window. Unlike radar_pi it does not talk to radar hardware directly; it consumes the mayara-server REST and WebSocket API, which supports Navico, Garmin, Furuno and Raymarine radars.
+</description>
+
+<target>msvc-wx32</target>
+<build-target>msvc</build-target>
+<build-gtk></build-gtk>
+<target-version>10.0.20348</target-version>
+<target-arch>x86</target-arch>
+<tarball-url>
+https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.0.0-msvc-x86-wx32-10.0.20348-MSVC-tarball/versions/0.1.0.0+100.e125946/mayara_pi-0.1.0.0-msvc-x86-wx32-10.0.20348-MSVC.tar.gz
+</tarball-url>
+<info-url> https://github.com/opencpn-radar-pi/mayara_pi </info-url>
+</plugin>


### PR DESCRIPTION
## Summary
- Add cloudsmith metadata for the new `mayara_pi` plugin (build 0.1.0.0+100.e125946 from opencpn-radar-pi/mayara-beta): msvc, darwin universal, debian x86_64 (12/13/24.04), debian arm64 (12/13), and flatpak (x86_64/aarch64)
- These are in addition to the existing Radar plugin metadata, not a replacement
