### PR TITLE
Update xGRIB Alpha to 0.2.5.1: fix macOS helper runtime

### DIFF
--- a/metadata/xgrib_pi-0.2.5.1-darwin-wx32-arm64-15.3.2-macos-arm64.xml
+++ b/metadata/xgrib_pi-0.2.5.1-darwin-wx32-arm64-15.3.2-macos-arm64.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> xGRIB </name>
-  <version> 0.2.4.0 </version>
-  <release> 0 </release>
+  <version> 0.2.5.1 </version>
+  <release> 1 </release>
   <summary> Display, download, and generate environmental GRIB files. </summary>
 
   <api-version> 1.21 </api-version>
@@ -20,7 +20,7 @@
   <target-version>15.3.2</target-version>
   <target-arch>arm64</target-arch>
   <tarball-url>
-    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.4.0-darwin-wx32-15.3.2-tarball/versions/0.2.4.0+526.48a05c4/xgrib_pi-0.2.4.0-darwin-wx32-arm64-15.3.2-macos-arm64.tar.gz
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.5.1-darwin-wx32-15.3.2-tarball/versions/0.2.5.1+697.f2897fc/xgrib_pi-0.2.5.1-darwin-wx32-arm64-15.3.2-macos-arm64.tar.gz
   </tarball-url>
   <info-url> https://github.com/pob220/xgrib_pi </info-url>
 </plugin>

--- a/metadata/xgrib_pi-0.2.5.1-debian-x86_64-12-bookworm.xml
+++ b/metadata/xgrib_pi-0.2.5.1-debian-x86_64-12-bookworm.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> xGRIB </name>
-  <version> 0.2.4.0 </version>
-  <release> 0 </release>
+  <version> 0.2.5.1 </version>
+  <release> 1 </release>
   <summary> Display, download, and generate environmental GRIB files. </summary>
 
   <api-version> 1.21 </api-version>
@@ -14,13 +14,13 @@
     A catalogue-installable GRIB viewer with integrated generation of combined weather, wave, and current GRIB files using an isolated native helper.
   </description>
 
-  <target>ubuntu-wx32-x86_64</target>
-  <build-target>ubuntu</build-target>
+  <target>debian-x86_64</target>
+  <build-target>debian</build-target>
   <build-gtk>gtk3</build-gtk>
-  <target-version>22.04</target-version>
+  <target-version>12</target-version>
   <target-arch>x86_64</target-arch>
   <tarball-url>
-    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.4.0-ubuntu-wx32-x86_64-22.04-tarball/versions/0.2.4.0+526.48a05c4/xgrib_pi-0.2.4.0-ubuntu-x86_64-22.04-jammy.tar.gz
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.5.1-debian-x86_64-12-tarball/versions/0.2.5.1+697.f2897fc/xgrib_pi-0.2.5.1-debian-x86_64-12-bookworm.tar.gz
   </tarball-url>
   <info-url> https://github.com/pob220/xgrib_pi </info-url>
 </plugin>

--- a/metadata/xgrib_pi-0.2.5.1-debian-x86_64-13-trixie.xml
+++ b/metadata/xgrib_pi-0.2.5.1-debian-x86_64-13-trixie.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> xGRIB </name>
-  <version> 0.2.4.0 </version>
-  <release> 0 </release>
+  <version> 0.2.5.1 </version>
+  <release> 1 </release>
   <summary> Display, download, and generate environmental GRIB files. </summary>
 
   <api-version> 1.21 </api-version>
@@ -14,13 +14,13 @@
     A catalogue-installable GRIB viewer with integrated generation of combined weather, wave, and current GRIB files using an isolated native helper.
   </description>
 
-  <target>msvc-wx32</target>
-  <build-target>msvc</build-target>
-  <build-gtk></build-gtk>
-  <target-version>10.0.20348</target-version>
-  <target-arch>x86</target-arch>
+  <target>debian-x86_64</target>
+  <build-target>debian</build-target>
+  <build-gtk>gtk3</build-gtk>
+  <target-version>13</target-version>
+  <target-arch>x86_64</target-arch>
   <tarball-url>
-    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.4.0-msvc-wx32-10.0.20348-tarball/versions/0.2.4.0+526.48a05c4/xgrib_pi-0.2.4.0-msvc-x86-wx32-10.0.20348-MSVC.tar.gz
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.5.1-debian-x86_64-13-tarball/versions/0.2.5.1+697.f2897fc/xgrib_pi-0.2.5.1-debian-x86_64-13-trixie.tar.gz
   </tarball-url>
   <info-url> https://github.com/pob220/xgrib_pi </info-url>
 </plugin>

