### PR TITLE
Update Mayara plugin metadata to v0.1.4 (beta)

### DIFF
--- a/metadata/mayara_pi-0.1.4.0-darwin-wx32-arm64-x86_64-14.8.7-macos.xml
+++ b/metadata/mayara_pi-0.1.4.0-darwin-wx32-arm64-x86_64-14.8.7-macos.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Mayara </name>
-<version> 0.1.3.0 </version>
+<version> 0.1.4.0 </version>
 <release> 0 </release>
 <summary> Marine radar overlay and PPI, served by mayara-server </summary>
 
@@ -14,13 +14,13 @@
 mayara_pi displays marine radar as a chart overlay and in a PPI window. Unlike radar_pi it does not talk to radar hardware directly; it consumes the mayara-server REST and WebSocket API, which supports Navico, Garmin, Furuno and Raymarine radars.
 </description>
 
-<target>flatpak-aarch64</target>
-<build-target>flatpak</build-target>
+<target>darwin-wx32</target>
+<build-target>darwin</build-target>
 <build-gtk></build-gtk>
-<target-version>25.08</target-version>
-<target-arch>aarch64</target-arch>
+<target-version>14.8.7</target-version>
+<target-arch>arm64;x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.3.0-flatpak-aarch64-25.08-flatpak-tarball/versions/v0.1.3/mayara_pi-0.1.3.0-aarch64_flatpak-25.08.tar.gz
+https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.4.0-darwin-wx32-arm64-x86_64-14.8.7-macos-tarball/versions/v0.1.4/mayara_pi-0.1.4.0-darwin-wx32-arm64-x86_64-14.8.7-macos.tar.gz
 </tarball-url>
 <info-url> https://github.com/opencpn-radar-pi/mayara_pi </info-url>
 </plugin>

--- a/metadata/mayara_pi-0.1.4.0-debian-arm64-12-bookworm.xml
+++ b/metadata/mayara_pi-0.1.4.0-debian-arm64-12-bookworm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Mayara </name>
-<version> 0.1.3.0 </version>
+<version> 0.1.4.0 </version>
 <release> 0 </release>
 <summary> Marine radar overlay and PPI, served by mayara-server </summary>
 
@@ -14,13 +14,13 @@
 mayara_pi displays marine radar as a chart overlay and in a PPI window. Unlike radar_pi it does not talk to radar hardware directly; it consumes the mayara-server REST and WebSocket API, which supports Navico, Garmin, Furuno and Raymarine radars.
 </description>
 
-<target>debian-x86_64</target>
+<target>debian-arm64</target>
 <build-target>debian</build-target>
 <build-gtk>gtk3</build-gtk>
-<target-version>22.04</target-version>
-<target-arch>x86_64</target-arch>
+<target-version>12</target-version>
+<target-arch>arm64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.3.0-debian-x86_64-22.04-jammy-tarball/versions/v0.1.3/mayara_pi-0.1.3.0-debian-x86_64-22.04-jammy.tar.gz
+https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.4.0-debian-arm64-12-bookworm-tarball/versions/v0.1.4/mayara_pi-0.1.4.0-debian-arm64-12-bookworm.tar.gz
 </tarball-url>
 <info-url> https://github.com/opencpn-radar-pi/mayara_pi </info-url>
 </plugin>

--- a/metadata/mayara_pi-0.1.4.0-debian-arm64-13-trixie.xml
+++ b/metadata/mayara_pi-0.1.4.0-debian-arm64-13-trixie.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Mayara </name>
-<version> 0.1.3.0 </version>
+<version> 0.1.4.0 </version>
 <release> 0 </release>
 <summary> Marine radar overlay and PPI, served by mayara-server </summary>
 
@@ -14,13 +14,13 @@
 mayara_pi displays marine radar as a chart overlay and in a PPI window. Unlike radar_pi it does not talk to radar hardware directly; it consumes the mayara-server REST and WebSocket API, which supports Navico, Garmin, Furuno and Raymarine radars.
 </description>
 
-<target>debian-x86_64</target>
+<target>debian-arm64</target>
 <build-target>debian</build-target>
 <build-gtk>gtk3</build-gtk>