--- a/metadata/xgrib_pi-0.2.5.1-flatpak-x86_64-25.08-flatpak.xml
+++ b/metadata/xgrib_pi-0.2.5.1-flatpak-x86_64-25.08-flatpak.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> xGRIB </name>
-  <version> 0.2.4.0 </version>
-  <release> 0 </release>
+  <version> 0.2.5.1 </version>
+  <release> 1 </release>
   <summary> Display, download, and generate environmental GRIB files. </summary>
 
   <api-version> 1.21 </api-version>
@@ -14,13 +14,13 @@
     A catalogue-installable GRIB viewer with integrated generation of combined weather, wave, and current GRIB files using an isolated native helper.
   </description>
 
-  <target>debian-x86_64</target>
-  <build-target>debian</build-target>
-  <build-gtk>gtk3</build-gtk>
-  <target-version>12</target-version>
+  <target>flatpak-x86_64</target>
+  <build-target>flatpak</build-target>
+  <build-gtk></build-gtk>
+  <target-version>25.08</target-version>
   <target-arch>x86_64</target-arch>
   <tarball-url>
-    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.4.0-debian-x86_64-12-tarball/versions/0.2.4.0+526.48a05c4/xgrib_pi-0.2.4.0-debian-x86_64-12-bookworm.tar.gz
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.5.1-flatpak-x86_64-25.08-tarball/versions/0.2.5.1+697.f2897fc/xgrib_pi-0.2.5.1-x86_64_flatpak-25.08.tar.gz
   </tarball-url>
   <info-url> https://github.com/pob220/xgrib_pi </info-url>
 </plugin>

--- a/metadata/xgrib_pi-0.2.5.1-msvc-x86-wx32-10.0.20348-MSVC.xml
+++ b/metadata/xgrib_pi-0.2.5.1-msvc-x86-wx32-10.0.20348-MSVC.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> xGRIB </name>
-  <version> 0.2.4.0 </version>
-  <release> 0 </release>
+  <version> 0.2.5.1 </version>
+  <release> 1 </release>
   <summary> Display, download, and generate environmental GRIB files. </summary>
 
   <api-version> 1.21 </api-version>
@@ -14,13 +14,13 @@
     A catalogue-installable GRIB viewer with integrated generation of combined weather, wave, and current GRIB files using an isolated native helper.
   </description>
 
-  <target>debian-x86_64</target>
-  <build-target>debian</build-target>
-  <build-gtk>gtk3</build-gtk>
-  <target-version>13</target-version>
-  <target-arch>x86_64</target-arch>
+  <target>msvc-wx32</target>
+  <build-target>msvc</build-target>
+  <build-gtk></build-gtk>
+  <target-version>10.0.20348</target-version>
+  <target-arch>x86</target-arch>
   <tarball-url>
-    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.4.0-debian-x86_64-13-tarball/versions/0.2.4.0+526.48a05c4/xgrib_pi-0.2.4.0-debian-x86_64-13-trixie.tar.gz
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.5.1-msvc-wx32-10.0.20348-tarball/versions/0.2.5.1+697.f2897fc/xgrib_pi-0.2.5.1-msvc-x86-wx32-10.0.20348-MSVC.tar.gz
   </tarball-url>
   <info-url> https://github.com/pob220/xgrib_pi </info-url>
 </plugin>

--- a/metadata/xgrib_pi-0.2.5.1-ubuntu-x86_64-22.04-jammy.xml
+++ b/metadata/xgrib_pi-0.2.5.1-ubuntu-x86_64-22.04-jammy.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> xGRIB </name>
-  <version> 0.2.4.0 </version>
-  <release> 0 </release>
+  <version> 0.2.5.1 </version>
+  <release> 1 </release>
   <summary> Display, download, and generate environmental GRIB files. </summary>
 
   <api-version> 1.21 </api-version>
@@ -14,13 +14,13 @@
     A catalogue-installable GRIB viewer with integrated generation of combined weather, wave, and current GRIB files using an isolated native helper.
   </description>
 
-  <target>flatpak-x86_64</target>
-  <build-target>flatpak</build-target>
-  <build-gtk></build-gtk>
-  <target-version>25.08</target-version>
+  <target>ubuntu-wx32-x86_64</target>
+  <build-target>ubuntu</build-target>
+  <build-gtk>gtk3</build-gtk>
+  <target-version>22.04</target-version>
   <target-arch>x86_64</target-arch>
   <tarball-url>
-    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.4.0-flatpak-x86_64-25.08-tarball/versions/0.2.4.0+526.48a05c4/xgrib_pi-0.2.4.0-x86_64_flatpak-25.08.tar.gz
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.5.1-ubuntu-wx32-x86_64-22.04-tarball/versions/0.2.5.1+697.f2897fc/xgrib_pi-0.2.5.1-ubuntu-x86_64-22.04-jammy.tar.gz
   </tarball-url>
   <info-url> https://github.com/pob220/xgrib_pi </info-url>
 </plugin>

--- a/metadata/xgrib_pi-0.2.5.1-ubuntu-x86_64-24.04-gtk3-noble.xml
+++ b/metadata/xgrib_pi-0.2.5.1-ubuntu-x86_64-24.04-gtk3-noble.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin version="1">
   <name> xGRIB </name>
-  <version> 0.2.4.0 </version>
-  <release> 0 </release>
+  <version> 0.2.5.1 </version>
+  <release> 1 </release>
   <summary> Display, download, and generate environmental GRIB files. </summary>
 
   <api-version> 1.21 </api-version>
@@ -20,7 +20,7 @@
   <target-version>24.04</target-version>
   <target-arch>x86_64</target-arch>
   <tarball-url>
-    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.4.0-ubuntu-gtk3-x86_64-24.04-tarball/versions/0.2.4.0+526.48a05c4/xgrib_pi-0.2.4.0-ubuntu-x86_64-24.04-gtk3-noble.tar.gz
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.5.1-ubuntu-gtk3-x86_64-24.04-tarball/versions/0.2.5.1+697.f2897fc/xgrib_pi-0.2.5.1-ubuntu-x86_64-24.04-gtk3-noble.tar.gz
   </tarball-url>
   <info-url> https://github.com/pob220/xgrib_pi </info-url>
 </plugin>

--- a/ocpn-plugins.xml
+++ b/ocpn-plugins.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <plugins>
   <version>0.0.0</version>
-  <date>2026-08-23 19:39</date>
+  <date>2026-09-09 22:49</date>
   <plugin version="1">
     <name> OCPN Draw </name>
     <version> 1.10.0.0 </version>
@@ -114,8 +114,8 @@ https://dl.cloudsmith.io/public/opencpn/windvane-alpha/raw/names/windvane_pi-1.0
   </plugin>
   <plugin version="1">
     <name> xGRIB </name>
-    <version> 0.2.4.0 </version>
-    <release> 0 </release>
+    <version> 0.2.5.1 </version>
+    <release> 1 </release>
     <summary> Display, download, and generate environmental GRIB files. </summary>
     <api-version> 1.21 </api-version>
     <open-source> yes </open-source>
@@ -130,7 +130,7 @@ https://dl.cloudsmith.io/public/opencpn/windvane-alpha/raw/names/windvane_pi-1.0
     <target-version>25.08</target-version>
     <target-arch>x86_64</target-arch>
     <tarball-url>
-    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.4.0-flatpak-x86_64-25.08-tarball/versions/0.2.4.0+526.48a05c4/xgrib_pi-0.2.4.0-x86_64_flatpak-25.08.tar.gz
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.5.1-flatpak-x86_64-25.08-tarball/versions/0.2.5.1+697.f2897fc/xgrib_pi-0.2.5.1-x86_64_flatpak-25.08.tar.gz
   </tarball-url>
     <info-url> https://github.com/pob220/xgrib_pi </info-url>
   </plugin>
@@ -338,8 +338,8 @@ https://dl.cloudsmith.io/public/opencpn/ocpn_draw-alpha/raw/names/ocpn_draw_pi-1
   </plugin>
   <plugin version="1">
     <name> xGRIB </name>
-    <version> 0.2.4.0 </version>
-    <release> 0 </release>
+    <version> 0.2.5.1 </version>
+    <release> 1 </release>
     <summary> Display, download, and generate environmental GRIB files. </summary>
     <api-version> 1.21 </api-version>
     <open-source> yes </open-source>
@@ -354,7 +354,7 @@ https://dl.cloudsmith.io/public/opencpn/ocpn_draw-alpha/raw/names/ocpn_draw_pi-1
     <target-version>15.3.2</target-version>
     <target-arch>arm64</target-arch>
     <tarball-url>