-<target-version>24.04</target-version>
-<target-arch>x86_64</target-arch>
+<target-version>13</target-version>
+<target-arch>arm64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.3.0-debian-x86_64-24.04-noble-tarball/versions/v0.1.3/mayara_pi-0.1.3.0-debian-x86_64-24.04-noble.tar.gz
+https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.4.0-debian-arm64-13-trixie-tarball/versions/v0.1.4/mayara_pi-0.1.4.0-debian-arm64-13-trixie.tar.gz
 </tarball-url>
 <info-url> https://github.com/opencpn-radar-pi/mayara_pi </info-url>
 </plugin>

--- a/metadata/mayara_pi-0.1.4.0-debian-armhf-22.04-jammy.xml
+++ b/metadata/mayara_pi-0.1.4.0-debian-armhf-22.04-jammy.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Mayara </name>
-<version> 0.1.3.0 </version>
+<version> 0.1.4.0 </version>
 <release> 0 </release>
 <summary> Marine radar overlay and PPI, served by mayara-server </summary>
 
@@ -14,13 +14,13 @@
 mayara_pi displays marine radar as a chart overlay and in a PPI window. Unlike radar_pi it does not talk to radar hardware directly; it consumes the mayara-server REST and WebSocket API, which supports Navico, Garmin, Furuno and Raymarine radars.
 </description>
 
-<target>flatpak-x86_64</target>
-<build-target>flatpak</build-target>
-<build-gtk></build-gtk>
-<target-version>25.08</target-version>
-<target-arch>x86_64</target-arch>
+<target>debian-armhf</target>
+<build-target>debian</build-target>
+<build-gtk>gtk3</build-gtk>
+<target-version>22.04</target-version>
+<target-arch>armhf</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.3.0-flatpak-x86_64-25.08-flatpak-tarball/versions/v0.1.3/mayara_pi-0.1.3.0-x86_64_flatpak-25.08.tar.gz
+https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.4.0-debian-armhf-22.04-jammy-tarball/versions/v0.1.4/mayara_pi-0.1.4.0-debian-armhf-22.04-jammy.tar.gz
 </tarball-url>
 <info-url> https://github.com/opencpn-radar-pi/mayara_pi </info-url>
 </plugin>

--- a/metadata/mayara_pi-0.1.4.0-debian-x86_64-12-bookworm.xml
+++ b/metadata/mayara_pi-0.1.4.0-debian-x86_64-12-bookworm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Mayara </name>
-<version> 0.1.3.0 </version>
+<version> 0.1.4.0 </version>
 <release> 0 </release>
 <summary> Marine radar overlay and PPI, served by mayara-server </summary>
 
@@ -20,7 +20,7 @@ mayara_pi displays marine radar as a chart overlay and in a PPI window. Unlike r
 <target-version>12</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.3.0-debian-x86_64-12-bookworm-tarball/versions/v0.1.3/mayara_pi-0.1.3.0-debian-x86_64-12-bookworm.tar.gz
+https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.4.0-debian-x86_64-12-bookworm-tarball/versions/v0.1.4/mayara_pi-0.1.4.0-debian-x86_64-12-bookworm.tar.gz
 </tarball-url>
 <info-url> https://github.com/opencpn-radar-pi/mayara_pi </info-url>
 </plugin>

--- a/metadata/mayara_pi-0.1.4.0-debian-x86_64-13-trixie.xml
+++ b/metadata/mayara_pi-0.1.4.0-debian-x86_64-13-trixie.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Mayara </name>
-<version> 0.1.3.0 </version>
+<version> 0.1.4.0 </version>
 <release> 0 </release>
 <summary> Marine radar overlay and PPI, served by mayara-server </summary>
 
@@ -20,7 +20,7 @@ mayara_pi displays marine radar as a chart overlay and in a PPI window. Unlike r
 <target-version>13</target-version>
 <target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.3.0-debian-x86_64-13-trixie-tarball/versions/v0.1.3/mayara_pi-0.1.3.0-debian-x86_64-13-trixie.tar.gz
+https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.4.0-debian-x86_64-13-trixie-tarball/versions/v0.1.4/mayara_pi-0.1.4.0-debian-x86_64-13-trixie.tar.gz
 </tarball-url>
 <info-url> https://github.com/opencpn-radar-pi/mayara_pi </info-url>
 </plugin>

--- a/metadata/mayara_pi-0.1.4.0-debian-x86_64-22.04-jammy.xml
+++ b/metadata/mayara_pi-0.1.4.0-debian-x86_64-22.04-jammy.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Mayara </name>
-<version> 0.1.3.0 </version>
+<version> 0.1.4.0 </version>
 <release> 0 </release>
 <summary> Marine radar overlay and PPI, served by mayara-server </summary>
 
@@ -14,13 +14,13 @@
 mayara_pi displays marine radar as a chart overlay and in a PPI window. Unlike radar_pi it does not talk to radar hardware directly; it consumes the mayara-server REST and WebSocket API, which supports Navico, Garmin, Furuno and Raymarine radars.
 </description>
 
-<target>darwin-wx32</target>
-<build-target>darwin</build-target>
-<build-gtk></build-gtk>
-<target-version>14.8.7</target-version>
-<target-arch>arm64;x86_64</target-arch>
+<target>debian-x86_64</target>
+<build-target>debian</build-target>
+<build-gtk>gtk3</build-gtk>
+<target-version>22.04</target-version>
+<target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.3.0-darwin-wx32-arm64-x86_64-14.8.7-macos-tarball/versions/v0.1.3/mayara_pi-0.1.3.0-darwin-wx32-arm64-x86_64-14.8.7-macos.tar.gz
+https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.4.0-debian-x86_64-22.04-jammy-tarball/versions/v0.1.4/mayara_pi-0.1.4.0-debian-x86_64-22.04-jammy.tar.gz
 </tarball-url>
 <info-url> https://github.com/opencpn-radar-pi/mayara_pi </info-url>
 </plugin>

--- a/metadata/mayara_pi-0.1.4.0-debian-x86_64-24.04-noble.xml
+++ b/metadata/mayara_pi-0.1.4.0-debian-x86_64-24.04-noble.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Mayara </name>
-<version> 0.1.3.0 </version>
+<version> 0.1.4.0 </version>
 <release> 0 </release>
 <summary> Marine radar overlay and PPI, served by mayara-server </summary>
 
@@ -14,13 +14,13 @@
 mayara_pi displays marine radar as a chart overlay and in a PPI window. Unlike radar_pi it does not talk to radar hardware directly; it consumes the mayara-server REST and WebSocket API, which supports Navico, Garmin, Furuno and Raymarine radars.
 </description>
 
-<target>debian-arm64</target>
+<target>debian-x86_64</target>
 <build-target>debian</build-target>
 <build-gtk>gtk3</build-gtk>
-<target-version>13</target-version>
-<target-arch>arm64</target-arch>
+<target-version>24.04</target-version>
+<target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.3.0-debian-arm64-13-trixie-tarball/versions/v0.1.3/mayara_pi-0.1.3.0-debian-arm64-13-trixie.tar.gz
+https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.4.0-debian-x86_64-24.04-noble-tarball/versions/v0.1.4/mayara_pi-0.1.4.0-debian-x86_64-24.04-noble.tar.gz
 </tarball-url>
 <info-url> https://github.com/opencpn-radar-pi/mayara_pi </info-url>
 </plugin>

--- a/metadata/mayara_pi-0.1.4.0-flatpak-aarch64-25.08-flatpak.xml
+++ b/metadata/mayara_pi-0.1.4.0-flatpak-aarch64-25.08-flatpak.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Mayara </name>
-<version> 0.1.3.0 </version>
+<version> 0.1.4.0 </version>
 <release> 0 </release>
 <summary> Marine radar overlay and PPI, served by mayara-server </summary>
 
@@ -14,13 +14,13 @@
 mayara_pi displays marine radar as a chart overlay and in a PPI window. Unlike radar_pi it does not talk to radar hardware directly; it consumes the mayara-server REST and WebSocket API, which supports Navico, Garmin, Furuno and Raymarine radars.
 </description>
 