-    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.4.0-darwin-wx32-15.3.2-tarball/versions/0.2.4.0+526.48a05c4/xgrib_pi-0.2.4.0-darwin-wx32-arm64-15.3.2-macos-arm64.tar.gz
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.5.1-darwin-wx32-15.3.2-tarball/versions/0.2.5.1+697.f2897fc/xgrib_pi-0.2.5.1-darwin-wx32-arm64-15.3.2-macos-arm64.tar.gz
   </tarball-url>
     <info-url> https://github.com/pob220/xgrib_pi </info-url>
   </plugin>
@@ -448,8 +448,8 @@ https://dl.cloudsmith.io/public/opencpn/windvane-alpha/raw/names/windvane_pi-1.0
   </plugin>
   <plugin version="1">
     <name> xGRIB </name>
-    <version> 0.2.4.0 </version>
-    <release> 0 </release>
+    <version> 0.2.5.1 </version>
+    <release> 1 </release>
     <summary> Display, download, and generate environmental GRIB files. </summary>
     <api-version> 1.21 </api-version>
     <open-source> yes </open-source>
@@ -464,7 +464,7 @@ https://dl.cloudsmith.io/public/opencpn/windvane-alpha/raw/names/windvane_pi-1.0
     <target-version>13</target-version>
     <target-arch>x86_64</target-arch>
     <tarball-url>
-    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.4.0-debian-x86_64-13-tarball/versions/0.2.4.0+526.48a05c4/xgrib_pi-0.2.4.0-debian-x86_64-13-trixie.tar.gz
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.5.1-debian-x86_64-13-tarball/versions/0.2.5.1+697.f2897fc/xgrib_pi-0.2.5.1-debian-x86_64-13-trixie.tar.gz
   </tarball-url>
     <info-url> https://github.com/pob220/xgrib_pi </info-url>
   </plugin>
@@ -1115,8 +1115,8 @@ can only be used after purchasing decryption keys from o-charts.org.
   </plugin>
   <plugin version="1">
     <name> xGRIB </name>
-    <version> 0.2.4.0 </version>
-    <release> 0 </release>
+    <version> 0.2.5.1 </version>
+    <release> 1 </release>
     <summary> Display, download, and generate environmental GRIB files. </summary>
     <api-version> 1.21 </api-version>
     <open-source> yes </open-source>
@@ -1131,7 +1131,7 @@ can only be used after purchasing decryption keys from o-charts.org.
     <target-version>12</target-version>
     <target-arch>x86_64</target-arch>
     <tarball-url>
-    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.4.0-debian-x86_64-12-tarball/versions/0.2.4.0+526.48a05c4/xgrib_pi-0.2.4.0-debian-x86_64-12-bookworm.tar.gz
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.5.1-debian-x86_64-12-tarball/versions/0.2.5.1+697.f2897fc/xgrib_pi-0.2.5.1-debian-x86_64-12-bookworm.tar.gz
   </tarball-url>
     <info-url> https://github.com/pob220/xgrib_pi </info-url>
   </plugin>
@@ -1493,8 +1493,8 @@ https://dl.cloudsmith.io/public/opencpn/windvane-alpha/raw/names/windvane_pi-1.0
   </plugin>
   <plugin version="1">
     <name> xGRIB </name>
-    <version> 0.2.4.0 </version>
-    <release> 0 </release>
+    <version> 0.2.5.1 </version>
+    <release> 1 </release>
     <summary> Display, download, and generate environmental GRIB files. </summary>
     <api-version> 1.21 </api-version>
     <open-source> yes </open-source>
@@ -1509,7 +1509,7 @@ https://dl.cloudsmith.io/public/opencpn/windvane-alpha/raw/names/windvane_pi-1.0
     <target-version>24.04</target-version>
     <target-arch>x86_64</target-arch>
     <tarball-url>
-    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.4.0-ubuntu-gtk3-x86_64-24.04-tarball/versions/0.2.4.0+526.48a05c4/xgrib_pi-0.2.4.0-ubuntu-x86_64-24.04-gtk3-noble.tar.gz
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.5.1-ubuntu-gtk3-x86_64-24.04-tarball/versions/0.2.5.1+697.f2897fc/xgrib_pi-0.2.5.1-ubuntu-x86_64-24.04-gtk3-noble.tar.gz
   </tarball-url>
     <info-url> https://github.com/pob220/xgrib_pi </info-url>
   </plugin>
@@ -1669,8 +1669,8 @@ https://dl.cloudsmith.io/public/opencpn/ocpn_draw-alpha/raw/names/ocpn_draw_pi-1
   </plugin>
   <plugin version="1">
     <name> xGRIB </name>
-    <version> 0.2.4.0 </version>
-    <release> 0 </release>
+    <version> 0.2.5.1 </version>
+    <release> 1 </release>
     <summary> Display, download, and generate environmental GRIB files. </summary>
     <api-version> 1.21 </api-version>
     <open-source> yes </open-source>
@@ -1685,7 +1685,7 @@ https://dl.cloudsmith.io/public/opencpn/ocpn_draw-alpha/raw/names/ocpn_draw_pi-1
     <target-version>22.04</target-version>
     <target-arch>x86_64</target-arch>
     <tarball-url>
-    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.4.0-ubuntu-wx32-x86_64-22.04-tarball/versions/0.2.4.0+526.48a05c4/xgrib_pi-0.2.4.0-ubuntu-x86_64-22.04-jammy.tar.gz
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.5.1-ubuntu-wx32-x86_64-22.04-tarball/versions/0.2.5.1+697.f2897fc/xgrib_pi-0.2.5.1-ubuntu-x86_64-22.04-jammy.tar.gz
   </tarball-url>
     <info-url> https://github.com/pob220/xgrib_pi </info-url>
   </plugin>
@@ -2007,8 +2007,8 @@ https://dl.cloudsmith.io/public/opencpn/ocpn_draw-alpha/raw/names/ocpn_draw_pi-1
   </plugin>
   <plugin version="1">
     <name> xGRIB </name>
-    <version> 0.2.4.0 </version>
-    <release> 0 </release>
+    <version> 0.2.5.1 </version>
+    <release> 1 </release>
     <summary> Display, download, and generate environmental GRIB files. </summary>
     <api-version> 1.21 </api-version>
     <open-source> yes </open-source>
@@ -2023,7 +2023,7 @@ https://dl.cloudsmith.io/public/opencpn/ocpn_draw-alpha/raw/names/ocpn_draw_pi-1
     <target-version>10.0.20348</target-version>
     <target-arch>x86</target-arch>
     <tarball-url>
-    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.4.0-msvc-wx32-10.0.20348-tarball/versions/0.2.4.0+526.48a05c4/xgrib_pi-0.2.4.0-msvc-x86-wx32-10.0.20348-MSVC.tar.gz
+    https://dl.cloudsmith.io/public/pob220/xgrib-alpha/raw/names/xgrib_pi-0.2.5.1-msvc-wx32-10.0.20348-tarball/versions/0.2.5.1+697.f2897fc/xgrib_pi-0.2.5.1-msvc-x86-wx32-10.0.20348-MSVC.tar.gz
   </tarball-url>
     <info-url> https://github.com/pob220/xgrib_pi </info-url>
   </plugin>


### PR DESCRIPTION
Update the seven existing xGRIB Alpha catalogue targets from 0.2.4.0 to 0.2.5.1 using metadata published in `pob220/xgrib-alpha`.

This fixes the macOS helper being killed immediately when checking dependencies or generating a GRIB. Dependency relocation invalidated the bundled libraries’ signatures; packaging now signs every relocated library and then the helper, and rejects invalid signatures. The Mac package also includes the ecCodes definitions and samples needed to generate GRIB files on machines without Homebrew.

The native Apple Silicon archive passed individual signature checks, capabilities, an offline job, and actual GRIB generation/reopening after extraction into an `Application Support` path. An independent audit verified code hashes for all 28 packaged Mach-O files. Native Mac testing used macOS 15.3.2; the reporter’s macOS 26.6 environment has not been tested directly.

Release workflow: https://app.circleci.com/workflow/e2c1b20c-b8d8-4dd5-9ba9-735f467913fe
Related report: https://github.com/OpenCPN/OpenCPN/discussions/5359#discussioncomment-18375825

Validation:

- All 11 release checks passed, covering nine package targets and the Windows OpenCPN runtime checks.
- Cloudsmith build `0.2.5.1+697.f2897fc`: all 18 package/metadata objects are `Completed`; all nine archive URLs are reachable, and archive checksums match CI manifests.
- The published Mac download is byte-for-byte identical to the tested archive.
- All seven replacement metadata files match Cloudsmith (Windows line endings normalized) and validate against `ocpn-plugin.xsd`.
- The catalogue remains well-formed, with only the existing xGRIB entries and catalogue date changed. Full `ocpn-plugins.xsd` validation reports the same pre-existing unrelated `meta-url` error at line 692 in both the base and updated catalogue.

Source tag: https://github.com/pob220/xgrib_pi/tree/v0.2.5.1