-<target>debian-arm64</target>
-<build-target>debian</build-target>
-<build-gtk>gtk3</build-gtk>
-<target-version>12</target-version>
-<target-arch>arm64</target-arch>
+<target>flatpak-aarch64</target>
+<build-target>flatpak</build-target>
+<build-gtk></build-gtk>
+<target-version>25.08</target-version>
+<target-arch>aarch64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.3.0-debian-arm64-12-bookworm-tarball/versions/v0.1.3/mayara_pi-0.1.3.0-debian-arm64-12-bookworm.tar.gz
+https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.4.0-flatpak-aarch64-25.08-flatpak-tarball/versions/v0.1.4/mayara_pi-0.1.4.0-aarch64_flatpak-25.08.tar.gz
 </tarball-url>
 <info-url> https://github.com/opencpn-radar-pi/mayara_pi </info-url>
 </plugin>

--- a/metadata/mayara_pi-0.1.4.0-flatpak-x86_64-25.08-flatpak.xml
+++ b/metadata/mayara_pi-0.1.4.0-flatpak-x86_64-25.08-flatpak.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Mayara </name>
-<version> 0.1.3.0 </version>
+<version> 0.1.4.0 </version>
 <release> 0 </release>
 <summary> Marine radar overlay and PPI, served by mayara-server </summary>
 
@@ -14,13 +14,13 @@
 mayara_pi displays marine radar as a chart overlay and in a PPI window. Unlike radar_pi it does not talk to radar hardware directly; it consumes the mayara-server REST and WebSocket API, which supports Navico, Garmin, Furuno and Raymarine radars.
 </description>
 
-<target>debian-armhf</target>
-<build-target>debian</build-target>
-<build-gtk>gtk3</build-gtk>
-<target-version>22.04</target-version>
-<target-arch>armhf</target-arch>
+<target>flatpak-x86_64</target>
+<build-target>flatpak</build-target>
+<build-gtk></build-gtk>
+<target-version>25.08</target-version>
+<target-arch>x86_64</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.3.0-debian-armhf-22.04-jammy-tarball/versions/v0.1.3/mayara_pi-0.1.3.0-debian-armhf-22.04-jammy.tar.gz
+https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.4.0-flatpak-x86_64-25.08-flatpak-tarball/versions/v0.1.4/mayara_pi-0.1.4.0-x86_64_flatpak-25.08.tar.gz
 </tarball-url>
 <info-url> https://github.com/opencpn-radar-pi/mayara_pi </info-url>
 </plugin>

--- a/metadata/mayara_pi-0.1.4.0-msvc-x86-wx32-10.0.20348-MSVC.xml
+++ b/metadata/mayara_pi-0.1.4.0-msvc-x86-wx32-10.0.20348-MSVC.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
 <name> Mayara </name>
-<version> 0.1.3.0 </version>
+<version> 0.1.4.0 </version>
 <release> 0 </release>
 <summary> Marine radar overlay and PPI, served by mayara-server </summary>
 
@@ -20,7 +20,7 @@ mayara_pi displays marine radar as a chart overlay and in a PPI window. Unlike r
 <target-version>10.0.20348</target-version>
 <target-arch>x86</target-arch>
 <tarball-url>
-https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.3.0-msvc-x86-wx32-10.0.20348-MSVC-tarball/versions/v0.1.3/mayara_pi-0.1.3.0-msvc-x86-wx32-10.0.20348-MSVC.tar.gz
+https://dl.cloudsmith.io/public/opencpn-radar-pi/mayara-beta/raw/names/mayara_pi-0.1.4.0-msvc-x86-wx32-10.0.20348-MSVC-tarball/versions/v0.1.4/mayara_pi-0.1.4.0-msvc-x86-wx32-10.0.20348-MSVC.tar.gz
 </tarball-url>
 <info-url> https://github.com/opencpn-radar-pi/mayara_pi </info-url>
 </plugin>


### PR DESCRIPTION
Metadata-only update for Mayara v0.1.4 (beta), following the same pattern as #1402.

`debian-armhf-24.04-noble` is left at v0.1.3: that platform's build failed in CI (`libbz2-1.0:armhf` unresolvable on the `ubuntu-noble` armhf runner — an upstream Ubuntu archive gap, unrelated to the plugin itself), so no v0.1.4 tarball exists for it yet. All other 11 tarball URLs verified live (HTTP 200) before opening this PR.